### PR TITLE
Fix demo page: include bundled JS and use master branch

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,7 @@ name: Deploy Demo to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
 dist/
 src/core/nape-compiled.js
-docs/nape-js.esm.js
 *.tsbuildinfo


### PR DESCRIPTION
- Remove docs/nape-js.esm.js from .gitignore so the bundle is committed and GitHub Pages can serve it statically from /docs
- Fix deploy workflow to trigger on master branch (not main)

https://claude.ai/code/session_01LBcVAzMAqVHxA4tfyRNB6s