### PR TITLE
feat: add full render code to demo snippets with 2D/3D mode toggle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -70,6 +70,10 @@
         <div class="code-panel-header">
           <span class="code-panel-title">Source Code</span>
           <div class="code-panel-actions">
+            <div class="render-mode-toggle" id="renderModeToggle">
+              <button class="render-mode-btn active" data-mode="2d">2D Canvas</button>
+              <button class="render-mode-btn" data-mode="3d">3D Three.js</button>
+            </div>
             <button class="btn btn-small" id="copyCodeBtn" title="Copy to clipboard">Copy</button>
             <button class="btn btn-small btn-codepen" id="codepenBtn" title="Open in CodePen">CodePen</button>
           </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -385,6 +385,31 @@ a:hover { text-decoration: underline; }
 .code-panel-actions {
   display: flex;
   gap: 8px;
+  align-items: center;
+}
+.render-mode-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-right: 4px;
+}
+.render-mode-btn {
+  padding: 4px 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.render-mode-btn:hover {
+  color: var(--text);
+}
+.render-mode-btn.active {
+  background: var(--accent-dim);
+  color: #fff;
 }
 .btn-codepen {
   background: var(--surface) !important;


### PR DESCRIPTION
Demo code snippets now include complete rendering code (Canvas 2D draw
loop) so they work as standalone examples when copied or opened in
CodePen. A render mode toggle lets users switch between a 2D Canvas
version and a 3D Three.js version (loaded from CDN). The CodePen export
adapts its HTML and JS wrapper based on the selected mode.

https://claude.ai/code/session_01QozsoQDbjqxr6ikJmbUW2w