### PR TITLE
Add 13 missing test files for public API classes (P29)

### DIFF
--- a/tests/callbacks/BodyCallback.test.ts
+++ b/tests/callbacks/BodyCallback.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { BodyListener } from "../../src/callbacks/BodyListener";
+import { BodyCallback } from "../../src/callbacks/BodyCallback";
+import { Callback } from "../../src/callbacks/Callback";
+import { CbType } from "../../src/callbacks/CbType";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { Circle } from "../../src/shape/Circle";
+import { Vec2 } from "../../src/geom/Vec2";
+
+describe("BodyCallback", () => {
+  it("cannot be instantiated directly", () => {
+    expect(() => new (Callback as any)()).toThrow();
+    expect(() => new (BodyCallback as any)()).toThrow();
+  });
+
+  it("fires SLEEP callback that is a BodyCallback instance", () => {
+    const space = new Space(new Vec2(0, 0));
+    let captured: BodyCallback | null = null;
+
+    const listener = new BodyListener(CbEvent.SLEEP, CbType.ANY_BODY, (cb) => {
+      captured = cb;
+    });
+    listener.space = space;
+
+    const body = new Body();
+    body.shapes.add(new Circle(10));
+    body.space = space;
+
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (captured) break;
+    }
+
+    expect(captured).not.toBeNull();
+    expect(captured).toBeInstanceOf(BodyCallback);
+    expect(captured).toBeInstanceOf(Callback);
+  });
+
+  it("callback.body returns the correct Body", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedBody: Body | null = null;
+    const body = new Body();
+    body.shapes.add(new Circle(10));
+
+    const listener = new BodyListener(CbEvent.SLEEP, CbType.ANY_BODY, (cb) => {
+      capturedBody = cb.body;
+    });
+    listener.space = space;
+    body.space = space;
+
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (capturedBody) break;
+    }
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody).toBe(body);
+  });
+
+  it("callback.event returns CbEvent.SLEEP for a SLEEP listener", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedEvent: CbEvent | null = null;
+
+    const listener = new BodyListener(CbEvent.SLEEP, CbType.ANY_BODY, (cb) => {
+      capturedEvent = cb.event;
+    });
+    listener.space = space;
+
+    const body = new Body();
+    body.shapes.add(new Circle(10));
+    body.space = space;
+
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (capturedEvent) break;
+    }
+
+    expect(capturedEvent).toBe(CbEvent.SLEEP);
+  });
+
+  it("callback.listener returns the BodyListener that triggered it", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedListener: any = null;
+
+    const listener = new BodyListener(CbEvent.SLEEP, CbType.ANY_BODY, (cb) => {
+      capturedListener = cb.listener;
+    });
+    listener.space = space;
+
+    const body = new Body();
+    body.shapes.add(new Circle(10));
+    body.space = space;
+
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (capturedListener) break;
+    }
+
+    expect(capturedListener).not.toBeNull();
+    expect(capturedListener).toBe(listener);
+  });
+
+  it("callback.toString() returns a non-empty string containing SLEEP", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedStr = "";
+
+    const listener = new BodyListener(CbEvent.SLEEP, CbType.ANY_BODY, (cb) => {
+      capturedStr = cb.toString();
+    });
+    listener.space = space;
+
+    const body = new Body();
+    body.shapes.add(new Circle(10));
+    body.space = space;
+
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (capturedStr) break;
+    }
+
+    expect(capturedStr.length).toBeGreaterThan(0);
+    expect(capturedStr).toContain("SLEEP");
+  });
+
+  it("fires WAKE callback when a sleeping body is woken", () => {
+    const space = new Space(new Vec2(0, 0));
+    let sleepFired = false;
+    let wakeEvent: CbEvent | null = null;
+    let wakeBody: Body | null = null;
+    let wakeIsBodyCallback = false;
+
+    const sleepListener = new BodyListener(CbEvent.SLEEP, CbType.ANY_BODY, () => {
+      sleepFired = true;
+    });
+    sleepListener.space = space;
+
+    const wakeListener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, (cb) => {
+      // Only capture wake events after the body has slept at least once
+      if (sleepFired) {
+        wakeEvent = cb.event;
+        wakeBody = cb.body;
+        wakeIsBodyCallback = cb instanceof BodyCallback;
+      }
+    });
+    wakeListener.space = space;
+
+    const body = new Body();
+    body.shapes.add(new Circle(10));
+    body.space = space;
+
+    // Let the body go to sleep
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (sleepFired) break;
+    }
+    expect(sleepFired).toBe(true);
+
+    // Wake it by applying an impulse, then step so the wake callback fires
+    body.applyImpulse(Vec2.weak(100, 0));
+    space.step(1 / 60);
+
+    expect(wakeIsBodyCallback).toBe(true);
+    expect(wakeEvent).toBe(CbEvent.WAKE);
+    expect(wakeBody).toBe(body);
+  });
+});

--- a/tests/callbacks/ConstraintCallback.test.ts
+++ b/tests/callbacks/ConstraintCallback.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from "vitest";
+import { ConstraintListener } from "../../src/callbacks/ConstraintListener";
+import { ConstraintCallback } from "../../src/callbacks/ConstraintCallback";
+import { Callback } from "../../src/callbacks/Callback";
+import { CbType } from "../../src/callbacks/CbType";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { Circle } from "../../src/shape/Circle";
+import { Vec2 } from "../../src/geom/Vec2";
+import { DistanceJoint } from "../../src/constraint/DistanceJoint";
+import { Constraint } from "../../src/constraint/Constraint";
+
+/**
+ * Unlike Body (which auto-registers CbType.ANY_BODY), constraints do NOT
+ * automatically add CbType.ANY_CONSTRAINT to their cbTypes list.
+ * We must explicitly add a matching CbType for the listener to fire.
+ */
+const CONSTRAINT_CB = new CbType();
+
+describe("ConstraintCallback", () => {
+  it("cannot be instantiated directly", () => {
+    expect(() => new (Callback as any)()).toThrow();
+    expect(() => new (ConstraintCallback as any)()).toThrow();
+  });
+
+  it("fires SLEEP callback when a constraint goes to sleep", () => {
+    const space = new Space(new Vec2(0, 0));
+    let captured: ConstraintCallback | null = null;
+
+    const listener = new ConstraintListener(CbEvent.SLEEP, CONSTRAINT_CB, (cb) => {
+      captured = cb;
+    });
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(10));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(10));
+    b2.position = Vec2.weak(100, 0);
+    b2.space = space;
+
+    const joint = new DistanceJoint(b1, b2, Vec2.weak(0, 0), Vec2.weak(0, 0), 100, 100);
+    (joint.cbTypes as any).add(CONSTRAINT_CB);
+    joint.space = space;
+
+    // With zero gravity and bodies at rest at the joint's distance, they should sleep
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (captured) break;
+    }
+
+    expect(captured).not.toBeNull();
+    expect(captured).toBeInstanceOf(ConstraintCallback);
+    expect(captured).toBeInstanceOf(Callback);
+  });
+
+  it("callback.constraint returns the correct constraint", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedConstraint: Constraint | null = null;
+
+    const listener = new ConstraintListener(CbEvent.SLEEP, CONSTRAINT_CB, (cb) => {
+      capturedConstraint = cb.constraint;
+    });
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(10));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(10));
+    b2.position = Vec2.weak(100, 0);
+    b2.space = space;
+
+    const joint = new DistanceJoint(b1, b2, Vec2.weak(0, 0), Vec2.weak(0, 0), 100, 100);
+    (joint.cbTypes as any).add(CONSTRAINT_CB);
+    joint.space = space;
+
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (capturedConstraint) break;
+    }
+
+    expect(capturedConstraint).not.toBeNull();
+    expect(capturedConstraint).toBe(joint);
+  });
+
+  it("callback.event returns CbEvent.SLEEP for a SLEEP listener", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedEvent: CbEvent | null = null;
+
+    const listener = new ConstraintListener(CbEvent.SLEEP, CONSTRAINT_CB, (cb) => {
+      capturedEvent = cb.event;
+    });
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(10));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(10));
+    b2.position = Vec2.weak(100, 0);
+    b2.space = space;
+
+    const joint = new DistanceJoint(b1, b2, Vec2.weak(0, 0), Vec2.weak(0, 0), 100, 100);
+    (joint.cbTypes as any).add(CONSTRAINT_CB);
+    joint.space = space;
+
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (capturedEvent) break;
+    }
+
+    expect(capturedEvent).toBe(CbEvent.SLEEP);
+  });
+
+  it("callback.listener returns the ConstraintListener", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedListener: any = null;
+
+    const listener = new ConstraintListener(CbEvent.SLEEP, CONSTRAINT_CB, (cb) => {
+      capturedListener = cb.listener;
+    });
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(10));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(10));
+    b2.position = Vec2.weak(100, 0);
+    b2.space = space;
+
+    const joint = new DistanceJoint(b1, b2, Vec2.weak(0, 0), Vec2.weak(0, 0), 100, 100);
+    (joint.cbTypes as any).add(CONSTRAINT_CB);
+    joint.space = space;
+
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (capturedListener) break;
+    }
+
+    expect(capturedListener).not.toBeNull();
+    expect(capturedListener).toBe(listener);
+  });
+
+  it("callback.toString() returns a non-empty string containing SLEEP", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedStr = "";
+
+    const listener = new ConstraintListener(CbEvent.SLEEP, CONSTRAINT_CB, (cb) => {
+      capturedStr = cb.toString();
+    });
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(10));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(10));
+    b2.position = Vec2.weak(100, 0);
+    b2.space = space;
+
+    const joint = new DistanceJoint(b1, b2, Vec2.weak(0, 0), Vec2.weak(0, 0), 100, 100);
+    (joint.cbTypes as any).add(CONSTRAINT_CB);
+    joint.space = space;
+
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (capturedStr) break;
+    }
+
+    expect(capturedStr.length).toBeGreaterThan(0);
+    expect(capturedStr).toContain("SLEEP");
+  });
+
+  it("fires BREAK callback when a constraint breaks under force", () => {
+    // Bodies start far apart but the joint wants them close — it can't cope and breaks
+    const space = new Space(new Vec2(0, 0));
+    let breakEvent: CbEvent | null = null;
+    let breakConstraint: Constraint | null = null;
+    let breakIsConstraintCallback = false;
+
+    const listener = new ConstraintListener(CbEvent.BREAK, CONSTRAINT_CB, (cb) => {
+      breakEvent = cb.event;
+      breakConstraint = cb.constraint;
+      breakIsConstraintCallback = cb instanceof ConstraintCallback;
+    });
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(10));
+    b1.position = Vec2.weak(0, 0);
+    b1.velocity = Vec2.weak(-500, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(10));
+    b2.position = Vec2.weak(50, 0);
+    b2.velocity = Vec2.weak(500, 0);
+    b2.space = space;
+
+    // Joint wants distance 30-30 but bodies are flying apart with high velocity
+    const joint = new DistanceJoint(b1, b2, Vec2.weak(0, 0), Vec2.weak(0, 0), 30, 30);
+    joint.breakUnderForce = true;
+    joint.maxForce = 1;
+    (joint.cbTypes as any).add(CONSTRAINT_CB);
+    joint.space = space;
+
+    for (let i = 0; i < 60; i++) {
+      space.step(1 / 60);
+      if (breakEvent) break;
+    }
+
+    expect(breakIsConstraintCallback).toBe(true);
+    expect(breakEvent).toBe(CbEvent.BREAK);
+    expect(breakConstraint).toBe(joint);
+  });
+
+  it("fires WAKE callback after a constraint wakes from sleep", () => {
+    const space = new Space(new Vec2(0, 0));
+    let sleepFired = false;
+    let wakeFired = false;
+
+    const sleepListener = new ConstraintListener(CbEvent.SLEEP, CONSTRAINT_CB, () => {
+      sleepFired = true;
+    });
+    sleepListener.space = space;
+
+    const wakeListener = new ConstraintListener(CbEvent.WAKE, CONSTRAINT_CB, () => {
+      wakeFired = true;
+    });
+    wakeListener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(10));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(10));
+    b2.position = Vec2.weak(100, 0);
+    b2.space = space;
+
+    const joint = new DistanceJoint(b1, b2, Vec2.weak(0, 0), Vec2.weak(0, 0), 100, 100);
+    (joint.cbTypes as any).add(CONSTRAINT_CB);
+    joint.space = space;
+
+    // Step until system sleeps
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      if (sleepFired) break;
+    }
+
+    expect(sleepFired).toBe(true);
+
+    // Now wake one body by applying velocity
+    b1.velocity = Vec2.weak(50, 0);
+
+    for (let i = 0; i < 5; i++) {
+      space.step(1 / 60);
+      if (wakeFired) break;
+    }
+
+    expect(wakeFired).toBe(true);
+  });
+});

--- a/tests/callbacks/ConstraintListener.test.ts
+++ b/tests/callbacks/ConstraintListener.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { ConstraintListener } from "../../src/callbacks/ConstraintListener";
+import { Listener } from "../../src/callbacks/Listener";
+import { CbType } from "../../src/callbacks/CbType";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { ListenerType } from "../../src/callbacks/ListenerType";
+import { Space } from "../../src/space/Space";
+import { Vec2 } from "../../src/geom/Vec2";
+
+describe("ConstraintListener", () => {
+  const noop = () => {};
+
+  describe("construction", () => {
+    it("constructs with WAKE event", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      expect(listener).toBeInstanceOf(ConstraintListener);
+    });
+
+    it("constructs with SLEEP event", () => {
+      const listener = new ConstraintListener(CbEvent.SLEEP, CbType.ANY_CONSTRAINT, noop);
+      expect(listener).toBeInstanceOf(ConstraintListener);
+      expect(listener.event).toBe(CbEvent.SLEEP);
+    });
+
+    it("constructs with BREAK event", () => {
+      const listener = new ConstraintListener(CbEvent.BREAK, CbType.ANY_CONSTRAINT, noop);
+      expect(listener).toBeInstanceOf(ConstraintListener);
+      expect(listener.event).toBe(CbEvent.BREAK);
+    });
+
+    it("throws for invalid event BEGIN", () => {
+      expect(() => {
+        new ConstraintListener(CbEvent.BEGIN, CbType.ANY_CONSTRAINT, noop);
+      }).toThrow("is not a valid event type for a ConstraintListener");
+    });
+
+    it("throws for invalid event END", () => {
+      expect(() => {
+        new ConstraintListener(CbEvent.END, CbType.ANY_CONSTRAINT, noop);
+      }).toThrow("is not a valid event type for a ConstraintListener");
+    });
+
+    it("throws for invalid event ONGOING", () => {
+      expect(() => {
+        new ConstraintListener(CbEvent.ONGOING, CbType.ANY_CONSTRAINT, noop);
+      }).toThrow("is not a valid event type for a ConstraintListener");
+    });
+
+    it("throws when handler is null", () => {
+      expect(() => {
+        new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, null as any);
+      }).toThrow("handler cannot be null");
+    });
+  });
+
+  describe("instanceof", () => {
+    it("is instanceof Listener", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      expect(listener).toBeInstanceOf(Listener);
+    });
+  });
+
+  describe("type", () => {
+    it("returns ListenerType.CONSTRAINT", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      expect(listener.type).toBe(ListenerType.CONSTRAINT);
+    });
+  });
+
+  describe("options getter", () => {
+    it("returns an OptionType", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      const options = listener.options;
+      expect(options).toBeDefined();
+      expect(options).not.toBeNull();
+    });
+  });
+
+  describe("handler getter/setter", () => {
+    it("returns the handler function", () => {
+      const handler = () => {};
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, handler);
+      expect(listener.handler).toBe(handler);
+    });
+
+    it("setter changes handler", () => {
+      const handler1 = () => {};
+      const handler2 = () => {};
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, handler1);
+      expect(listener.handler).toBe(handler1);
+      listener.handler = handler2;
+      expect(listener.handler).toBe(handler2);
+    });
+
+    it("throws when setting handler to null", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      expect(() => {
+        listener.handler = null as any;
+      }).toThrow("handler cannot be null");
+    });
+  });
+
+  describe("precedence", () => {
+    it("defaults to 0", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      expect(listener.precedence).toBe(0);
+    });
+
+    it("can be set via constructor", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop, 7);
+      expect(listener.precedence).toBe(7);
+    });
+
+    it("can be changed via setter", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      listener.precedence = 42;
+      expect(listener.precedence).toBe(42);
+    });
+  });
+
+  describe("space", () => {
+    it("can be added to a space", () => {
+      const space = new Space(new Vec2(0, -10));
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      listener.space = space;
+      expect(listener.space).toBeInstanceOf(Space);
+    });
+
+    it("can be removed from a space", () => {
+      const space = new Space(new Vec2(0, -10));
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      listener.space = space;
+      expect(listener.space).not.toBeNull();
+      listener.space = null;
+      expect(listener.space).toBeNull();
+    });
+  });
+
+  describe("toString", () => {
+    it("returns a string containing ConstraintListener", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, noop);
+      const str = listener.toString();
+      expect(str).toContain("ConstraintListener");
+      expect(str).toContain("WAKE");
+    });
+  });
+});

--- a/tests/callbacks/InteractionCallback.test.ts
+++ b/tests/callbacks/InteractionCallback.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from "vitest";
+import { InteractionListener } from "../../src/callbacks/InteractionListener";
+import { InteractionCallback } from "../../src/callbacks/InteractionCallback";
+import { Callback } from "../../src/callbacks/Callback";
+import { CbType } from "../../src/callbacks/CbType";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { InteractionType } from "../../src/callbacks/InteractionType";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { Circle } from "../../src/shape/Circle";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Interactor } from "../../src/phys/Interactor";
+
+describe("InteractionCallback", () => {
+  it("cannot be instantiated directly", () => {
+    expect(() => new (Callback as any)()).toThrow();
+    expect(() => new (InteractionCallback as any)()).toThrow();
+  });
+
+  it("fires BEGIN callback when two shapes overlap", () => {
+    const space = new Space(new Vec2(0, 0));
+    let captured: InteractionCallback | null = null;
+
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        captured = cb;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(20));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(20));
+    b2.position = Vec2.weak(10, 0); // overlapping with b1
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(captured).not.toBeNull();
+    expect(captured).toBeInstanceOf(InteractionCallback);
+    expect(captured).toBeInstanceOf(Callback);
+  });
+
+  it("callback.int1 and callback.int2 are Interactor instances", () => {
+    const space = new Space(new Vec2(0, 0));
+    let int1: any = null;
+    let int2: any = null;
+
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        int1 = cb.int1;
+        int2 = cb.int2;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(20));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(20));
+    b2.position = Vec2.weak(10, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(int1).not.toBeNull();
+    expect(int2).not.toBeNull();
+    expect(int1).toBeInstanceOf(Interactor);
+    expect(int2).toBeInstanceOf(Interactor);
+  });
+
+  it("callback.int1 and int2 correspond to the two interacting bodies", () => {
+    const space = new Space(new Vec2(0, 0));
+    let int1: any = null;
+    let int2: any = null;
+
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        int1 = cb.int1;
+        int2 = cb.int2;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(20));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(20));
+    b2.position = Vec2.weak(10, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    // The two interactors should be our two bodies (order may vary)
+    const bodies = [int1, int2];
+    expect(bodies).toContain(b1);
+    expect(bodies).toContain(b2);
+  });
+
+  it("callback.arbiters is not null", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedArbiters: any = null;
+
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        capturedArbiters = cb.arbiters;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(20));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(20));
+    b2.position = Vec2.weak(10, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(capturedArbiters).not.toBeNull();
+    expect(capturedArbiters).toBeDefined();
+  });
+
+  it("callback.event returns CbEvent.BEGIN for a BEGIN listener", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedEvent: CbEvent | null = null;
+
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        capturedEvent = cb.event;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(20));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(20));
+    b2.position = Vec2.weak(10, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(capturedEvent).toBe(CbEvent.BEGIN);
+  });
+
+  it("callback.listener returns the InteractionListener", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedListener: any = null;
+
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        capturedListener = cb.listener;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(20));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(20));
+    b2.position = Vec2.weak(10, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(capturedListener).not.toBeNull();
+    expect(capturedListener).toBe(listener);
+  });
+
+  it("callback.toString() returns a meaningful string containing BEGIN", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedStr = "";
+
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        capturedStr = cb.toString();
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(20));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(20));
+    b2.position = Vec2.weak(10, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(capturedStr.length).toBeGreaterThan(0);
+    expect(capturedStr).toContain("BEGIN");
+  });
+
+  it("fires END callback when bodies separate", () => {
+    const space = new Space(new Vec2(0, 0));
+    let beginFired = false;
+    let endEvent: CbEvent | null = null;
+    let endIsInteractionCallback = false;
+
+    const beginListener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        beginFired = true;
+      },
+    );
+    beginListener.space = space;
+
+    const endListener = new InteractionListener(
+      CbEvent.END,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        endEvent = cb.event;
+        endIsInteractionCallback = cb instanceof InteractionCallback;
+      },
+    );
+    endListener.space = space;
+
+    const b1 = new Body();
+    b1.shapes.add(new Circle(20));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body();
+    b2.shapes.add(new Circle(20));
+    b2.position = Vec2.weak(10, 0);
+    b2.space = space;
+
+    // Step to get BEGIN
+    space.step(1 / 60);
+    expect(beginFired).toBe(true);
+
+    // Move bodies far apart to trigger END
+    b2.position = Vec2.weak(1000, 0);
+    // Need to step to process the separation
+    for (let i = 0; i < 5; i++) {
+      space.step(1 / 60);
+      if (endEvent) break;
+    }
+
+    expect(endIsInteractionCallback).toBe(true);
+    expect(endEvent).toBe(CbEvent.END);
+  });
+});

--- a/tests/callbacks/Listener.test.ts
+++ b/tests/callbacks/Listener.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import { Listener, cbEventToNumber } from "../../src/callbacks/Listener";
+import { BodyListener } from "../../src/callbacks/BodyListener";
+import { InteractionListener } from "../../src/callbacks/InteractionListener";
+import { ConstraintListener } from "../../src/callbacks/ConstraintListener";
+import { CbType } from "../../src/callbacks/CbType";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { ListenerType } from "../../src/callbacks/ListenerType";
+import { InteractionType } from "../../src/callbacks/InteractionType";
+import { Space } from "../../src/space/Space";
+import { Vec2 } from "../../src/geom/Vec2";
+
+describe("Listener", () => {
+  describe("instantiation guard", () => {
+    it("cannot be instantiated directly", () => {
+      expect(() => new Listener()).toThrow("Cannot instantiate Listener");
+    });
+  });
+
+  describe("cbEventToNumber", () => {
+    it("maps BEGIN to 0", () => {
+      expect(cbEventToNumber(CbEvent.BEGIN)).toBe(0);
+    });
+
+    it("maps END to 1", () => {
+      expect(cbEventToNumber(CbEvent.END)).toBe(1);
+    });
+
+    it("maps WAKE to 2", () => {
+      expect(cbEventToNumber(CbEvent.WAKE)).toBe(2);
+    });
+
+    it("maps SLEEP to 3", () => {
+      expect(cbEventToNumber(CbEvent.SLEEP)).toBe(3);
+    });
+
+    it("maps BREAK to 4", () => {
+      expect(cbEventToNumber(CbEvent.BREAK)).toBe(4);
+    });
+
+    it("maps PRE to 5", () => {
+      expect(cbEventToNumber(CbEvent.PRE)).toBe(5);
+    });
+
+    it("maps ONGOING to 6", () => {
+      expect(cbEventToNumber(CbEvent.ONGOING)).toBe(6);
+    });
+
+    it("returns -1 for unknown value", () => {
+      expect(cbEventToNumber({} as CbEvent)).toBe(-1);
+    });
+  });
+
+  describe("instanceof", () => {
+    it("BodyListener is instanceof Listener", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      expect(listener).toBeInstanceOf(Listener);
+    });
+
+    it("InteractionListener is instanceof Listener", () => {
+      const listener = new InteractionListener(
+        CbEvent.BEGIN,
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        () => {},
+      );
+      expect(listener).toBeInstanceOf(Listener);
+    });
+
+    it("ConstraintListener is instanceof Listener", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, () => {});
+      expect(listener).toBeInstanceOf(Listener);
+    });
+  });
+
+  describe("type getter", () => {
+    it("returns BODY for BodyListener", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      expect(listener.type).toBe(ListenerType.BODY);
+    });
+
+    it("returns CONSTRAINT for ConstraintListener", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, () => {});
+      expect(listener.type).toBe(ListenerType.CONSTRAINT);
+    });
+
+    it("returns INTERACTION for InteractionListener", () => {
+      const listener = new InteractionListener(
+        CbEvent.BEGIN,
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        () => {},
+      );
+      expect(listener.type).toBe(ListenerType.INTERACTION);
+    });
+  });
+
+  describe("event getter", () => {
+    it("returns correct CbEvent for BodyListener WAKE", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      expect(listener.event).toBe(CbEvent.WAKE);
+    });
+
+    it("returns correct CbEvent for BodyListener SLEEP", () => {
+      const listener = new BodyListener(CbEvent.SLEEP, CbType.ANY_BODY, () => {});
+      expect(listener.event).toBe(CbEvent.SLEEP);
+    });
+
+    it("returns correct CbEvent for InteractionListener BEGIN", () => {
+      const listener = new InteractionListener(
+        CbEvent.BEGIN,
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        () => {},
+      );
+      expect(listener.event).toBe(CbEvent.BEGIN);
+    });
+  });
+
+  describe("event setter", () => {
+    it("changes event on BodyListener from WAKE to SLEEP", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      expect(listener.event).toBe(CbEvent.WAKE);
+      listener.event = CbEvent.SLEEP;
+      expect(listener.event).toBe(CbEvent.SLEEP);
+    });
+
+    it("throws when setting event to null", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      expect(() => {
+        listener.event = null as unknown as CbEvent;
+      }).toThrow("Cannot set listener event type to null");
+    });
+  });
+
+  describe("precedence getter/setter", () => {
+    it("returns default precedence of 0", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      expect(listener.precedence).toBe(0);
+    });
+
+    it("returns custom precedence set in constructor", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {}, 5);
+      expect(listener.precedence).toBe(5);
+    });
+
+    it("setter changes precedence", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      listener.precedence = 10;
+      expect(listener.precedence).toBe(10);
+    });
+
+    it("setter can set negative precedence", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      listener.precedence = -3;
+      expect(listener.precedence).toBe(-3);
+    });
+  });
+
+  describe("space getter/setter", () => {
+    it("returns null initially", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      expect(listener.space).toBeNull();
+    });
+
+    it("setter adds listener to space", () => {
+      const space = new Space(new Vec2(0, -10));
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      listener.space = space;
+      expect(listener.space).toBeInstanceOf(Space);
+    });
+
+    it("setter can remove listener from space by setting null", () => {
+      const space = new Space(new Vec2(0, -10));
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      listener.space = space;
+      expect(listener.space).not.toBeNull();
+      listener.space = null;
+      expect(listener.space).toBeNull();
+    });
+  });
+
+  describe("toString", () => {
+    it("returns non-empty string for BodyListener", () => {
+      const listener = new BodyListener(CbEvent.WAKE, CbType.ANY_BODY, () => {});
+      const str = listener.toString();
+      expect(str).toBeTruthy();
+      expect(str.length).toBeGreaterThan(0);
+      expect(str).toContain("BodyListener");
+    });
+
+    it("returns non-empty string for ConstraintListener", () => {
+      const listener = new ConstraintListener(CbEvent.WAKE, CbType.ANY_CONSTRAINT, () => {});
+      const str = listener.toString();
+      expect(str).toBeTruthy();
+      expect(str).toContain("ConstraintListener");
+    });
+
+    it("returns non-empty string for InteractionListener", () => {
+      const listener = new InteractionListener(
+        CbEvent.BEGIN,
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        () => {},
+      );
+      const str = listener.toString();
+      expect(str).toBeTruthy();
+      expect(str).toContain("InteractionListener");
+    });
+  });
+});

--- a/tests/callbacks/PreCallback.test.ts
+++ b/tests/callbacks/PreCallback.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import { PreListener } from "../../src/callbacks/PreListener";
+import { PreCallback } from "../../src/callbacks/PreCallback";
+import { Callback } from "../../src/callbacks/Callback";
+import { CbType } from "../../src/callbacks/CbType";
+import { InteractionType } from "../../src/callbacks/InteractionType";
+import { PreFlag } from "../../src/callbacks/PreFlag";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { Circle } from "../../src/shape/Circle";
+import { Vec2 } from "../../src/geom/Vec2";
+import { BodyType } from "../../src/phys/BodyType";
+
+describe("PreCallback", () => {
+  it("should not be instantiable directly", () => {
+    expect(() => new Callback()).toThrow();
+  });
+
+  it("should fire PRE callback when two shapes are about to collide", () => {
+    const space = new Space(new Vec2(0, 0));
+    let preFired = false;
+    let capturedCallback: any = null;
+
+    const listener = new PreListener(
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        preFired = true;
+        capturedCallback = cb;
+        return PreFlag.ACCEPT;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body(BodyType.DYNAMIC);
+    b1.shapes.add(new Circle(50));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body(BodyType.DYNAMIC);
+    b2.shapes.add(new Circle(50));
+    b2.position = Vec2.weak(30, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(preFired).toBe(true);
+    expect(capturedCallback).not.toBeNull();
+  });
+
+  it("should have int1 and int2 as Interactors", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedCallback: any = null;
+
+    const listener = new PreListener(
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        capturedCallback = cb;
+        return PreFlag.ACCEPT;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body(BodyType.DYNAMIC);
+    b1.shapes.add(new Circle(50));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body(BodyType.DYNAMIC);
+    b2.shapes.add(new Circle(50));
+    b2.position = Vec2.weak(30, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(capturedCallback).not.toBeNull();
+    expect(capturedCallback.int1).toBeDefined();
+    expect(capturedCallback.int2).toBeDefined();
+  });
+
+  it("should have an arbiter", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedCallback: any = null;
+
+    const listener = new PreListener(
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        capturedCallback = cb;
+        return PreFlag.ACCEPT;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body(BodyType.DYNAMIC);
+    b1.shapes.add(new Circle(50));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body(BodyType.DYNAMIC);
+    b2.shapes.add(new Circle(50));
+    b2.position = Vec2.weak(30, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(capturedCallback).not.toBeNull();
+    expect(capturedCallback.arbiter).toBeDefined();
+  });
+
+  it("should have swapped as boolean", () => {
+    const space = new Space(new Vec2(0, 0));
+    let capturedCallback: any = null;
+
+    const listener = new PreListener(
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        capturedCallback = cb;
+        return PreFlag.ACCEPT;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body(BodyType.DYNAMIC);
+    b1.shapes.add(new Circle(50));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body(BodyType.DYNAMIC);
+    b2.shapes.add(new Circle(50));
+    b2.position = Vec2.weak(30, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(capturedCallback).not.toBeNull();
+    expect(typeof capturedCallback.swapped).toBe("boolean");
+  });
+
+  it("should prevent collision when returning PreFlag.IGNORE", () => {
+    const space = new Space(new Vec2(0, 0));
+
+    const listener = new PreListener(
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        return PreFlag.IGNORE;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body(BodyType.DYNAMIC);
+    b1.shapes.add(new Circle(50));
+    b1.position = Vec2.weak(0, 0);
+    b1.velocity = Vec2.weak(100, 0);
+    b1.space = space;
+
+    const b2 = new Body(BodyType.DYNAMIC);
+    b2.shapes.add(new Circle(50));
+    b2.position = Vec2.weak(30, 0);
+    b2.velocity = Vec2.weak(-100, 0);
+    b2.space = space;
+
+    // Step multiple times — bodies should pass through each other
+    for (let i = 0; i < 10; i++) {
+      space.step(1 / 60);
+    }
+
+    // If collision was ignored, bodies should have passed through each other
+    // b1 moved right, b2 moved left, they should be further apart than initial 30
+    const b1x = b1.position.x;
+    const b2x = b2.position.x;
+    // b1 should be to the right of its original position
+    expect(b1x).toBeGreaterThan(0);
+    // b2 should be to the left of its original position
+    expect(b2x).toBeLessThan(30);
+  });
+
+  it("should have toString() return a string", () => {
+    const space = new Space(new Vec2(0, 0));
+    let toStringResult = "";
+
+    const listener = new PreListener(
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb) => {
+        toStringResult = cb.toString();
+        return PreFlag.ACCEPT;
+      },
+    );
+    listener.space = space;
+
+    const b1 = new Body(BodyType.DYNAMIC);
+    b1.shapes.add(new Circle(50));
+    b1.position = Vec2.weak(0, 0);
+    b1.space = space;
+
+    const b2 = new Body(BodyType.DYNAMIC);
+    b2.shapes.add(new Circle(50));
+    b2.position = Vec2.weak(30, 0);
+    b2.space = space;
+
+    space.step(1 / 60);
+
+    expect(toStringResult.length).toBeGreaterThan(0);
+    expect(toStringResult).toContain("PRE");
+  });
+});

--- a/tests/callbacks/PreListener.test.ts
+++ b/tests/callbacks/PreListener.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect } from "vitest";
+import { PreListener } from "../../src/callbacks/PreListener";
+import { Listener } from "../../src/callbacks/Listener";
+import { CbType } from "../../src/callbacks/CbType";
+import { InteractionType } from "../../src/callbacks/InteractionType";
+import { ListenerType } from "../../src/callbacks/ListenerType";
+import { PreFlag } from "../../src/callbacks/PreFlag";
+import { Space } from "../../src/space/Space";
+import { Vec2 } from "../../src/geom/Vec2";
+
+describe("PreListener", () => {
+  const noop = () => PreFlag.ACCEPT;
+
+  describe("construction", () => {
+    it("constructs with COLLISION interaction type", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener).toBeInstanceOf(PreListener);
+      expect(listener.interactionType).toBe(InteractionType.COLLISION);
+    });
+
+    it("constructs with SENSOR interaction type", () => {
+      const listener = new PreListener(
+        InteractionType.SENSOR,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener).toBeInstanceOf(PreListener);
+      expect(listener.interactionType).toBe(InteractionType.SENSOR);
+    });
+
+    it("constructs with FLUID interaction type", () => {
+      const listener = new PreListener(
+        InteractionType.FLUID,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener).toBeInstanceOf(PreListener);
+      expect(listener.interactionType).toBe(InteractionType.FLUID);
+    });
+
+    it("throws when handler is null", () => {
+      expect(() => {
+        new PreListener(
+          InteractionType.COLLISION,
+          CbType.ANY_BODY,
+          CbType.ANY_BODY,
+          null as any,
+        );
+      }).toThrow("PreListener must take a handler");
+    });
+
+    it("throws when interaction type is null", () => {
+      expect(() => {
+        new PreListener(
+          null as any,
+          CbType.ANY_BODY,
+          CbType.ANY_BODY,
+          noop,
+        );
+      }).toThrow("Cannot set listener interaction type to null");
+    });
+  });
+
+  describe("instanceof", () => {
+    it("is instanceof Listener", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener).toBeInstanceOf(Listener);
+    });
+  });
+
+  describe("type", () => {
+    it("returns ListenerType.PRE", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener.type).toBe(ListenerType.PRE);
+    });
+  });
+
+  describe("options1/options2 getters", () => {
+    it("options1 returns an OptionType", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener.options1).toBeDefined();
+      expect(listener.options1).not.toBeNull();
+    });
+
+    it("options2 returns an OptionType", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener.options2).toBeDefined();
+      expect(listener.options2).not.toBeNull();
+    });
+  });
+
+  describe("handler getter/setter", () => {
+    it("returns the handler function", () => {
+      const handler = () => PreFlag.ACCEPT;
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        handler,
+      );
+      expect(listener.handler).toBe(handler);
+    });
+
+    it("setter changes handler", () => {
+      const handler1 = () => PreFlag.ACCEPT;
+      const handler2 = () => PreFlag.IGNORE;
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        handler1,
+      );
+      expect(listener.handler).toBe(handler1);
+      listener.handler = handler2;
+      expect(listener.handler).toBe(handler2);
+    });
+
+    it("throws when setting handler to null", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(() => {
+        listener.handler = null as any;
+      }).toThrow("non-null handler");
+    });
+  });
+
+  describe("pure getter/setter", () => {
+    it("defaults to false", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener.pure).toBe(false);
+    });
+
+    it("can be set to true via constructor", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+        0,
+        true,
+      );
+      expect(listener.pure).toBe(true);
+    });
+
+    it("setter changes pure", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener.pure).toBe(false);
+      listener.pure = true;
+      expect(listener.pure).toBe(true);
+    });
+
+    it("setter can set back to false", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+        0,
+        true,
+      );
+      listener.pure = false;
+      expect(listener.pure).toBe(false);
+    });
+  });
+
+  describe("interactionType getter/setter", () => {
+    it("returns the interaction type set in constructor", () => {
+      const listener = new PreListener(
+        InteractionType.SENSOR,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener.interactionType).toBe(InteractionType.SENSOR);
+    });
+
+    it("setter changes interaction type", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener.interactionType).toBe(InteractionType.COLLISION);
+      listener.interactionType = InteractionType.FLUID;
+      expect(listener.interactionType).toBe(InteractionType.FLUID);
+    });
+
+    it("throws when setting interaction type to null", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(() => {
+        listener.interactionType = null;
+      }).toThrow("Cannot set listener interaction type to null");
+    });
+  });
+
+  describe("precedence", () => {
+    it("defaults to 0", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      expect(listener.precedence).toBe(0);
+    });
+
+    it("can be set via constructor", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+        12,
+      );
+      expect(listener.precedence).toBe(12);
+    });
+
+    it("can be changed via setter", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      listener.precedence = -5;
+      expect(listener.precedence).toBe(-5);
+    });
+  });
+
+  describe("space", () => {
+    it("can be added to a space", () => {
+      const space = new Space(new Vec2(0, -10));
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      listener.space = space;
+      expect(listener.space).toBeInstanceOf(Space);
+    });
+
+    it("can be removed from a space", () => {
+      const space = new Space(new Vec2(0, -10));
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      listener.space = space;
+      expect(listener.space).not.toBeNull();
+      listener.space = null;
+      expect(listener.space).toBeNull();
+    });
+  });
+
+  describe("toString", () => {
+    it("returns a string containing PreListener", () => {
+      const listener = new PreListener(
+        InteractionType.COLLISION,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        noop,
+      );
+      const str = listener.toString();
+      expect(str).toContain("PreListener");
+      expect(str).toContain("COLLISION");
+    });
+  });
+});

--- a/tests/core/engine.test.ts
+++ b/tests/core/engine.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { getNape, ensureEnumsReady } from "../../src/core/engine";
+import { BodyType } from "../../src/phys/BodyType";
+import { ShapeType } from "../../src/shape/ShapeType";
+import { ArbiterType } from "../../src/dynamics/ArbiterType";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { ListenerType } from "../../src/callbacks/ListenerType";
+
+describe("engine", () => {
+  describe("getNape()", () => {
+    it("returns a valid namespace object", () => {
+      const nape = getNape();
+      expect(nape).toBeDefined();
+      expect(typeof nape).toBe("object");
+      expect(nape).not.toBeNull();
+    });
+
+    it("has expected sub-namespaces", () => {
+      const nape = getNape();
+      expect(nape.callbacks).toBeDefined();
+      expect(nape.dynamics).toBeDefined();
+      expect(nape.phys).toBeDefined();
+      expect(nape.shape).toBeDefined();
+      expect(nape.geom).toBeDefined();
+      expect(nape.space).toBeDefined();
+      expect(nape.constraint).toBeDefined();
+    });
+
+    it("returns the same object on multiple calls (singleton)", () => {
+      const first = getNape();
+      const second = getNape();
+      expect(first).toBe(second);
+    });
+
+    it("has __zpp internal namespace", () => {
+      const nape = getNape();
+      expect(nape.__zpp).toBeDefined();
+      expect(typeof nape.__zpp).toBe("object");
+    });
+  });
+
+  describe("ensureEnumsReady()", () => {
+    it("does not throw", () => {
+      expect(() => ensureEnumsReady()).not.toThrow();
+    });
+
+    it("makes BodyType enum singletons available", () => {
+      ensureEnumsReady();
+      expect(BodyType.DYNAMIC).toBeDefined();
+      expect(BodyType.STATIC).toBeDefined();
+      expect(BodyType.KINEMATIC).toBeDefined();
+    });
+
+    it("makes ShapeType enum singletons available", () => {
+      ensureEnumsReady();
+      expect(ShapeType.CIRCLE).toBeDefined();
+      expect(ShapeType.POLYGON).toBeDefined();
+    });
+
+    it("makes ArbiterType enum singletons available", () => {
+      ensureEnumsReady();
+      expect(ArbiterType.COLLISION).toBeDefined();
+      expect(ArbiterType.FLUID).toBeDefined();
+      expect(ArbiterType.SENSOR).toBeDefined();
+    });
+
+    it("makes CbEvent enum singletons available", () => {
+      ensureEnumsReady();
+      expect(CbEvent.BEGIN).toBeDefined();
+      expect(CbEvent.END).toBeDefined();
+      expect(CbEvent.PRE).toBeDefined();
+      expect(CbEvent.ONGOING).toBeDefined();
+      expect(CbEvent.WAKE).toBeDefined();
+      expect(CbEvent.SLEEP).toBeDefined();
+    });
+
+    it("makes ListenerType enum singletons available", () => {
+      ensureEnumsReady();
+      expect(ListenerType.BODY).toBeDefined();
+      expect(ListenerType.CONSTRAINT).toBeDefined();
+      expect(ListenerType.INTERACTION).toBeDefined();
+      expect(ListenerType.PRE).toBeDefined();
+    });
+
+    it("is idempotent (safe to call multiple times)", () => {
+      ensureEnumsReady();
+      ensureEnumsReady();
+      // Should still work — singletons remain valid
+      expect(BodyType.DYNAMIC).toBeDefined();
+      expect(ShapeType.CIRCLE).toBeDefined();
+    });
+  });
+});

--- a/tests/dynamics/CollisionArbiter.test.ts
+++ b/tests/dynamics/CollisionArbiter.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from "vitest";
+import { CollisionArbiter } from "../../src/dynamics/CollisionArbiter";
+import { Arbiter } from "../../src/dynamics/Arbiter";
+import { InteractionListener } from "../../src/callbacks/InteractionListener";
+import { CbType } from "../../src/callbacks/CbType";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { InteractionType } from "../../src/callbacks/InteractionType";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { Vec2 } from "../../src/geom/Vec2";
+import { BodyType } from "../../src/phys/BodyType";
+import "../../src/callbacks/PreFlag";
+import "../../src/dynamics/Contact";
+
+/**
+ * Helper: create a space with two overlapping circle bodies and step once.
+ * An InteractionListener captures the CollisionArbiter from the BEGIN callback.
+ */
+function createCircleCollision() {
+  const space = new Space(new Vec2(0, 0));
+
+  let captured: CollisionArbiter | null = null;
+  const listener = new InteractionListener(
+    CbEvent.BEGIN,
+    InteractionType.COLLISION,
+    CbType.ANY_BODY,
+    CbType.ANY_BODY,
+    (cb: any) => {
+      // cb is an InteractionCallback; cb.arbiters is an ArbiterList
+      const arbiters = cb.arbiters;
+      for (let i = 0; i < arbiters.length; i++) {
+        const arb = arbiters.at(i);
+        if (arb.isCollisionArbiter()) {
+          captured = arb.collisionArbiter;
+          break;
+        }
+      }
+    },
+  );
+  listener.space = space;
+
+  const b1 = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+  b1.shapes.add(new Circle(50));
+  b1.space = space;
+
+  const b2 = new Body(BodyType.DYNAMIC, new Vec2(30, 0));
+  b2.shapes.add(new Circle(50));
+  b2.space = space;
+
+  space.step(1 / 60);
+
+  return { space, b1, b2, captured };
+}
+
+/**
+ * Helper: create a polygon-on-polygon collision scene using gravity.
+ * A box falls onto a static floor; we step until a collision arbiter appears.
+ */
+function createPolygonCollision() {
+  const space = new Space(new Vec2(0, 500));
+
+  const floor = new Body(BodyType.STATIC, new Vec2(0, 50));
+  floor.shapes.add(new Polygon(Polygon.box(500, 10)));
+  floor.space = space;
+
+  const box = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+  box.shapes.add(new Polygon(Polygon.box(20, 20)));
+  box.space = space;
+
+  // Step until collision occurs
+  for (let i = 0; i < 60; i++) {
+    space.step(1 / 60, 10, 10);
+  }
+
+  return { space, floor, box };
+}
+
+describe("CollisionArbiter", () => {
+  // -------------------------------------------------------------------------
+  // Construction guards
+  // -------------------------------------------------------------------------
+
+  it("cannot be instantiated directly", () => {
+    expect(() => new CollisionArbiter()).toThrow("Cannot instantiate");
+  });
+
+  it("extends Arbiter", () => {
+    expect(CollisionArbiter.__super__).toBe(Arbiter);
+  });
+
+  it("has correct __name__", () => {
+    expect(CollisionArbiter.__name__).toEqual([
+      "nape",
+      "dynamics",
+      "CollisionArbiter",
+    ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Callback-captured CollisionArbiter (circle-circle)
+  // -------------------------------------------------------------------------
+
+  describe("circle-circle collision via callback", () => {
+    it("captures a CollisionArbiter in the BEGIN callback", () => {
+      const { captured } = createCircleCollision();
+      expect(captured).not.toBeNull();
+      expect(captured).toBeInstanceOf(CollisionArbiter);
+    });
+
+    it("isCollisionArbiter() returns true", () => {
+      const { captured } = createCircleCollision();
+      expect(captured).not.toBeNull();
+      const arb = captured as unknown as Arbiter;
+      expect(arb.isCollisionArbiter()).toBe(true);
+      expect(arb.isFluidArbiter()).toBe(false);
+      expect(arb.isSensorArbiter()).toBe(false);
+    });
+
+    it("normal is a unit Vec2", () => {
+      const { captured } = createCircleCollision();
+      expect(captured).not.toBeNull();
+      const normal = captured!.normal;
+      expect(normal).toBeDefined();
+      const len = Math.sqrt(normal.x * normal.x + normal.y * normal.y);
+      expect(len).toBeCloseTo(1, 3);
+    });
+
+    it("contacts is defined and non-empty", () => {
+      const { captured } = createCircleCollision();
+      expect(captured).not.toBeNull();
+      const contacts = captured!.contacts as any;
+      expect(contacts).toBeDefined();
+      expect(contacts.length).toBeGreaterThan(0);
+    });
+
+    it("radius is a non-negative number", () => {
+      const { captured } = createCircleCollision();
+      expect(captured).not.toBeNull();
+      expect(typeof captured!.radius).toBe("number");
+      expect(captured!.radius).toBeGreaterThanOrEqual(0);
+    });
+
+    it("elasticity is a non-negative number", () => {
+      const { captured } = createCircleCollision();
+      expect(captured).not.toBeNull();
+      expect(typeof captured!.elasticity).toBe("number");
+      expect(captured!.elasticity).toBeGreaterThanOrEqual(0);
+    });
+
+    it("dynamicFriction is a non-negative number", () => {
+      const { captured } = createCircleCollision();
+      expect(captured).not.toBeNull();
+      expect(typeof captured!.dynamicFriction).toBe("number");
+      expect(captured!.dynamicFriction).toBeGreaterThanOrEqual(0);
+    });
+
+    it("staticFriction is a non-negative number", () => {
+      const { captured } = createCircleCollision();
+      expect(captured).not.toBeNull();
+      expect(typeof captured!.staticFriction).toBe("number");
+      expect(captured!.staticFriction).toBeGreaterThanOrEqual(0);
+    });
+
+    it("rollingFriction is a non-negative number", () => {
+      const { captured } = createCircleCollision();
+      expect(captured).not.toBeNull();
+      expect(typeof captured!.rollingFriction).toBe("number");
+      expect(captured!.rollingFriction).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Arbiter access via space.arbiters (polygon collision)
+  // -------------------------------------------------------------------------
+
+  describe("polygon collision via space.arbiters", () => {
+    it("exposes a CollisionArbiter from space.arbiters", () => {
+      const { space } = createPolygonCollision();
+      const arb = space.arbiters.at(0);
+      expect(arb).toBeDefined();
+      expect(arb.isCollisionArbiter()).toBe(true);
+      expect(arb.collisionArbiter).not.toBeNull();
+    });
+
+    it("referenceEdge1 and referenceEdge2 are Edge or null", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      // For polygon-polygon, reference edges may be non-null
+      const e1 = colArb.referenceEdge1;
+      const e2 = colArb.referenceEdge2;
+      // They are either null or an Edge object
+      if (e1 !== null) {
+        expect(e1).toBeDefined();
+      }
+      if (e2 !== null) {
+        expect(e2).toBeDefined();
+      }
+    });
+
+    it("firstVertex() and secondVertex() return booleans", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      expect(typeof colArb.firstVertex()).toBe("boolean");
+      expect(typeof colArb.secondVertex()).toBe("boolean");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Impulse methods
+  // -------------------------------------------------------------------------
+
+  describe("impulse methods", () => {
+    it("normalImpulse() returns a Vec3", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      const imp = colArb.normalImpulse();
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+      expect(typeof imp.y).toBe("number");
+      expect(typeof imp.z).toBe("number");
+    });
+
+    it("tangentImpulse() returns a Vec3", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      const imp = colArb.tangentImpulse();
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+    });
+
+    it("totalImpulse() returns a Vec3", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      const imp = colArb.totalImpulse();
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+      expect(typeof imp.y).toBe("number");
+      expect(typeof imp.z).toBe("number");
+    });
+
+    it("rollingImpulse() returns a number", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      const imp = colArb.rollingImpulse();
+      expect(typeof imp).toBe("number");
+    });
+
+    it("normalImpulse(body) scoped to a specific body", () => {
+      const { space, box } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      const imp = colArb.normalImpulse(box);
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+    });
+
+    it("totalImpulse(body) scoped to a specific body", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      // Use one of the arbiter's bodies
+      const body = (colArb as unknown as Arbiter).body1;
+      const imp = colArb.totalImpulse(body);
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toString
+  // -------------------------------------------------------------------------
+
+  describe("toString", () => {
+    it("includes CollisionArbiter in the string", () => {
+      const { space } = createPolygonCollision();
+      const arb = space.arbiters.at(0);
+      const str = arb.toString();
+      expect(str).toContain("CollisionArbiter");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Setter validation (outside pre-handler)
+  // -------------------------------------------------------------------------
+
+  describe("mutable property guards", () => {
+    it("setting elasticity outside pre-handler throws", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      expect(() => {
+        colArb.elasticity = 0.5;
+      }).toThrow("only mutable during a pre-handler");
+    });
+
+    it("setting dynamicFriction outside pre-handler throws", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      expect(() => {
+        colArb.dynamicFriction = 0.5;
+      }).toThrow("only mutable during a pre-handler");
+    });
+
+    it("setting staticFriction outside pre-handler throws", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      expect(() => {
+        colArb.staticFriction = 0.5;
+      }).toThrow("only mutable during a pre-handler");
+    });
+
+    it("setting rollingFriction outside pre-handler throws", () => {
+      const { space } = createPolygonCollision();
+      const colArb = space.arbiters.at(0).collisionArbiter!;
+      expect(() => {
+        colArb.rollingFriction = 0.5;
+      }).toThrow("only mutable during a pre-handler");
+    });
+  });
+});

--- a/tests/dynamics/ContactList.test.ts
+++ b/tests/dynamics/ContactList.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect } from "vitest";
+import { getNape } from "../../src/core/engine";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { Contact } from "../../src/dynamics/Contact";
+import { CbType } from "../../src/callbacks/CbType";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { InteractionType } from "../../src/callbacks/InteractionType";
+import { InteractionListener } from "../../src/callbacks/InteractionListener";
+
+// Side-effect imports: ensure modules are registered
+import "../../src/callbacks/PreFlag";
+import "../../src/dynamics/CollisionArbiter";
+import "../../src/dynamics/FluidArbiter";
+
+/**
+ * Helper: create a space with two colliding circle bodies and step until contacts exist.
+ * Returns the space and both bodies.
+ */
+function createCollisionScene() {
+  const space = new Space(new Vec2(0, 500));
+
+  const floor = new Body(BodyType.STATIC, new Vec2(0, 50));
+  floor.shapes.add(new Polygon(Polygon.box(500, 10)));
+  floor.space = space;
+
+  const ball = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+  ball.shapes.add(new Circle(10));
+  ball.space = space;
+
+  // Step until collision occurs
+  for (let i = 0; i < 60; i++) {
+    space.step(1 / 60, 10, 10);
+  }
+  return { space, floor, ball };
+}
+
+/**
+ * Helper: get the ContactList from the first collision arbiter in the scene.
+ */
+function getContacts(space: any): any {
+  const arb = space.arbiters.at(0);
+  const colArb = arb.collisionArbiter;
+  return colArb.contacts;
+}
+
+describe("ContactList", () => {
+  // --------------------------------------------------------------------------
+  // Unit tests: empty list operations
+  // --------------------------------------------------------------------------
+  describe("empty list (unit)", () => {
+    function createEmptyList() {
+      const nape = getNape();
+      return new nape.dynamics.ContactList();
+    }
+
+    it("should have length 0", () => {
+      const list = createEmptyList();
+      expect(list.length).toBe(0);
+    });
+
+    it("empty() should return true", () => {
+      const list = createEmptyList();
+      expect(list.empty()).toBe(true);
+    });
+
+    it("toString() should return '[]'", () => {
+      const list = createEmptyList();
+      expect(list.toString()).toBe("[]");
+    });
+
+    it("at(0) should throw index out of bounds", () => {
+      const list = createEmptyList();
+      expect(() => list.at(0)).toThrow("Index out of bounds");
+    });
+
+    it("at(-1) should throw index out of bounds", () => {
+      const list = createEmptyList();
+      expect(() => list.at(-1)).toThrow("Index out of bounds");
+    });
+
+    it("iterator().hasNext() should return false on empty list", () => {
+      const list = createEmptyList();
+      const it = list.iterator();
+      expect(it.hasNext()).toBe(false);
+    });
+
+    it("for...of should yield no elements on empty list", () => {
+      const list = createEmptyList();
+      const items: any[] = [];
+      for (const item of list) {
+        items.push(item);
+      }
+      expect(items).toHaveLength(0);
+    });
+
+    it("foreach with null lambda should throw", () => {
+      const list = createEmptyList();
+      expect(() => list.foreach(null)).toThrow("Cannot execute null");
+    });
+
+    it("copy() should return a new empty list", () => {
+      const list = createEmptyList();
+      const copy = list.copy();
+      expect(copy.length).toBe(0);
+      expect(copy.empty()).toBe(true);
+    });
+
+    it("merge with null should throw", () => {
+      const list = createEmptyList();
+      expect(() => list.merge(null)).toThrow("Cannot merge with null");
+    });
+
+    it("clear() on empty list should not throw", () => {
+      const list = createEmptyList();
+      expect(() => list.clear()).not.toThrow();
+      expect(list.length).toBe(0);
+    });
+
+    it("filter with null lambda should throw", () => {
+      const list = createEmptyList();
+      expect(() => list.filter(null)).toThrow("Cannot select elements");
+    });
+
+    it("fromArray(null) should throw", () => {
+      const nape = getNape();
+      const ContactListCtor = nape.dynamics.ContactList;
+      expect(() => ContactListCtor.fromArray(null)).toThrow(
+        "Cannot convert null Array",
+      );
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Integration tests: contacts from actual collision
+  // --------------------------------------------------------------------------
+  describe("with active contacts (integration)", () => {
+    it("should have length >= 1", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      expect(contacts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("empty() should return false", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      expect(contacts.empty()).toBe(false);
+    });
+
+    it("at(0) should return a Contact instance", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const contact = contacts.at(0);
+      expect(contact).toBeInstanceOf(Contact);
+    });
+
+    it("at() with out-of-bounds index should throw", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const len = contacts.length;
+      expect(() => contacts.at(len)).toThrow("Index out of bounds");
+      expect(() => contacts.at(-1)).toThrow("Index out of bounds");
+    });
+
+    it("toString() should contain Contact representation", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const str = contacts.toString();
+      expect(str).toMatch(/^\[/);
+      expect(str).toMatch(/\]$/);
+      // Should contain at least one Contact entry
+      expect(str.length).toBeGreaterThan(2);
+    });
+
+    it("has() should detect contained contacts", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const contact = contacts.at(0);
+      expect(contacts.has(contact)).toBe(true);
+    });
+
+    it("iterator() / hasNext() / next() should iterate all contacts", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const it = contacts.iterator();
+      const items: any[] = [];
+      while (it.hasNext()) {
+        items.push(it.next());
+      }
+      expect(items.length).toBe(contacts.length);
+      for (const item of items) {
+        expect(item).toBeInstanceOf(Contact);
+      }
+    });
+
+    it("for...of iteration should work via Symbol.iterator", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const items: any[] = [];
+      for (const contact of contacts) {
+        items.push(contact);
+      }
+      expect(items.length).toBe(contacts.length);
+      for (const item of items) {
+        expect(item).toBeInstanceOf(Contact);
+      }
+    });
+
+    it("spread operator should work via Symbol.iterator", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const items = [...contacts];
+      expect(items.length).toBe(contacts.length);
+    });
+
+    it("foreach() should call lambda for each contact", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const items: any[] = [];
+      contacts.foreach((c: any) => items.push(c));
+      expect(items.length).toBe(contacts.length);
+      for (const item of items) {
+        expect(item).toBeInstanceOf(Contact);
+      }
+    });
+
+    it("copy() should return a separate list with the same contacts", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const copy = contacts.copy();
+      expect(copy.length).toBe(contacts.length);
+      for (let i = 0; i < copy.length; i++) {
+        expect(copy.at(i)).toBe(contacts.at(i));
+      }
+    });
+
+    it("copy(true) should throw since Contact is not copyable", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      expect(() => contacts.copy(true)).toThrow("not a copyable type");
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Integration tests: contacts via InteractionListener callback
+  // --------------------------------------------------------------------------
+  describe("contacts via ONGOING callback", () => {
+    it("should access contacts inside an ONGOING collision callback", () => {
+      const space = new Space(new Vec2(0, 500));
+      const cbType = new CbType();
+      let capturedContacts: any = null;
+
+      const listener = new InteractionListener(
+        CbEvent.ONGOING,
+        InteractionType.COLLISION,
+        cbType,
+        cbType,
+        (cb: any) => {
+          const colArb = cb.arbiters.at(0).collisionArbiter;
+          if (colArb != null) {
+            capturedContacts = colArb.contacts;
+          }
+        },
+      );
+      listener.space = space;
+
+      const floor = new Body(BodyType.STATIC, new Vec2(0, 50));
+      const floorShape = new Polygon(Polygon.box(500, 10));
+      floorShape.cbTypes.add(cbType);
+      floor.shapes.add(floorShape);
+      floor.space = space;
+
+      const ball = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      const ballShape = new Circle(10);
+      ballShape.cbTypes.add(cbType);
+      ball.shapes.add(ballShape);
+      ball.space = space;
+
+      // Step multiple times: first step triggers BEGIN, subsequent steps trigger ONGOING
+      for (let i = 0; i < 60; i++) {
+        space.step(1 / 60, 10, 10);
+      }
+
+      expect(capturedContacts).not.toBeNull();
+      expect(capturedContacts.length).toBeGreaterThanOrEqual(1);
+      expect(capturedContacts.at(0)).toBeInstanceOf(Contact);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Immutability
+  // --------------------------------------------------------------------------
+  describe("immutability", () => {
+    it("contacts from an arbiter should be immutable (cannot push)", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      // The contacts list from a collision arbiter is immutable
+      expect(contacts.zpp_inner.immutable).toBe(true);
+      // Attempting to push should throw
+      const contact = contacts.at(0);
+      expect(() => contacts.push(contact)).toThrow("immutable");
+    });
+
+    it("contacts from an arbiter should be immutable (cannot pop)", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      expect(() => contacts.pop()).toThrow("immutable");
+    });
+
+    it("contacts from an arbiter should be immutable (cannot shift)", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      expect(() => contacts.shift()).toThrow("immutable");
+    });
+
+    it("contacts from an arbiter should be immutable (cannot clear)", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      expect(() => contacts.clear()).toThrow("immutable");
+    });
+
+    it("contacts from an arbiter should be immutable (cannot remove)", () => {
+      const { space } = createCollisionScene();
+      const contacts = getContacts(space);
+      const contact = contacts.at(0);
+      expect(() => contacts.remove(contact)).toThrow("immutable");
+    });
+  });
+});

--- a/tests/dynamics/FluidArbiter.test.ts
+++ b/tests/dynamics/FluidArbiter.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect } from "vitest";
+import { FluidArbiter } from "../../src/dynamics/FluidArbiter";
+import { Arbiter } from "../../src/dynamics/Arbiter";
+import { InteractionListener } from "../../src/callbacks/InteractionListener";
+import { PreListener } from "../../src/callbacks/PreListener";
+import { CbType } from "../../src/callbacks/CbType";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { InteractionType } from "../../src/callbacks/InteractionType";
+import { PreFlag } from "../../src/callbacks/PreFlag";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { Vec2 } from "../../src/geom/Vec2";
+import { BodyType } from "../../src/phys/BodyType";
+import { FluidProperties } from "../../src/phys/FluidProperties";
+import "../../src/dynamics/Contact";
+
+/**
+ * Helper: create a space with a fluid-enabled static shape and a dynamic body.
+ *
+ * Fluid arbiters are transient and do not persist in space.arbiters after
+ * the step completes. All fluid arbiter access must happen inside callbacks.
+ *
+ * This helper uses an ONGOING listener (which fires after BEGIN, once the
+ * solver has populated impulse data) to capture the FluidArbiter and its
+ * base Arbiter reference for testing impulse methods and properties.
+ */
+function createFluidScene() {
+  const space = new Space(new Vec2(0, 400));
+
+  let captured: FluidArbiter | null = null;
+  let capturedArbBase: Arbiter | null = null;
+
+  const listener = new InteractionListener(
+    CbEvent.ONGOING,
+    InteractionType.FLUID,
+    CbType.ANY_BODY,
+    CbType.ANY_BODY,
+    (cb: any) => {
+      const arbiters = cb.arbiters;
+      for (let i = 0; i < arbiters.length; i++) {
+        const arb = arbiters.at(i);
+        if (arb.isFluidArbiter()) {
+          captured = arb.fluidArbiter;
+          capturedArbBase = arb;
+          break;
+        }
+      }
+    },
+  );
+  listener.space = space;
+
+  // Static body with a large fluid-enabled polygon
+  const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+  const fluidShape = new Polygon(Polygon.box(1000, 1000));
+  fluidShape.fluidEnabled = true;
+  fluidShape.fluidProperties = new FluidProperties(3, 5);
+  fluidBody.shapes.add(fluidShape as any);
+  fluidBody.space = space;
+
+  // Dynamic circle starting inside the fluid region
+  const ball = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+  ball.shapes.add(new Circle(20));
+  ball.space = space;
+
+  // First step triggers BEGIN; second step triggers ONGOING with solver data
+  space.step(1 / 60, 10, 10);
+  space.step(1 / 60, 10, 10);
+
+  return { space, fluidBody, ball, captured, capturedArbBase };
+}
+
+/**
+ * Helper: create a fluid scene using a BEGIN callback for initial detection tests.
+ */
+function createFluidSceneBegin() {
+  const space = new Space(new Vec2(0, 400));
+
+  let captured: FluidArbiter | null = null;
+
+  const listener = new InteractionListener(
+    CbEvent.BEGIN,
+    InteractionType.FLUID,
+    CbType.ANY_BODY,
+    CbType.ANY_BODY,
+    (cb: any) => {
+      const arbiters = cb.arbiters;
+      for (let i = 0; i < arbiters.length; i++) {
+        const arb = arbiters.at(i);
+        if (arb.isFluidArbiter()) {
+          captured = arb.fluidArbiter;
+          break;
+        }
+      }
+    },
+  );
+  listener.space = space;
+
+  const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+  const fluidShape = new Polygon(Polygon.box(1000, 1000));
+  fluidShape.fluidEnabled = true;
+  fluidShape.fluidProperties = new FluidProperties(3, 5);
+  fluidBody.shapes.add(fluidShape as any);
+  fluidBody.space = space;
+
+  const ball = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+  ball.shapes.add(new Circle(20));
+  ball.space = space;
+
+  space.step(1 / 60);
+
+  return { space, fluidBody, ball, captured };
+}
+
+describe("FluidArbiter", () => {
+  // -------------------------------------------------------------------------
+  // Construction guards
+  // -------------------------------------------------------------------------
+
+  it("cannot be instantiated directly", () => {
+    expect(() => new FluidArbiter()).toThrow("Cannot instantiate");
+  });
+
+  it("extends Arbiter", () => {
+    expect(FluidArbiter.__super__).toBe(Arbiter);
+  });
+
+  it("has correct __name__", () => {
+    expect(FluidArbiter.__name__).toEqual([
+      "nape",
+      "dynamics",
+      "FluidArbiter",
+    ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Callback-captured FluidArbiter (BEGIN)
+  // -------------------------------------------------------------------------
+
+  describe("fluid interaction via BEGIN callback", () => {
+    it("captures a FluidArbiter in the BEGIN callback", () => {
+      const { captured } = createFluidSceneBegin();
+      expect(captured).not.toBeNull();
+      expect(captured).toBeInstanceOf(FluidArbiter);
+    });
+
+    it("is also an instance of Arbiter", () => {
+      const { captured } = createFluidSceneBegin();
+      expect(captured).not.toBeNull();
+      expect(captured).toBeInstanceOf(Arbiter);
+    });
+
+    it("isFluidArbiter() returns true", () => {
+      const { captured } = createFluidSceneBegin();
+      expect(captured).not.toBeNull();
+      const arb = captured as unknown as Arbiter;
+      expect(arb.isFluidArbiter()).toBe(true);
+      expect(arb.isCollisionArbiter()).toBe(false);
+      expect(arb.isSensorArbiter()).toBe(false);
+    });
+
+    it("position is defined", () => {
+      const { captured } = createFluidSceneBegin();
+      expect(captured).not.toBeNull();
+      const pos = captured!.position;
+      expect(pos).toBeDefined();
+      expect(typeof pos.x).toBe("number");
+      expect(typeof pos.y).toBe("number");
+    });
+
+    it("overlap is a positive number", () => {
+      const { captured } = createFluidSceneBegin();
+      expect(captured).not.toBeNull();
+      expect(typeof captured!.overlap).toBe("number");
+      expect(captured!.overlap).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Callback-captured FluidArbiter (ONGOING -- with solver data)
+  // -------------------------------------------------------------------------
+
+  describe("fluid interaction via ONGOING callback", () => {
+    it("captures a FluidArbiter in the ONGOING callback", () => {
+      const { captured } = createFluidScene();
+      expect(captured).not.toBeNull();
+      expect(captured).toBeInstanceOf(FluidArbiter);
+    });
+
+    it("fluidArbiter getter on base Arbiter returns the FluidArbiter", () => {
+      const { capturedArbBase } = createFluidScene();
+      expect(capturedArbBase).not.toBeNull();
+      expect(capturedArbBase!.fluidArbiter).not.toBeNull();
+      expect(capturedArbBase!.collisionArbiter).toBeNull();
+    });
+
+    it("type checks are correct on the base Arbiter", () => {
+      const { capturedArbBase } = createFluidScene();
+      expect(capturedArbBase).not.toBeNull();
+      expect(capturedArbBase!.isFluidArbiter()).toBe(true);
+      expect(capturedArbBase!.isCollisionArbiter()).toBe(false);
+      expect(capturedArbBase!.isSensorArbiter()).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Impulse methods (use ONGOING scene so solver has run)
+  // -------------------------------------------------------------------------
+
+  describe("impulse methods", () => {
+    it("buoyancyImpulse() returns a Vec3", () => {
+      const { captured } = createFluidScene();
+      expect(captured).not.toBeNull();
+      const imp = captured!.buoyancyImpulse();
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+      expect(typeof imp.y).toBe("number");
+      expect(typeof imp.z).toBe("number");
+    });
+
+    it("dragImpulse() returns a Vec3", () => {
+      const { captured } = createFluidScene();
+      expect(captured).not.toBeNull();
+      const imp = captured!.dragImpulse();
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+      expect(typeof imp.y).toBe("number");
+      expect(typeof imp.z).toBe("number");
+    });
+
+    it("totalImpulse() returns a Vec3", () => {
+      const { captured } = createFluidScene();
+      expect(captured).not.toBeNull();
+      const imp = captured!.totalImpulse();
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+      expect(typeof imp.y).toBe("number");
+      expect(typeof imp.z).toBe("number");
+    });
+
+    it("buoyancyImpulse(body) scoped to a specific body", () => {
+      const { captured, capturedArbBase, ball } = createFluidScene();
+      expect(captured).not.toBeNull();
+      expect(capturedArbBase).not.toBeNull();
+      const body =
+        capturedArbBase!.body1 === ball ? ball : capturedArbBase!.body2;
+      const imp = captured!.buoyancyImpulse(body);
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+      expect(typeof imp.y).toBe("number");
+      expect(typeof imp.z).toBe("number");
+    });
+
+    it("dragImpulse(body) scoped to a specific body", () => {
+      const { captured, capturedArbBase, ball } = createFluidScene();
+      expect(captured).not.toBeNull();
+      expect(capturedArbBase).not.toBeNull();
+      const body =
+        capturedArbBase!.body1 === ball ? ball : capturedArbBase!.body2;
+      const imp = captured!.dragImpulse(body);
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+    });
+
+    it("totalImpulse(body) scoped to a specific body", () => {
+      const { captured, capturedArbBase, ball } = createFluidScene();
+      expect(captured).not.toBeNull();
+      expect(capturedArbBase).not.toBeNull();
+      const body =
+        capturedArbBase!.body1 === ball ? ball : capturedArbBase!.body2;
+      const imp = captured!.totalImpulse(body);
+      expect(imp).toBeDefined();
+      expect(typeof imp.x).toBe("number");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Mutable property guards via PreListener
+  // -------------------------------------------------------------------------
+
+  describe("mutable property guards", () => {
+    it("can modify position and overlap inside a pre-handler", () => {
+      const space = new Space(new Vec2(0, 400));
+      let positionModified = false;
+      let overlapModified = false;
+
+      const preListener = new PreListener(
+        InteractionType.FLUID,
+        CbType.ANY_BODY,
+        CbType.ANY_BODY,
+        (cb: any) => {
+          const arb = cb.arbiter;
+          if (arb.isFluidArbiter()) {
+            const farb = arb.fluidArbiter;
+            farb.position = Vec2.weak(5, 5);
+            positionModified = true;
+            farb.overlap = 50;
+            overlapModified = true;
+          }
+          return PreFlag.ACCEPT;
+        },
+      );
+      preListener.space = space;
+
+      const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+      const fluidShape = new Polygon(Polygon.box(1000, 1000));
+      fluidShape.fluidEnabled = true;
+      fluidShape.fluidProperties = new FluidProperties(3, 5);
+      fluidBody.shapes.add(fluidShape as any);
+      fluidBody.space = space;
+
+      const ball = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      ball.shapes.add(new Circle(20));
+      ball.space = space;
+
+      for (let i = 0; i < 5; i++) {
+        space.step(1 / 60);
+        if (positionModified) break;
+      }
+
+      expect(positionModified).toBe(true);
+      expect(overlapModified).toBe(true);
+    });
+
+    it("setting position outside pre-handler throws", () => {
+      const { captured } = createFluidScene();
+      expect(captured).not.toBeNull();
+      expect(() => {
+        captured!.position = Vec2.weak(10, 10);
+      }).toThrow("mutable only within a pre-handler");
+    });
+
+    it("setting overlap outside pre-handler throws", () => {
+      const { captured } = createFluidScene();
+      expect(captured).not.toBeNull();
+      expect(() => {
+        captured!.overlap = 100;
+      }).toThrow("mutable only within a pre-handler");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toString
+  // -------------------------------------------------------------------------
+
+  describe("toString", () => {
+    it("includes FluidArbiter in the string", () => {
+      const { capturedArbBase } = createFluidScene();
+      expect(capturedArbBase).not.toBeNull();
+      const str = capturedArbBase!.toString();
+      expect(str).toContain("FluidArbiter");
+    });
+  });
+});

--- a/tests/geom/GeomVertexIterator.test.ts
+++ b/tests/geom/GeomVertexIterator.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import { GeomVertexIterator } from "../../src/geom/GeomVertexIterator";
+import { GeomPoly } from "../../src/geom/GeomPoly";
+import { Vec2 } from "../../src/geom/Vec2";
+
+describe("GeomVertexIterator", () => {
+  describe("instantiation guard", () => {
+    it("should throw when instantiated directly", () => {
+      expect(() => new (GeomVertexIterator as any)()).toThrow(
+        "Cannot instantiate GeomVertexIterator"
+      );
+    });
+  });
+
+  describe("forward iteration via hasNext()/next()", () => {
+    it("should iterate over all vertices of a triangle", () => {
+      const poly = new GeomPoly([
+        Vec2.get(0, 0),
+        Vec2.get(10, 0),
+        Vec2.get(10, 10),
+      ]);
+      const iter = poly.forwardIterator();
+
+      const verts: Vec2[] = [];
+      while (iter.hasNext()) {
+        verts.push(iter.next());
+      }
+
+      expect(verts).toHaveLength(3);
+    });
+
+    it("should iterate over all vertices of a quad", () => {
+      const poly = new GeomPoly([
+        Vec2.get(0, 0),
+        Vec2.get(20, 0),
+        Vec2.get(20, 15),
+        Vec2.get(0, 15),
+      ]);
+      const iter = poly.forwardIterator();
+
+      const verts: Vec2[] = [];
+      while (iter.hasNext()) {
+        verts.push(iter.next());
+      }
+
+      expect(verts).toHaveLength(4);
+    });
+
+    it("should return Vec2 instances", () => {
+      const poly = new GeomPoly([
+        Vec2.get(1, 2),
+        Vec2.get(3, 4),
+        Vec2.get(5, 6),
+      ]);
+      const iter = poly.forwardIterator();
+
+      while (iter.hasNext()) {
+        const v = iter.next();
+        expect(v).toBeInstanceOf(Vec2);
+      }
+    });
+
+    it("should return vertices with correct coordinates", () => {
+      const poly = new GeomPoly([
+        Vec2.get(0, 0),
+        Vec2.get(10, 0),
+        Vec2.get(10, 10),
+        Vec2.get(0, 10),
+      ]);
+      const iter = poly.forwardIterator();
+
+      const coords: Array<[number, number]> = [];
+      while (iter.hasNext()) {
+        const v: Vec2 = iter.next();
+        coords.push([v.x, v.y]);
+      }
+
+      // GeomPoly stores vertices in a circular linked list starting at the
+      // current head position after the constructor's skipForward(1).
+      expect(coords).toEqual([
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+      ]);
+    });
+  });
+
+  describe("backwards iteration", () => {
+    it("should iterate in reverse order", () => {
+      const poly = new GeomPoly([
+        Vec2.get(0, 0),
+        Vec2.get(10, 0),
+        Vec2.get(10, 10),
+        Vec2.get(0, 10),
+      ]);
+
+      const fwdCoords: Array<[number, number]> = [];
+      const fwdIter = poly.forwardIterator();
+      while (fwdIter.hasNext()) {
+        const v: Vec2 = fwdIter.next();
+        fwdCoords.push([v.x, v.y]);
+      }
+
+      const bwdCoords: Array<[number, number]> = [];
+      const bwdIter = poly.backwardsIterator();
+      while (bwdIter.hasNext()) {
+        const v: Vec2 = bwdIter.next();
+        bwdCoords.push([v.x, v.y]);
+      }
+
+      // Backwards traverses the circular list in reverse link order.
+      // Starting from the same head, backwards goes prev instead of next.
+      expect(bwdCoords).toHaveLength(fwdCoords.length);
+      // The backwards order should contain the same vertices but traversed
+      // in the opposite direction through the circular list.
+      const fwdSet = new Set(fwdCoords.map(([x, y]) => `${x},${y}`));
+      const bwdSet = new Set(bwdCoords.map(([x, y]) => `${x},${y}`));
+      expect(bwdSet).toEqual(fwdSet);
+    });
+  });
+
+  describe("Symbol.iterator support", () => {
+    it("should be iterable with for...of", () => {
+      const poly = new GeomPoly([
+        Vec2.get(0, 0),
+        Vec2.get(5, 0),
+        Vec2.get(5, 5),
+      ]);
+      const iter = poly.forwardIterator();
+
+      const verts: Vec2[] = [];
+      for (const v of iter) {
+        verts.push(v as Vec2);
+      }
+
+      expect(verts).toHaveLength(3);
+      verts.forEach((v) => expect(v).toBeInstanceOf(Vec2));
+    });
+
+    it("should support spread syntax", () => {
+      const poly = new GeomPoly([
+        Vec2.get(1, 1),
+        Vec2.get(2, 2),
+        Vec2.get(3, 3),
+        Vec2.get(4, 4),
+      ]);
+      const iter = poly.forwardIterator();
+
+      const verts = [...iter];
+      expect(verts).toHaveLength(4);
+    });
+  });
+
+  describe("iterator disposal", () => {
+    it("should dispose after full iteration", () => {
+      const poly = new GeomPoly([
+        Vec2.get(0, 0),
+        Vec2.get(1, 0),
+        Vec2.get(1, 1),
+      ]);
+      const iter = poly.forwardIterator();
+
+      // Exhaust the iterator
+      while (iter.hasNext()) {
+        iter.next();
+      }
+
+      // After exhaustion, the inner state is released and further use throws
+      expect(() => iter.hasNext()).toThrow("Iterator has been disposed");
+    });
+
+    it("should throw on next() after disposal", () => {
+      const poly = new GeomPoly([
+        Vec2.get(0, 0),
+        Vec2.get(1, 0),
+        Vec2.get(1, 1),
+      ]);
+      const iter = poly.forwardIterator();
+
+      while (iter.hasNext()) {
+        iter.next();
+      }
+
+      expect(() => iter.next()).toThrow("Iterator has been disposed");
+    });
+  });
+
+  describe("single vertex polygon", () => {
+    it("should iterate over a single vertex", () => {
+      const poly = new GeomPoly([Vec2.get(7, 13)]);
+      const iter = poly.forwardIterator();
+
+      const verts: Vec2[] = [];
+      while (iter.hasNext()) {
+        verts.push(iter.next());
+      }
+
+      expect(verts).toHaveLength(1);
+      expect(verts[0].x).toBe(7);
+      expect(verts[0].y).toBe(13);
+    });
+  });
+});

--- a/tests/geom/Vec2List.test.ts
+++ b/tests/geom/Vec2List.test.ts
@@ -1,0 +1,475 @@
+import { describe, it, expect } from "vitest";
+import { Vec2 } from "../../src/geom/Vec2";
+import { getNape } from "../../src/core/engine";
+
+function makeList() {
+  const nape = getNape();
+  return new nape.geom.Vec2List();
+}
+
+describe("Vec2List", () => {
+  describe("construction", () => {
+    it("should create an empty list via nape namespace", () => {
+      const list = makeList();
+      expect(list).toBeDefined();
+      expect(list.length).toBe(0);
+      expect(list.empty()).toBe(true);
+    });
+  });
+
+  describe("push / unshift", () => {
+    it("should push elements to the end", () => {
+      const list = makeList();
+      const v1 = new Vec2(1, 2);
+      const v2 = new Vec2(3, 4);
+      list.push(v1);
+      list.push(v2);
+      expect(list.length).toBe(2);
+      expect(list.at(0).x).toBe(1);
+      expect(list.at(1).x).toBe(3);
+    });
+
+    it("should unshift elements to the front", () => {
+      const list = makeList();
+      const v1 = new Vec2(1, 2);
+      const v2 = new Vec2(3, 4);
+      list.push(v1);
+      list.unshift(v2);
+      expect(list.length).toBe(2);
+      expect(list.at(0).x).toBe(3);
+      expect(list.at(1).x).toBe(1);
+    });
+
+    it("push and unshift return true on success", () => {
+      const list = makeList();
+      expect(list.push(new Vec2(1, 2))).toBe(true);
+      expect(list.unshift(new Vec2(3, 4))).toBe(true);
+    });
+  });
+
+  describe("pop / shift", () => {
+    it("should pop the last element", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      list.push(new Vec2(3, 4));
+      const popped = list.pop();
+      expect(popped.x).toBe(3);
+      expect(popped.y).toBe(4);
+      expect(list.length).toBe(1);
+    });
+
+    it("should shift the first element", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      list.push(new Vec2(3, 4));
+      const shifted = list.shift();
+      expect(shifted.x).toBe(1);
+      expect(shifted.y).toBe(2);
+      expect(list.length).toBe(1);
+    });
+
+    it("should throw when popping from empty list", () => {
+      const list = makeList();
+      expect(() => list.pop()).toThrow("Cannot remove from empty list");
+    });
+
+    it("should throw when shifting from empty list", () => {
+      const list = makeList();
+      expect(() => list.shift()).toThrow("Cannot remove from empty list");
+    });
+  });
+
+  describe("at", () => {
+    it("should access elements by index", () => {
+      const list = makeList();
+      list.push(new Vec2(10, 20));
+      list.push(new Vec2(30, 40));
+      list.push(new Vec2(50, 60));
+      expect(list.at(0).x).toBe(10);
+      expect(list.at(1).x).toBe(30);
+      expect(list.at(2).x).toBe(50);
+    });
+
+    it("should throw for negative index", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      expect(() => list.at(-1)).toThrow("Index out of bounds");
+    });
+
+    it("should throw for index >= length", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      expect(() => list.at(1)).toThrow("Index out of bounds");
+    });
+
+    it("should throw for index on empty list", () => {
+      const list = makeList();
+      expect(() => list.at(0)).toThrow("Index out of bounds");
+    });
+  });
+
+  describe("has", () => {
+    it("should return true when element exists", () => {
+      const list = makeList();
+      const v = new Vec2(5, 6);
+      list.push(v);
+      expect(list.has(v)).toBe(true);
+    });
+
+    it("should return false when element does not exist", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      const other = new Vec2(1, 2);
+      expect(list.has(other)).toBe(false);
+    });
+  });
+
+  describe("remove", () => {
+    it("should remove an existing element and return true", () => {
+      const list = makeList();
+      const v1 = new Vec2(1, 2);
+      const v2 = new Vec2(3, 4);
+      list.push(v1);
+      list.push(v2);
+      expect(list.remove(v1)).toBe(true);
+      expect(list.length).toBe(1);
+      expect(list.at(0).x).toBe(3);
+    });
+
+    it("should return false when element not found", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      const other = new Vec2(5, 6);
+      expect(list.remove(other)).toBe(false);
+      expect(list.length).toBe(1);
+    });
+  });
+
+  describe("clear", () => {
+    it("should remove all elements", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      list.push(new Vec2(3, 4));
+      list.push(new Vec2(5, 6));
+      list.clear();
+      expect(list.length).toBe(0);
+      expect(list.empty()).toBe(true);
+    });
+
+    it("should be safe to clear an empty list", () => {
+      const list = makeList();
+      list.clear();
+      expect(list.length).toBe(0);
+    });
+  });
+
+  describe("empty", () => {
+    it("should return true for new list", () => {
+      expect(makeList().empty()).toBe(true);
+    });
+
+    it("should return false after push", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      expect(list.empty()).toBe(false);
+    });
+
+    it("should return true after removing all elements", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      list.pop();
+      expect(list.empty()).toBe(true);
+    });
+  });
+
+  describe("length", () => {
+    it("should reflect push and pop operations", () => {
+      const list = makeList();
+      expect(list.length).toBe(0);
+      list.push(new Vec2(1, 1));
+      expect(list.length).toBe(1);
+      list.push(new Vec2(2, 2));
+      expect(list.length).toBe(2);
+      list.pop();
+      expect(list.length).toBe(1);
+      list.shift();
+      expect(list.length).toBe(0);
+    });
+  });
+
+  describe("copy", () => {
+    it("should create a shallow copy (same Vec2 references)", () => {
+      const list = makeList();
+      const v1 = new Vec2(1, 2);
+      const v2 = new Vec2(3, 4);
+      list.push(v1);
+      list.push(v2);
+
+      const shallow = list.copy();
+      expect(shallow.length).toBe(2);
+      // Shallow copy shares the same underlying ZPP_Vec2, so modifying
+      // the original Vec2 coordinates is visible through the copy's wrappers
+      expect(shallow.at(0).x).toBe(1);
+      expect(shallow.at(1).x).toBe(3);
+    });
+
+    it("should create a deep copy with independent Vec2 objects", () => {
+      const list = makeList();
+      const v1 = new Vec2(10, 20);
+      const v2 = new Vec2(30, 40);
+      list.push(v1);
+      list.push(v2);
+
+      const deep = list.copy(true);
+      expect(deep.length).toBe(2);
+      expect(deep.at(0).x).toBe(10);
+      expect(deep.at(0).y).toBe(20);
+      expect(deep.at(1).x).toBe(30);
+      expect(deep.at(1).y).toBe(40);
+
+      // Modifying the deep copy should not affect the original
+      deep.at(0).x = 999;
+      expect(v1.x).toBe(10);
+    });
+  });
+
+  describe("merge", () => {
+    it("should merge another list, skipping duplicates", () => {
+      const list1 = makeList();
+      const v1 = new Vec2(1, 2);
+      const v2 = new Vec2(3, 4);
+      list1.push(v1);
+      list1.push(v2);
+
+      const list2 = makeList();
+      const v3 = new Vec2(5, 6);
+      list2.push(v1); // duplicate (same reference)
+      list2.push(v3);
+
+      list1.merge(list2);
+      // v1 is already in list1, so only v3 is added
+      expect(list1.length).toBe(3);
+      expect(list1.has(v3)).toBe(true);
+    });
+
+    it("should throw when merging with null", () => {
+      const list = makeList();
+      expect(() => list.merge(null)).toThrow("Cannot merge with null list");
+    });
+  });
+
+  describe("iterator / hasNext / next", () => {
+    it("should iterate over all elements in order", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 0));
+      list.push(new Vec2(2, 0));
+      list.push(new Vec2(3, 0));
+
+      const values: number[] = [];
+      const it = list.iterator();
+      while (it.hasNext()) {
+        values.push(it.next().x);
+      }
+      expect(values).toEqual([1, 2, 3]);
+    });
+
+    it("should return no elements for empty list", () => {
+      const list = makeList();
+      const it = list.iterator();
+      expect(it.hasNext()).toBe(false);
+    });
+  });
+
+  describe("Symbol.iterator (for...of)", () => {
+    it("should support for...of loop", () => {
+      const list = makeList();
+      list.push(new Vec2(10, 0));
+      list.push(new Vec2(20, 0));
+      list.push(new Vec2(30, 0));
+
+      const values: number[] = [];
+      for (const v of list) {
+        values.push(v.x);
+      }
+      expect(values).toEqual([10, 20, 30]);
+    });
+
+    it("should support spread operator", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 0));
+      list.push(new Vec2(2, 0));
+
+      const arr = [...list];
+      expect(arr.length).toBe(2);
+      expect(arr[0].x).toBe(1);
+      expect(arr[1].x).toBe(2);
+    });
+
+    it("should produce no elements for empty list", () => {
+      const list = makeList();
+      const values: number[] = [];
+      for (const v of list) {
+        values.push(v.x);
+      }
+      expect(values).toEqual([]);
+    });
+  });
+
+  describe("foreach", () => {
+    it("should call lambda for each element", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 0));
+      list.push(new Vec2(2, 0));
+      list.push(new Vec2(3, 0));
+
+      const values: number[] = [];
+      list.foreach((v: any) => values.push(v.x));
+      expect(values).toEqual([1, 2, 3]);
+    });
+
+    it("should return the list for chaining", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      const result = list.foreach(() => {});
+      expect(result).toBe(list);
+    });
+
+    it("should throw when lambda is null", () => {
+      const list = makeList();
+      expect(() => list.foreach(null)).toThrow(
+        "Cannot execute null on list elements",
+      );
+    });
+  });
+
+  describe("filter", () => {
+    it("should keep only elements matching the predicate", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 0));
+      list.push(new Vec2(2, 0));
+      list.push(new Vec2(3, 0));
+      list.push(new Vec2(4, 0));
+
+      list.filter((v: any) => v.x > 2);
+      expect(list.length).toBe(2);
+      expect(list.at(0).x).toBe(3);
+      expect(list.at(1).x).toBe(4);
+    });
+
+    it("should return the list for chaining", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      const result = list.filter(() => true);
+      expect(result).toBe(list);
+    });
+
+    it("should throw when lambda is null", () => {
+      const list = makeList();
+      expect(() => list.filter(null)).toThrow(
+        "Cannot select elements of list with null",
+      );
+    });
+
+    it("should handle filtering all elements out", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 0));
+      list.push(new Vec2(2, 0));
+      list.filter(() => false);
+      expect(list.length).toBe(0);
+    });
+  });
+
+  describe("toString", () => {
+    it("should produce string representation of elements", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      list.push(new Vec2(3, 4));
+      const str = list.toString();
+      expect(str).toMatch(/^\[/);
+      expect(str).toMatch(/\]$/);
+      // Should contain coordinate info for both elements
+      expect(str).toContain("1");
+      expect(str).toContain("2");
+      expect(str).toContain("3");
+      expect(str).toContain("4");
+    });
+
+    it("should return [] for empty list", () => {
+      const list = makeList();
+      expect(list.toString()).toBe("[]");
+    });
+  });
+
+  describe("fromArray", () => {
+    it("should create a list from an array of Vec2", () => {
+      const nape = getNape();
+      const arr = [new Vec2(1, 2), new Vec2(3, 4), new Vec2(5, 6)];
+      const list = nape.geom.Vec2List.fromArray(arr);
+      expect(list.length).toBe(3);
+      expect(list.at(0).x).toBe(1);
+      expect(list.at(1).x).toBe(3);
+      expect(list.at(2).x).toBe(5);
+    });
+
+    it("should throw when array is null", () => {
+      const nape = getNape();
+      expect(() => nape.geom.Vec2List.fromArray(null)).toThrow(
+        "Cannot convert null Array to Nape list",
+      );
+    });
+
+    it("should create an empty list from empty array", () => {
+      const nape = getNape();
+      const list = nape.geom.Vec2List.fromArray([]);
+      expect(list.length).toBe(0);
+      expect(list.empty()).toBe(true);
+    });
+  });
+
+  describe("immutability errors", () => {
+    it("should throw on push when list is immutable", () => {
+      const list = makeList();
+      list.zpp_inner.immutable = true;
+      expect(() => list.push(new Vec2(1, 2))).toThrow(
+        "Vec2List is immutable",
+      );
+    });
+
+    it("should throw on unshift when list is immutable", () => {
+      const list = makeList();
+      list.zpp_inner.immutable = true;
+      expect(() => list.unshift(new Vec2(1, 2))).toThrow(
+        "Vec2List is immutable",
+      );
+    });
+
+    it("should throw on pop when list is immutable", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      list.zpp_inner.immutable = true;
+      expect(() => list.pop()).toThrow("Vec2List is immutable");
+    });
+
+    it("should throw on shift when list is immutable", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      list.zpp_inner.immutable = true;
+      expect(() => list.shift()).toThrow("Vec2List is immutable");
+    });
+
+    it("should throw on remove when list is immutable", () => {
+      const list = makeList();
+      const v = new Vec2(1, 2);
+      list.push(v);
+      list.zpp_inner.immutable = true;
+      expect(() => list.remove(v)).toThrow("Vec2List is immutable");
+    });
+
+    it("should throw on clear when list is immutable", () => {
+      const list = makeList();
+      list.push(new Vec2(1, 2));
+      list.zpp_inner.immutable = true;
+      expect(() => list.clear()).toThrow("Vec2List is immutable");
+    });
+  });
+});


### PR DESCRIPTION
Adds 254 new tests covering previously untested public API classes:
- tests/core/engine.test.ts — getNape() lazy init, ensureEnumsReady
- tests/geom/Vec2List.test.ts — list operations, iteration, Symbol.iterator
- tests/geom/GeomVertexIterator.test.ts — vertex iteration, for...of
- tests/dynamics/ContactList.test.ts — unit + integration with collision contacts
- tests/dynamics/CollisionArbiter.test.ts — collision properties, impulses, friction
- tests/dynamics/FluidArbiter.test.ts — fluid interaction, buoyancy/drag impulses
- tests/callbacks/BodyCallback.test.ts — SLEEP callback integration
- tests/callbacks/ConstraintCallback.test.ts — SLEEP/BREAK/WAKE callbacks
- tests/callbacks/InteractionCallback.test.ts — BEGIN collision callback
- tests/callbacks/PreCallback.test.ts — PRE handler with ACCEPT/IGNORE
- tests/callbacks/Listener.test.ts — base class, cbEventToNumber, type/event/space
- tests/callbacks/ConstraintListener.test.ts — WAKE/SLEEP/BREAK events, options
- tests/callbacks/PreListener.test.ts — interaction types, pure, handler

https://claude.ai/code/session_01PZaLKjm6VGtjG6vUGHAmFg