### PR TITLE
Add preview frames and play/pause on scroll for examples page

### DIFF
--- a/docs/demo-runner.js
+++ b/docs/demo-runner.js
@@ -235,6 +235,16 @@ export class DemoRunner {
   }
 
   /**
+   * Load a demo, run one physics step, render a single frame, then stop.
+   * Used for generating static preview thumbnails on the examples grid.
+   */
+  renderPreview(demoDef) {
+    this.load(demoDef);
+    this.#space.step(1 / 60, demoDef.velocityIterations ?? 8, demoDef.positionIterations ?? 3);
+    this.#render2d();
+  }
+
+  /**
    * Switch render mode. Call `await loadThree()` before setMode("3d").
    * Restarts the loop if it was running.
    */

--- a/docs/examples.js
+++ b/docs/examples.js
@@ -240,15 +240,21 @@ function createCard(demo) {
   card.appendChild(info);
   card.appendChild(codePanel);
 
-  // --- Play overlay click: load + start ---
+  // --- Render a static preview frame ---
+  runner.renderPreview(demo);
+
+  // --- Play overlay click: start (demo is already loaded by renderPreview) ---
+  let started = false;
   overlay.addEventListener("click", () => {
-    runner.load(demo);
+    if (!started) {
+      started = true;
+    }
     runner.start();
     overlay.hidden = true;
     statsBar.hidden = false;
   });
 
-  return { card, runner };
+  return { card, runner, overlay, statsBar, isStarted: () => started };
 }
 
 // =========================================================================
@@ -296,9 +302,17 @@ const observer = new IntersectionObserver((entries) => {
   for (const entry of entries) {
     const match = cards.find(c => c.card === entry.target);
     if (!match) continue;
-    const { runner } = match;
-    if (!runner.isRunning) continue;   // not started yet — play button handles start
-    if (entry.isIntersecting) { runner.start(); } else { runner.stop(); }
+    if (!match.isStarted()) continue;   // not started yet — play button handles start
+    const { runner, overlay, statsBar } = match;
+    if (entry.isIntersecting) {
+      runner.start();
+      overlay.hidden = true;
+      statsBar.hidden = false;
+    } else {
+      runner.stop();
+      overlay.hidden = false;
+      statsBar.hidden = true;
+    }
   }
 }, { threshold: 0.1 });
 


### PR DESCRIPTION
- Render first physics frame as static preview thumbnail when cards load
- Show play overlay when demo is paused by scrolling out of viewport
- Add DemoRunner.renderPreview() method for single-frame rendering

https://claude.ai/code/session_016xH6QfGotzweGuCCkK3NcG