### PR TITLE
fix(demos): fix cog image path — use ./assets/ instead of ../assets/

### DIFF
--- a/docs/demos/body-from-graphic.js
+++ b/docs/demos/body-from-graphic.js
@@ -107,7 +107,7 @@ export default {
 
   async preload() {
     // Load at the largest required size; smaller ones will be downscaled from this
-    _cogCanvas = await loadImageToCanvas("../assets/cog.webp", COG_SIZES[COG_SIZES.length - 1], COG_SIZES[COG_SIZES.length - 1]);
+    _cogCanvas = await loadImageToCanvas("./assets/cog.webp", COG_SIZES[COG_SIZES.length - 1], COG_SIZES[COG_SIZES.length - 1]);
   },
 
   setup(space, W, H) {


### PR DESCRIPTION
The relative URL ../assets/cog.webp resolved one level above /nape-js/ on GitHub Pages, resulting in a 404. Corrected to ./assets/cog.webp.