### PR TITLE
docs: add P38 Debug draw API to priority roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,12 +194,30 @@ renderer ships in the core bundle.
 
 - `CanvasDebugDraw` — HTML5 Canvas 2D context (~200 lines, in `docs/`)
 - `ThreeDebugDraw` — Three.js `LineSegments` overlay (~200 lines, in `docs/`)
-- Both integrate with the existing `DemoRunner` 2D/3D toggle
+- `PixiDebugDraw` — PixiJS `Graphics` API (~200 lines, in `docs/`) — **highest priority**
+  reference impl; PixiJS is the #1 pure 2D renderer (~46.6k stars, ~403k npm/week) and
+  the most natural pairing for external physics engines
+- `P5DebugDraw` — p5.js immediate-mode drawing (~150 lines, in `docs/`) — optional,
+  targets the educational/creative-coding community (~23.5k stars)
+- All integrate with the existing `DemoRunner` 2D/3D toggle where applicable
+
+**Renderer ecosystem research (2026-03):**
+
+Best pairing targets (pure renderers, no built-in physics):
+- **PixiJS** — 46.6k stars, ~403k npm/week, WebGL/WebGPU. #1 target.
+- **p5.js** — 23.5k stars, ~40-66k npm/week, Canvas+WebGL. Educational reach.
+- **Two.js** — 8.5k stars, ~3k npm/week, SVG/Canvas/WebGL. Small community.
+
+Not targeted (built-in physics or non-physics use case):
+- Phaser (38k stars) — bundles Arcade Physics + Matter.js
+- Konva (14.2k stars) — UI/editor focus, not physics
+- Fabric.js (31k stars) — design tool/whiteboard focus
+- Excalibur / KAPLAY — self-contained with own physics
 
 **Why Box2D pattern over Rapier-style buffers:**
 
 - Semantic primitives (circle vs polygon vs point) give renderers more information
-- Fits naturally into both Canvas 2D and Three.js pipelines
+- Fits naturally into Canvas 2D, Three.js, PixiJS, and p5.js pipelines
 - Matches the existing `DemoRunner` architecture (2D canvas + 3D WebGL)
 - Users can implement for any target (PixiJS, SVG, raw WebGL, etc.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,44 @@ State snapshot + restore: `space.toJSON()` / `Space.fromJSON(data)`:
 
 ---
 
+### Priority 38: Debug draw API
+
+**Effort: M | Impact: medium (DX) | Risk: low**
+
+Abstract debug-rendering interface following the Box2D `b2Draw` pattern. The engine
+traverses its internal state and calls user-provided draw callbacks — no concrete
+renderer ships in the core bundle.
+
+**Design:**
+
+- `DebugDraw` — abstract class with primitive draw methods:
+  `drawSegment`, `drawCircle`, `drawSolidCircle`, `drawPolygon`, `drawSolidPolygon`,
+  `drawPoint`, `drawTransform`
+- `Space.debugDraw(drawer, flags)` — walks bodies, shapes, constraints, contacts,
+  broadphase AABBs, and velocity vectors; calls the appropriate `drawer` methods
+- `DebugDrawFlags` bitmask — `SHAPES`, `JOINTS`, `CONTACTS`, `AABB`, `CENTER_OF_MASS`,
+  `VELOCITIES` (user picks which layers to render)
+- **No concrete renderer in the library** — keeps the bundle at 0 KB extra for users
+  who don't use debug draw
+
+**Reference implementations (docs/examples, not in core bundle):**
+
+- `CanvasDebugDraw` — HTML5 Canvas 2D context (~200 lines, in `docs/`)
+- `ThreeDebugDraw` — Three.js `LineSegments` overlay (~200 lines, in `docs/`)
+- Both integrate with the existing `DemoRunner` 2D/3D toggle
+
+**Why Box2D pattern over Rapier-style buffers:**
+
+- Semantic primitives (circle vs polygon vs point) give renderers more information
+- Fits naturally into both Canvas 2D and Three.js pipelines
+- Matches the existing `DemoRunner` architecture (2D canvas + 3D WebGL)
+- Users can implement for any target (PixiJS, SVG, raw WebGL, etc.)
+
+**Bundle impact:** The abstract `DebugDraw` class + `Space.debugDraw()` traversal adds
+~5–8 KB minified to core (<1% of ~994 KB). Tree-shakeable if not imported.
+
+---
+
 ## Priority table
 
 | Priority                              | Effort | Impact  | Risk   | Status            |
@@ -191,3 +229,4 @@ State snapshot + restore: `space.toJSON()` / `Space.fromJSON(data)`:
 | P35 — Type system improvements        | S      | DX      | low    | ✅ Done           |
 | P36 — Server-side + demo examples     | M      | medium  | low    | ⬜ Not started    |
 | P37 — Serialization API               | L      | medium  | medium | ⬜ Not started    |
+| P38 — Debug draw API                  | M      | DX      | low    | ⬜ Not started    |


### PR DESCRIPTION
Box2D-style abstract DebugDraw interface + Space.debugDraw() traversal,
with CanvasDebugDraw and ThreeDebugDraw reference implementations in docs/.

https://claude.ai/code/session_01BSTM43zoqutisbJGGiZDQS