### PR TITLE
refactor: optimize CLAUDE.md, move detailed docs to .claude/docs/

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -1,0 +1,86 @@
+# nape-js — Internal Architecture Reference
+
+## Layer Overview
+
+```
+Public API wrappers (src/{phys,shape,constraint,callbacks,dynamics,geom,space}/)
+        ↕
+Internal ZPP_* classes (src/native/)
+        ↕
+Engine bootstrap (src/core/engine.ts → ZPPRegistry.ts + bootstrap.ts)
+```
+
+- **85 ZPP\_\* internal classes** in `src/native/`
+- **68 public API classes** in `src/` with direct `zpp_inner` access
+
+---
+
+## Registration Flow
+
+- `src/core/bootstrap.ts` — single place for all `nape.xxx = Foo` assignments and
+  `_createFn`/factory-callback wiring. Imported first from `index.ts` + `tests/setup.ts`.
+- `src/native/util/ZPPRegistry.ts` (`registerZPPClasses`) — registers all 85 ZPP classes,
+  initializes the `nape` namespace object, calls `_init()`/`_initStatics()`/`_initEnums()`.
+- `src/native/util/ZNPRegistry.ts` (`registerZNPClasses`) — creates ZNPNode/ZNPList/ZPP_Set
+  subclass pairs for each element type.
+- `src/core/engine.ts` — lazy `getNape()` + `ensureEnumsReady()`.
+
+## Factory Callback Pattern
+
+ZPP → public API subclass instances:
+
+- `ZPP_Callback`: `_createBodyCb`, `_createConCb`, `_createIntCb`, `_createPreCb`
+- `ZPP_Arbiter`: `_createColArb`, `_createFluidArb`
+- `ZPP_*Joint`: `_createFn` on each joint class
+
+## ESM Circular Dependency Prevention
+
+Subclasses using `extends` (Body, Circle, Polygon, all joints, callbacks, arbiters)
+self-register from `index.ts` — they cannot be side-effect imported from `engine.ts` due
+to ESM circular dependency (`class extends undefined` at init time).
+
+## `ensureEnumsReady` Pattern
+
+Uses `var` (not `let`) to avoid temporal dead zone. Called by each of the 6 enum classes
+after self-registering; fires `_initEnums` once all 6 are ready.
+
+## `any` Usage Rules in Native Files
+
+- `outer`/`wrap`/`wrap_min`/`wrap_max` → always `any` (circular ESM prevention + Haxe pool disconnection)
+- `_nape`/`_zpp` static namespace refs → always `any` (dynamic dispatch)
+- `_wrapFn` callbacks → `((zpp: ZPP_Foo) => any) | null`
+- User-facing `userData` → `Record<string, unknown> | null`
+- Dynamic ZNPList/ZNPNode/ZPP_Set subclass fields → `any` (created at runtime)
+
+## Iterator Loop Pattern
+
+Manual ZPP iterator (Body.ts style):
+
+```ts
+const iter = arbList.iterator();
+while (true) {
+  iter.zpp_inner.zpp_inner.valmod();
+  const length = iter.zpp_inner.zpp_gl();   // zpp_gl() is on TypedList (NapeListFactory)
+  iter.zpp_critical = true;
+  if (iter.zpp_i >= length) {
+    iter.zpp_next = getNape().dynamics.ArbiterIterator.zpp_pool;
+    getNape().dynamics.ArbiterIterator.zpp_pool = iter;
+    iter.zpp_inner = null;
+    break;
+  }
+  iter.zpp_critical = false;
+  const item = iter.zpp_inner.at(iter.zpp_i++);
+  // ... process item
+}
+```
+
+`zpp_gl()` is defined on `TypedList.prototype` in `src/util/NapeListFactory.ts` — it computes
+the validated length from `ZPP_PublicList.user_length`.
+
+## Tree Shaking Constraints
+
+Tree shaking is architecturally limited because `index.ts` always imports `bootstrap.ts`,
+which imports every class unconditionally. The `sideEffects` config in `package.json` is
+correct — `dist/index.js` and `dist/index.cjs` legitimately have side effects (bootstrap
+runs nape namespace assignments, `_createFn` wiring, `_bindBodyWrapForInteractor`, etc.).
+This is consistent with competing engines (Three.js, Planck.js, Matter.js).

--- a/.claude/docs/roadmap.md
+++ b/.claude/docs/roadmap.md
@@ -1,0 +1,93 @@
+# nape-js — Roadmap & Priority History
+
+## Priority Table
+
+| Priority                              | Effort | Impact  | Risk   | Status            |
+| ------------------------------------- | ------ | ------- | ------ | ----------------- |
+| P21 — Drop `__class__` / `$hxClasses` | S      | medium  | low    | ✅ Done           |
+| P22 — Minification                    | XS     | large   | none   | ✅ Done           |
+| P23 — `__zpp` → direct imports        | M      | large   | medium | ✅ Done           |
+| P24 — Namespace reduction             | S      | medium  | low    | ✅ Done           |
+| P25 — `Any` → real types              | XL     | largest | medium | ✅ Done           |
+| P26 — Tree shaking                    | L      | large   | high   | ✅ Done           |
+| P27 — HaxeShims audit                 | S      | small   | low    | ✅ Done           |
+| P28 — API ergonomics (28a+28b+28c)    | M      | DX      | low    | ✅ Done           |
+| P29 — Test coverage ≥80%              | L      | safety  | none   | 🔶 ~54.3%+ (3228 tests, Step 7 pending) |
+| P30 — TSDoc documentation             | L      | DX      | none   | ✅ Done           |
+| P31 — API ergonomics additions        | M      | DX      | low    | ✅ Done           |
+| P32 — Internal accessor cleanup       | S      | small   | low    | ✅ Done           |
+| P33 — Benchmark CI                    | M      | medium  | low    | ✅ Done           |
+| P34 — Granular tree shaking           | XL     | large   | high   | ❌ Cancelled      |
+| P35 — Type system improvements        | S      | DX      | low    | ✅ Done           |
+| P36 — Server-side + demo examples     | M      | medium  | low    | ⬜ Not started    |
+| P37 — Serialization API               | L      | medium  | medium | ✅ Done           |
+| P38 — Debug draw API                  | M      | DX      | low    | ✅ Done           |
+
+---
+
+## Active: P29 — Test Coverage ≥80%
+
+Steps 1–6 done (+959 tests, 2269 → 3228). All previously crashing APIs are now fixed and tested.
+
+**Current coverage: ~54.3% statements.**
+
+**Remaining gaps (Step 7):**
+- `ZPP_Collide` ~21%→improving, `ZPP_Broadphase` ~27%→improving, `ZPP_Ray` ~44%→improving
+- `ZPP_Space` deeper paths ~57%, `ZPP_Body` ~73%
+- Reaching ≥80% requires further ZPP native path tests (ZPP_Space, ZPP_Body deeper paths)
+
+### Step history
+
+**Step 5 (2026-03-11):** Added `ZPP_ColArbiter.test.ts` (+22 tests) and `ZPP_FluidArbiter.test.ts` (+14 tests), covering preStep/impulse/warm-start/pool/material paths.
+
+**Step 6 (2026-03-11):** +110 tests across three files:
+- `ZPP_Ray.test.ts` — full rewrite (~45 tests): constructor fields, invalidation callbacks,
+  `validate_dir` normalisation, `rayAABB` all quadrants, `aabbtest`/`aabbsect`,
+  `circlesect`/`polysect` via ZPP shapes, full `Space.rayCast`/`rayMultiCast` integration.
+- `ZPP_Collide.test.ts` — +33 tests: `polyContains`, `shapeContains`, `bodyContains`,
+  `containTest`, `testCollide_safe`, `flowCollide`, `contactCollide`.
+- `ZPP_Broadphase.integration.test.ts` — 35 tests: body insert/remove, AABB sync,
+  collision consistency, raycast for both algorithms.
+
+---
+
+## Planned: P36 — Server-side + Demo Examples
+
+**Effort: M | Impact: medium | Risk: low**
+
+The engine has no DOM dependencies and runs on Node.js already. Goals:
+
+- Verify bundle is DOM-free (no `window`/`document` references)
+- `/examples/server/` — Node.js script that runs a simulation and outputs positions
+- `/examples/browser/` — canvas renderer + physics loop for web use
+- CI job ensuring examples run on Node.js (regression protection)
+
+---
+
+## Completed Features (Reference)
+
+### P37 — Serialization API
+
+**Entry point:** `import { spaceToJSON, spaceFromJSON } from '@newkrok/nape-js/serialization'`
+
+Serializes: Space config, all bodies (position, velocity, shapes, userData), all shapes
+(circle/polygon, material, filters, fluid), all constraints except UserConstraint.
+Not serialized: Arbiters (rebuilt), UserConstraint, broadphase tree state, isSleeping.
+
+### P38 — Debug Draw API
+
+Abstract debug-rendering interface (Box2D `b2Draw` pattern). Engine traverses internal
+state and calls user-provided draw callbacks — no concrete renderer in core bundle.
+
+Classes: `DebugDraw` (abstract), `DebugDrawFlags` bitmask, `Space.debugDraw(drawer, flags)`.
+
+Reference implementations (in docs/examples): CanvasDebugDraw, ThreeDebugDraw,
+PixiDebugDraw (highest priority — PixiJS is #1 2D renderer), P5DebugDraw.
+
+---
+
+## Cancelled: P34 — Granular Tree Shaking
+
+**Decision (2026-03-10): Not worth pursuing.** Tree shaking is architecturally limited
+because `bootstrap.ts` imports every class unconditionally. Competing engines behave the
+same way. See `.claude/docs/architecture.md` for details.

--- a/.claude/docs/roadmap.md
+++ b/.claude/docs/roadmap.md
@@ -1,27 +1,63 @@
 # nape-js — Roadmap & Priority History
 
+## Competitive Advantages
+
+nape-js already leads in several areas vs Matter.js, Planck.js, and other pure-JS engines:
+
+- **CCD** (continuous collision detection) — Matter.js lacks this entirely (#1 user complaint)
+- **Fluid simulation** — buoyancy/drag unique among JS engines (only LiquidFun via WASM compares)
+- **Per-interaction-type filtering** — separate group/mask for collision, sensor, fluid (more granular than Box2D)
+- **Pixel-based units** — no meters-to-pixels conversion needed (Box2D pain point)
+- **Full TypeScript** with `strict: true` — Matter.js relies on DefinitelyTyped
+- **Serialization API** — save/load/replay/multiplayer sync
+- **Debug draw API** — abstract interface, no renderer dependency in core
+
+Key competitors to watch:
+- **Phaser Box2D** (Dec 2024) — Box2D v3 port, 70KB, improved solver+CCD
+- **Rapier** — WASM, cross-platform determinism, binary snapshots, but large bundle + async init
+- **Matter.js** — largest community but no CCD, no TypeScript, slow development
+
+---
+
 ## Priority Table
 
-| Priority                              | Effort | Impact  | Risk   | Status            |
-| ------------------------------------- | ------ | ------- | ------ | ----------------- |
-| P21 — Drop `__class__` / `$hxClasses` | S      | medium  | low    | ✅ Done           |
-| P22 — Minification                    | XS     | large   | none   | ✅ Done           |
-| P23 — `__zpp` → direct imports        | M      | large   | medium | ✅ Done           |
-| P24 — Namespace reduction             | S      | medium  | low    | ✅ Done           |
-| P25 — `Any` → real types              | XL     | largest | medium | ✅ Done           |
-| P26 — Tree shaking                    | L      | large   | high   | ✅ Done           |
-| P27 — HaxeShims audit                 | S      | small   | low    | ✅ Done           |
-| P28 — API ergonomics (28a+28b+28c)    | M      | DX      | low    | ✅ Done           |
-| P29 — Test coverage ≥80%              | L      | safety  | none   | 🔶 ~54.3%+ (3228 tests, Step 7 pending) |
-| P30 — TSDoc documentation             | L      | DX      | none   | ✅ Done           |
-| P31 — API ergonomics additions        | M      | DX      | low    | ✅ Done           |
-| P32 — Internal accessor cleanup       | S      | small   | low    | ✅ Done           |
-| P33 — Benchmark CI                    | M      | medium  | low    | ✅ Done           |
-| P34 — Granular tree shaking           | XL     | large   | high   | ❌ Cancelled      |
-| P35 — Type system improvements        | S      | DX      | low    | ✅ Done           |
-| P36 — Server-side + demo examples     | M      | medium  | low    | ⬜ Not started    |
-| P37 — Serialization API               | L      | medium  | medium | ✅ Done           |
-| P38 — Debug draw API                  | M      | DX      | low    | ✅ Done           |
+### Completed (P21–P38)
+
+| Priority                              | Effort | Impact  | Status       |
+| ------------------------------------- | ------ | ------- | ------------ |
+| P21 — Drop `__class__` / `$hxClasses` | S      | medium  | ✅ Done      |
+| P22 — Minification                    | XS     | large   | ✅ Done      |
+| P23 — `__zpp` → direct imports        | M      | large   | ✅ Done      |
+| P24 — Namespace reduction             | S      | medium  | ✅ Done      |
+| P25 — `Any` → real types              | XL     | largest | ✅ Done      |
+| P26 — Tree shaking                    | L      | large   | ✅ Done      |
+| P27 — HaxeShims audit                 | S      | small   | ✅ Done      |
+| P28 — API ergonomics (28a+28b+28c)    | M      | DX      | ✅ Done      |
+| P30 — TSDoc documentation             | L      | DX      | ✅ Done      |
+| P31 — API ergonomics additions        | M      | DX      | ✅ Done      |
+| P32 — Internal accessor cleanup       | S      | small   | ✅ Done      |
+| P33 — Benchmark CI                    | M      | medium  | ✅ Done      |
+| P34 — Granular tree shaking           | XL     | large   | ❌ Cancelled |
+| P35 — Type system improvements        | S      | DX      | ✅ Done      |
+| P37 — Serialization API               | L      | medium  | ✅ Done      |
+| P38 — Debug draw API                  | M      | DX      | ✅ Done      |
+
+### Active & Planned
+
+| Priority                                  | Effort | Impact   | Risk   | Status         |
+| ----------------------------------------- | ------ | -------- | ------ | -------------- |
+| P29 — Test coverage ≥80%                  | L      | safety   | none   | 🔶 ~54% (3228 tests) |
+| P36 — Server-side + demo examples         | M      | medium   | low    | ⬜ Not started |
+| P39 — Binary serialization (Uint8Array)   | M      | critical | medium | ⬜ Not started |
+| P40 — Haxe remnant cleanup                | M      | medium   | low    | ⬜ Not started |
+| P41 — Capsule shape                       | S      | medium   | low    | ⬜ Not started |
+| P42 — Web Worker helper                   | M      | perf/DX  | medium | ⬜ Not started |
+| P43 — Concave polygon helper              | M      | high     | low    | ⬜ Not started |
+| P44 — PixiJS integration package          | M      | adoption | low    | ⬜ Not started |
+| P45 — Character controller                | M      | DX       | medium | ⬜ Not started |
+| P46 — Hot-path optimization               | M      | perf     | low    | ⬜ Not started |
+| P47 — CJS bundle dedup (serialization)    | S      | bundle   | low    | ⬜ Not started |
+| P48 — Deterministic mode (soft)           | L      | critical | high   | ⬜ Not started |
 
 ---
 
@@ -32,22 +68,9 @@ Steps 1–6 done (+959 tests, 2269 → 3228). All previously crashing APIs are n
 **Current coverage: ~54.3% statements.**
 
 **Remaining gaps (Step 7):**
-- `ZPP_Collide` ~21%→improving, `ZPP_Broadphase` ~27%→improving, `ZPP_Ray` ~44%→improving
-- `ZPP_Space` deeper paths ~57%, `ZPP_Body` ~73%
-- Reaching ≥80% requires further ZPP native path tests (ZPP_Space, ZPP_Body deeper paths)
-
-### Step history
-
-**Step 5 (2026-03-11):** Added `ZPP_ColArbiter.test.ts` (+22 tests) and `ZPP_FluidArbiter.test.ts` (+14 tests), covering preStep/impulse/warm-start/pool/material paths.
-
-**Step 6 (2026-03-11):** +110 tests across three files:
-- `ZPP_Ray.test.ts` — full rewrite (~45 tests): constructor fields, invalidation callbacks,
-  `validate_dir` normalisation, `rayAABB` all quadrants, `aabbtest`/`aabbsect`,
-  `circlesect`/`polysect` via ZPP shapes, full `Space.rayCast`/`rayMultiCast` integration.
-- `ZPP_Collide.test.ts` — +33 tests: `polyContains`, `shapeContains`, `bodyContains`,
-  `containTest`, `testCollide_safe`, `flowCollide`, `contactCollide`.
-- `ZPP_Broadphase.integration.test.ts` — 35 tests: body insert/remove, AABB sync,
-  collision consistency, raycast for both algorithms.
+- `ZPP_Collide` ~21%, `ZPP_Broadphase` ~27%, `ZPP_Ray` ~44%
+- `ZPP_Space` ~57%, `ZPP_Body` ~73%
+- 40 native files have no dedicated test file, including `ZPP_Space.ts` (12,781 lines)
 
 ---
 
@@ -61,6 +84,139 @@ The engine has no DOM dependencies and runs on Node.js already. Goals:
 - `/examples/server/` — Node.js script that runs a simulation and outputs positions
 - `/examples/browser/` — canvas renderer + physics loop for web use
 - CI job ensuring examples run on Node.js (regression protection)
+
+---
+
+## Planned: P39 — Binary Serialization (Uint8Array Snapshots)
+
+**Effort: M | Impact: critical (multiplayer) | Risk: medium**
+
+The existing JSON serialization (P37) is suitable for save/load but too slow for per-frame
+rollback netcode (needs sub-millisecond). Binary snapshots following Rapier's pattern:
+
+- `spaceToBinary(space): Uint8Array` — compact binary state snapshot
+- `spaceFromBinary(data): Space` — fast restore
+- Delta encoding option for network sync (only send changed bodies)
+- Target: <1ms for 100-body scene snapshot + restore
+
+**Use cases:** rollback netcode, client-side prediction, fast save/load, replay recording.
+
+---
+
+## Planned: P40 — Haxe Remnant Cleanup
+
+**Effort: M | Impact: medium (bundle, perf, code quality) | Risk: low**
+
+Remaining Haxe compilation artifacts found in the codebase:
+
+- `__name__` static arrays — 128 files, ~3-5 KB dead weight in bundle
+- `__class__` instance fields — 15 files, unnecessary runtime overhead
+- `__super__` static fields — 24 files, Haxe-style manual inheritance
+- Prototype-copy `_init()` — 2 files (DynAABBPhase, SweepPhase) should use proper `extends`
+- `const _gthis = this` — 4 occurrences in ZPP_Space.ts, replace with arrow functions
+
+---
+
+## Planned: P41 — Capsule Shape
+
+**Effort: S | Impact: medium | Risk: low**
+
+Native capsule shape primitive (two semicircles + rectangle), commonly needed for character
+controllers and rounded obstacles. Box2D v3 added this as a first-class shape. Currently
+achievable only via Polygon approximation or compound Circle+Polygon bodies.
+
+---
+
+## Planned: P42 — Web Worker Helper
+
+**Effort: M | Impact: perf/DX | Risk: medium**
+
+Run physics simulation off the main thread using Web Workers + SharedArrayBuffer:
+
+- Flat transform buffer layout: `[x0, y0, rot0, x1, y1, rot1, ...]`
+- Main thread reads transforms for rendering at any framerate
+- Physics runs at fixed timestep in worker (e.g., 60 Hz)
+- Reference: p2-es/use-p2 pattern, SharedArrayBuffer + Atomics
+- Requires COOP/COEP headers (Spectre mitigation)
+
+---
+
+## Planned: P43 — Concave Polygon Helper
+
+**Effort: M | Impact: high (user demand) | Risk: low**
+
+Convenience API for creating bodies from concave polygon vertices. The engine already has
+`GeomPoly.convexDecomposition()` — this wraps it into a user-friendly API:
+
+- `Body.fromConcavePolygon(vertices, material?)` — auto-decomposes into convex shapes
+- Handles winding order normalization, simplification, validation
+- Addresses #1 pain point in Matter.js (fragile external `poly-decomp.js` dependency)
+
+---
+
+## Planned: P44 — PixiJS Integration Package
+
+**Effort: M | Impact: adoption | Risk: low**
+
+PixiJS (~46.6k stars, ~403k npm/week) is the #1 pure 2D renderer and the most natural
+pairing for an external physics engine. Package: `@newkrok/nape-pixi`
+
+- Auto-sync body transforms → PixiJS DisplayObject transforms
+- Debug draw implementation using PixiJS Graphics API
+- Example scenes with common game patterns (platformer, top-down, etc.)
+
+---
+
+## Planned: P45 — Character Controller
+
+**Effort: M | Impact: DX | Risk: medium**
+
+Geometric character controller (Box2D v3.1 pattern) separate from the physics world:
+
+- Ground detection, slope handling, step climbing
+- One-way platform support (builds on existing PreListener pattern)
+- Moving platform support via kinematic body tracking
+- Common in platformers — currently requires manual implementation
+
+---
+
+## Planned: P46 — Hot-path Optimization
+
+**Effort: M | Impact: perf | Risk: low**
+
+Performance improvements identified in the codebase:
+
+- Deduplicate body invalidation loops in `step()` (~90 lines of copy-paste)
+- Extract inlined linked-list operations in `prestep()` (3×50 lines repeated)
+- Fix pool bypass: several `new ZPP_Vec2()` / `new ZPP_AABB()` in hot paths should use pools
+- Optimize `DynAABBPhase.__remove`: O(n) linear scan of syncs/moves/pairs lists
+- Reduce 300+ `any` annotations in hot-path files for better V8 optimization
+
+---
+
+## Planned: P47 — CJS Bundle Dedup
+
+**Effort: S | Impact: bundle size | Risk: low**
+
+The serialization CJS bundle duplicates the entire engine (902 KB). The ESM version
+correctly code-splits (8.2 KB). Fix via tsup config: `splitting`, `treeshake`, `target: es2020`.
+
+---
+
+## Planned: P48 — Deterministic Mode (Soft)
+
+**Effort: L | Impact: critical (multiplayer) | Risk: high**
+
+Same-platform deterministic simulation (identical results on same browser/OS):
+
+- Already has `sortContacts: true` as a foundation
+- Audit all non-deterministic code paths (hash iteration, floating-point ordering)
+- Ensure fixed timestep produces identical results across runs
+- Document limitations vs cross-platform determinism (which requires WASM/fixed-point)
+
+Note: True cross-platform bit-level determinism (like Rapier) is impractical in pure JS
+due to IEEE 754 implementation differences. "Soft determinism" (same platform = same results)
+is the achievable goal and sufficient for most multiplayer patterns.
 
 ---
 

--- a/.claude/docs/roadmap.md
+++ b/.claude/docs/roadmap.md
@@ -58,6 +58,9 @@ Key competitors to watch:
 | P46 — Hot-path optimization               | M      | perf     | low    | ⬜ Not started |
 | P47 — CJS bundle dedup (serialization)    | S      | bundle   | low    | ⬜ Not started |
 | P48 — Deterministic mode (soft)           | L      | critical | high   | ⬜ Not started |
+| P49 — ECS adapter layer                   | M      | DX       | medium | ⬜ Not started |
+| P50 — Spatial hash grid broadphase        | S-M    | perf     | low    | ⬜ Not started |
+| P51 — Sub-stepping solver                 | XL     | stability| high   | ⬜ Not started |
 
 ---
 
@@ -217,6 +220,46 @@ Same-platform deterministic simulation (identical results on same browser/OS):
 Note: True cross-platform bit-level determinism (like Rapier) is impractical in pure JS
 due to IEEE 754 implementation differences. "Soft determinism" (same platform = same results)
 is the achievable goal and sufficient for most multiplayer patterns.
+
+---
+
+## Planned: P49 — ECS Adapter Layer
+
+**Effort: M | Impact: DX | Risk: medium**
+
+Optional adapter for Entity Component System frameworks (bitECS, miniplex, Becsy):
+
+- Physics components (position, velocity, mass) as flat typed arrays
+- System that syncs ECS components ↔ nape-js Body objects each frame
+- Enables better cache locality and easier serialization
+- Growing trend in JS game development — no physics engine currently offers this
+
+---
+
+## Planned: P50 — Spatial Hash Grid Broadphase
+
+**Effort: S-M | Impact: perf (niche) | Risk: low**
+
+Third broadphase algorithm option for dense, uniform-object scenes:
+
+- O(1) expected lookup for nearby objects
+- Best for: particle simulations, many same-sized objects, bounded worlds
+- Complements existing SAP (good for few moving objects) and AABB tree (general purpose)
+- Not useful for variable-size objects or sparse worlds
+
+---
+
+## Planned: P51 — Sub-stepping Solver
+
+**Effort: XL | Impact: stability | Risk: high**
+
+Box2D v3's "Soft Step" solver approach: soft constraints + sub-stepping for better stability:
+
+- Handles higher mass ratios without jitter
+- More stable long body chains and stacks
+- Better convergence for complex constraint networks
+- Major architectural change — requires careful testing and benchmarking
+- Long-term goal, depends on P46 (hot-path optimization) as prerequisite
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,18 @@ npm run lint         # eslint + prettier
 2. `npm test` — all tests must pass
 3. `npm run build` — DTS generation must succeed (catches type errors vitest misses)
 
+**Documentation to review** — when the PR changes features, APIs, priorities, or versions:
+
+| File | What to update | When |
+| ---- | -------------- | ---- |
+| `CLAUDE.md` | Status table, test count, key features list | Priority status changes, new features |
+| `.claude/docs/roadmap.md` | Priority table, detailed descriptions, competitive analysis | New/changed/completed priorities |
+| `.claude/docs/architecture.md` | Internal patterns, registration flow, `any` rules | Architecture or bootstrap changes |
+| `README.md` | Quick start, API tables, test count, badge versions | Public API changes, releases |
+| `llms.txt` | Class list, links, quick start example | Public API additions/removals |
+| `llms-full.txt` | Complete API reference, version number (line 1) | Any public API change, releases |
+| `package.json` | `version` field | Releases |
+
 ## Architecture
 
 ```
@@ -67,17 +79,3 @@ iterator patterns, ESM constraints) see `.claude/docs/architecture.md`.
 | Sub-stepping solver      | ⬜ Planned — P51 (long-term) |
 
 Full roadmap with details, competitor analysis, and history: `.claude/docs/roadmap.md`
-
-## Documentation Files — Update Before PR
-
-When a PR changes features, APIs, priorities, or version numbers, review these files:
-
-| File | What to update | When |
-| ---- | -------------- | ---- |
-| `CLAUDE.md` | Status table, test count, key features list | Priority status changes, new features |
-| `.claude/docs/roadmap.md` | Priority table, detailed descriptions, competitive analysis | New/changed/completed priorities |
-| `.claude/docs/architecture.md` | Internal patterns, registration flow, `any` rules | Architecture or bootstrap changes |
-| `README.md` | Quick start, API tables, test count, badge versions | Public API changes, releases |
-| `llms.txt` | Class list, links, quick start example | Public API additions/removals |
-| `llms-full.txt` | Complete API reference, version number (line 1) | Any public API change, releases |
-| `package.json` | `version` field | Releases |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,5 +62,8 @@ iterator patterns, ESM constraints) see `.claude/docs/architecture.md`.
 | Character controller     | ⬜ Planned — P45 |
 | Hot-path optimization    | ⬜ Planned — P46 |
 | Deterministic mode       | ⬜ Planned — P48 (multiplayer) |
+| ECS adapter              | ⬜ Planned — P49 |
+| Spatial hash grid        | ⬜ Planned — P50 |
+| Sub-stepping solver      | ⬜ Planned — P51 (long-term) |
 
 Full roadmap with details, competitor analysis, and history: `.claude/docs/roadmap.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ A fully typed TypeScript 2D physics engine — modernized rewrite of the origina
 - **Pure TypeScript**, `strict: true`, zero DOM dependencies (runs on Node.js + browser)
 - **Rigid body dynamics** — circles, convex polygons, compounds, static/dynamic/kinematic bodies
 - **Constraint system** — PivotJoint, DistanceJoint, AngleJoint, MotorJoint, LineJoint, PulleyJoint, WeldJoint, UserConstraint
-- **Collision detection** — broadphase (sweep-and-prune / dynamic AABB tree), narrowphase, raycasting
+- **Collision detection** — broadphase (sweep-and-prune / dynamic AABB tree), narrowphase, CCD, raycasting, convex sweep
 - **Callback system** — body/interaction/constraint listeners, pre-collision callbacks
-- **Fluid simulation** — buoyancy and drag via fluid-enabled shapes
+- **Fluid simulation** — buoyancy and drag via fluid-enabled shapes (unique among JS engines)
 - **Serialization** — `spaceToJSON` / `spaceFromJSON` for save/load/multiplayer sync
 - **Debug draw** — abstract `DebugDraw` interface (Box2D pattern), reference impls for Canvas/Three.js/PixiJS/p5.js
 - **~994 KB** minified ESM + CJS dual bundle, TSDoc documented, 3200+ tests
@@ -46,12 +46,21 @@ iterator patterns, ESM constraints) see `.claude/docs/architecture.md`.
 
 ## Current Status
 
-| What                | Status |
-| ------------------- | ------ |
-| Haxe modernization  | ✅ Complete — pure TypeScript, fully typed |
-| Test coverage       | 🔶 ~54% statements (3228 tests), target ≥80% — [details](.claude/docs/roadmap.md) |
-| Serialization API   | ✅ Done — `@newkrok/nape-js/serialization` |
-| Debug draw API      | ✅ Done — abstract `DebugDraw` + `Space.debugDraw()` |
-| Server/demo examples| ⬜ Planned — P36 |
+| What                     | Status |
+| ------------------------ | ------ |
+| Haxe modernization       | ✅ Complete — pure TypeScript, fully typed |
+| Test coverage            | 🔶 ~54% statements (3228 tests), target ≥80% |
+| Serialization API        | ✅ Done — `@newkrok/nape-js/serialization` |
+| Debug draw API           | ✅ Done — abstract `DebugDraw` + `Space.debugDraw()` |
+| Server/demo examples     | ⬜ Planned — P36 |
+| Binary snapshots         | ⬜ Planned — P39 (multiplayer rollback) |
+| Haxe remnant cleanup     | ⬜ Planned — P40 (128 files with `__name__`/`__class__`/`__super__`) |
+| Capsule shape            | ⬜ Planned — P41 |
+| Web Worker helper        | ⬜ Planned — P42 |
+| Concave polygon helper   | ⬜ Planned — P43 |
+| PixiJS integration       | ⬜ Planned — P44 |
+| Character controller     | ⬜ Planned — P45 |
+| Hot-path optimization    | ⬜ Planned — P46 |
+| Deterministic mode       | ⬜ Planned — P48 (multiplayer) |
 
-Full priority table and history: `.claude/docs/roadmap.md`
+Full roadmap with details, competitor analysis, and history: `.claude/docs/roadmap.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,17 @@ iterator patterns, ESM constraints) see `.claude/docs/architecture.md`.
 | Sub-stepping solver      | ⬜ Planned — P51 (long-term) |
 
 Full roadmap with details, competitor analysis, and history: `.claude/docs/roadmap.md`
+
+## Documentation Files — Update Before PR
+
+When a PR changes features, APIs, priorities, or version numbers, review these files:
+
+| File | What to update | When |
+| ---- | -------------- | ---- |
+| `CLAUDE.md` | Status table, test count, key features list | Priority status changes, new features |
+| `.claude/docs/roadmap.md` | Priority table, detailed descriptions, competitive analysis | New/changed/completed priorities |
+| `.claude/docs/architecture.md` | Internal patterns, registration flow, `any` rules | Architecture or bootstrap changes |
+| `README.md` | Quick start, API tables, test count, badge versions | Public API changes, releases |
+| `llms.txt` | Class list, links, quick start example | Public API additions/removals |
+| `llms-full.txt` | Complete API reference, version number (line 1) | Any public API change, releases |
+| `package.json` | `version` field | Releases |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,277 +1,57 @@
-# nape-js — Development Guide
+# nape-js
 
-## Project Overview
+A fully typed TypeScript 2D physics engine — modernized rewrite of the original
+[nape](https://napephys.com/) Haxe engine.
 
-nape-js is a 2D physics engine ported from Haxe to JavaScript. The codebase has been
-fully modernized: all code extracted from the compiled blob (`nape-compiled.js`, originally
-~82k lines) into clean, typed TypeScript classes. `nape-compiled.js` is now **deleted**.
+## Key Features
 
-### Architecture
+- **Pure TypeScript**, `strict: true`, zero DOM dependencies (runs on Node.js + browser)
+- **Rigid body dynamics** — circles, convex polygons, compounds, static/dynamic/kinematic bodies
+- **Constraint system** — PivotJoint, DistanceJoint, AngleJoint, MotorJoint, LineJoint, PulleyJoint, WeldJoint, UserConstraint
+- **Collision detection** — broadphase (sweep-and-prune / dynamic AABB tree), narrowphase, raycasting
+- **Callback system** — body/interaction/constraint listeners, pre-collision callbacks
+- **Fluid simulation** — buoyancy and drag via fluid-enabled shapes
+- **Serialization** — `spaceToJSON` / `spaceFromJSON` for save/load/multiplayer sync
+- **Debug draw** — abstract `DebugDraw` interface (Box2D pattern), reference impls for Canvas/Three.js/PixiJS/p5.js
+- **~994 KB** minified ESM + CJS dual bundle, TSDoc documented, 3200+ tests
+
+## Build & Test
+
+```bash
+npm run build        # tsup → dist/
+npm test             # vitest
+npm run lint         # eslint + prettier
+```
+
+## Pre-push Checklist
+
+**Before every `git push`, always run all three:**
+
+1. `npm run lint` — must pass (catches unused vars, formatting)
+2. `npm test` — all tests must pass
+3. `npm run build` — DTS generation must succeed (catches type errors vitest misses)
+
+## Architecture
 
 ```
 Public API wrappers (src/{phys,shape,constraint,callbacks,dynamics,geom,space}/)
         ↕
-Internal ZPP_* classes (src/native/)
+Internal ZPP_* classes (src/native/)  — 85 classes
         ↕
 Engine bootstrap (src/core/engine.ts → ZPPRegistry.ts + bootstrap.ts)
 ```
 
-### Build & Test
+For detailed internal patterns (registration flow, factory callbacks, `any` rules,
+iterator patterns, ESM constraints) see `.claude/docs/architecture.md`.
 
-```bash
-npm run build        # tsup → dist/
-npm test             # vitest — 3118 tests across 147 files
-npm run lint         # eslint + prettier
-```
+## Current Status
 
-### Pre-push checklist
+| What                | Status |
+| ------------------- | ------ |
+| Haxe modernization  | ✅ Complete — pure TypeScript, fully typed |
+| Test coverage       | 🔶 ~54% statements (3228 tests), target ≥80% — [details](.claude/docs/roadmap.md) |
+| Serialization API   | ✅ Done — `@newkrok/nape-js/serialization` |
+| Debug draw API      | ✅ Done — abstract `DebugDraw` + `Space.debugDraw()` |
+| Server/demo examples| ⬜ Planned — P36 |
 
-**Before every `git push`, always run all three:**
-
-1. `npm run lint` — ESLint + Prettier must pass (catches unused vars, formatting issues)
-2. `npm test` — all tests must pass
-3. `npm run build` — DTS generation must succeed
-
-The build step catches TypeScript type errors that vitest does not (e.g., missing method
-declarations for runtime-copied prototype methods). Never push without a green lint + test + build.
-
----
-
-## Codebase State
-
-All Haxe modernization is complete. The codebase is **pure TypeScript**, fully typed,
-tree-shakeable, and minified. Key facts:
-
-- **85 ZPP\_\* internal classes** in `src/native/`
-- **68 public API classes** in `src/` with direct `zpp_inner` access
-- **Bundle:** ~994 KB minified ESM + CJS, dual exports map, tree shaking via `bootstrap.ts`
-- **Tests:** 3118 passing across 147 files
-- **`strict: true`**, `tsc --noEmit` → 0 errors
-
-### Key architectural patterns (reference)
-
-**Registration flow:**
-
-- `src/core/bootstrap.ts` — single place for all `nape.xxx = Foo` assignments and
-  `_createFn`/factory-callback wiring. Imported first from `index.ts` + `tests/setup.ts`.
-- `src/native/util/ZPPRegistry.ts` (`registerZPPClasses`) — registers all 85 ZPP classes,
-  initializes the `nape` namespace object, calls `_init()`/`_initStatics()`/`_initEnums()`.
-- `src/native/util/ZNPRegistry.ts` (`registerZNPClasses`) — creates ZNPNode/ZNPList/ZPP_Set
-  subclass pairs for each element type.
-- `src/core/engine.ts` — lazy `getNape()` + `ensureEnumsReady()`.
-
-**Factory callback pattern** (ZPP → public API subclass instances):
-
-- `ZPP_Callback`: `_createBodyCb`, `_createConCb`, `_createIntCb`, `_createPreCb`
-- `ZPP_Arbiter`: `_createColArb`, `_createFluidArb`
-- `ZPP_*Joint`: `_createFn` on each joint class
-
-**Subclasses using `extends`** (Body, Circle, Polygon, all joints, callbacks, arbiters)
-self-register from `index.ts` — they cannot be side-effect imported from `engine.ts` due
-to ESM circular dependency (`class extends undefined` at init time).
-
-**`ensureEnumsReady` pattern**: Uses `var` (not `let`) to avoid temporal dead zone. Called
-by each of the 6 enum classes after self-registering; fires `_initEnums` once all 6 are ready.
-
-**`any` usage rules in native files:**
-
-- `outer`/`wrap`/`wrap_min`/`wrap_max` → always `any` (circular ESM prevention + Haxe pool disconnection)
-- `_nape`/`_zpp` static namespace refs → always `any` (dynamic dispatch)
-- `_wrapFn` callbacks → `((zpp: ZPP_Foo) => any) | null`
-- User-facing `userData` → `Record<string, unknown> | null`
-- Dynamic ZNPList/ZNPNode/ZPP_Set subclass fields → `any` (created at runtime)
-
-**Iterator loop pattern** (manual ZPP iterator — Body.ts style):
-
-```ts
-const iter = arbList.iterator();
-while (true) {
-  iter.zpp_inner.zpp_inner.valmod();
-  const length = iter.zpp_inner.zpp_gl();   // zpp_gl() is on TypedList (NapeListFactory)
-  iter.zpp_critical = true;
-  if (iter.zpp_i >= length) {
-    iter.zpp_next = getNape().dynamics.ArbiterIterator.zpp_pool;
-    getNape().dynamics.ArbiterIterator.zpp_pool = iter;
-    iter.zpp_inner = null;
-    break;
-  }
-  iter.zpp_critical = false;
-  const item = iter.zpp_inner.at(iter.zpp_i++);
-  // ... process item
-}
-```
-
-`zpp_gl()` is defined on `TypedList.prototype` in `src/util/NapeListFactory.ts` — it computes
-the validated length from `ZPP_PublicList.user_length`.
-
----
-
-## Roadmap
-
-### Priority 29: Test coverage — target ≥80% 🔶 In progress
-
-Steps 1–6 done (+959 tests, 2269 → 3228). All previously crashing APIs are now fixed and tested.
-
-**Current coverage: ~54.3% statements** (was ~44.7% before Step 4 + bugfixes; Step 6 expected to push this higher).
-
-**Step 5 (partial — 2026-03-11):** Added `ZPP_ColArbiter.test.ts` (+22 tests) and `ZPP_FluidArbiter.test.ts` (+14 tests), covering preStep/impulse/warm-start/pool/material paths.
-
-**Step 6 (2026-03-11):** +110 tests across three files:
-- `ZPP_Ray.test.ts` — full rewrite (~45 tests): constructor fields, invalidation callbacks,
-  `validate_dir` normalisation, `rayAABB` all quadrants, `aabbtest`/`aabbsect`,
-  `circlesect`/`polysect` via ZPP shapes, full `Space.rayCast`/`rayMultiCast` integration
-  (both broadphase algorithms, `maxDistance`, inner mode, multi-hit ordering).
-- `ZPP_Collide.test.ts` — +33 tests: `polyContains`, `shapeContains` polygon routing,
-  `bodyContains` multi-shape/polygon, `containTest` mixed shape types, `testCollide_safe`
-  reversed args, `flowCollide` via fluid simulation, `contactCollide` via simulation
-  (circle-circle, circle-polygon, polygon-polygon).
-- `ZPP_Broadphase.integration.test.ts` — new file, 35 tests: body insert/remove for both
-  algorithms, AABB sync for dynamic shapes, collision consistency, 10-body scenes,
-  raycast hit/miss/multicast for both algorithms, extreme positions.
-
-**Remaining gaps (Step 7):**
-- `ZPP_Collide` ~21%→improving, `ZPP_Broadphase` ~27%→improving, `ZPP_Ray` ~44%→improving
-- `ZPP_Space` deeper paths ~57%, `ZPP_Body` ~73%
-- Reaching ≥80% requires further ZPP native path tests (ZPP_Space, ZPP_Body deeper paths)
-
----
-
-### Priority 34: Granular tree shaking (lazy ZPP registration) ❌ Cancelled
-
-**Effort: XL | Impact: large (bundle) | Risk: high**
-
-**Decision (2026-03-10): Not worth pursuing.** Investigation revealed:
-
-- The current `sideEffects` config in `package.json` is **correct** — `dist/index.js` and
-  `dist/index.cjs` legitimately have side effects (bootstrap runs nape namespace assignments,
-  `_createFn` wiring, `_bindBodyWrapForInteractor`, etc.).
-- Tree shaking is **architecturally impossible** without the full P34 refactor because
-  `index.ts` always imports `bootstrap.ts`, which imports every class unconditionally.
-- Competing engines (Three.js, Planck.js, Matter.js) do not use lazy registration either —
-  they ship single concatenated ESM builds and rely on standard bundler tree shaking of
-  named exports, which only helps when the user avoids the entry point entirely.
-- The only engine with true per-class tree shaking is Rapier (non-compat), which requires
-  an async `init()` call — a DX tradeoff not worth making for nape-js.
-- The full lazy ZPP registration refactor remains theoretically possible but the complexity
-  and risk are disproportionate to the benefit.
-
----
-
-### Priority 36: Server-side + demo examples
-
-**Effort: M | Impact: medium | Risk: low**
-
-The engine has no DOM dependencies and runs on Node.js already. Goals:
-
-- Verify bundle is DOM-free (no `window`/`document` references)
-- `/examples/server/` — Node.js script that runs a simulation and outputs positions
-- `/examples/browser/` — canvas renderer + physics loop for web use
-- CI job ensuring examples run on Node.js (regression protection)
-
----
-
-### Priority 37: Serialization API ✅ Done
-
-**Entry point:** `import { spaceToJSON, spaceFromJSON } from '@newkrok/nape-js/serialization'`
-
-**Files:**
-- `src/serialization/types.ts` — `SpaceSnapshot` + all snapshot interfaces
-- `src/serialization/serialize.ts` — `spaceToJSON(space): SpaceSnapshot`
-- `src/serialization/deserialize.ts` — `spaceFromJSON(snapshot): Space`
-- `src/serialization/index.ts` — public re-export + type exports
-- `tests/serialization/serialization.test.ts` — 48 tests
-
-**What is serialized:** Space config (gravity, drags, broadphase, sortContacts), all bodies
-(position, rotation, velocity, angularVel, kinematicVel, surfaceVel, force, torque, mass,
-inertia, gravMass, allowMovement, allowRotation, isBullet, shapes, userData), all shapes
-(circle radius / polygon vertices, material, interactionFilter, sensorEnabled,
-fluidEnabled, fluidProperties), all constraints except UserConstraint (PivotJoint,
-DistanceJoint, AngleJoint, MotorJoint, LineJoint, PulleyJoint, WeldJoint — full base
-props: active, stiff, frequency, damping, maxForce, maxError, break flags, userData),
-compounds (as body-ID + constraint-index groupings).
-
-**What is NOT serialized:** Arbiters (rebuilt each step), UserConstraint (not
-serializable), broadphase tree internal state (rebuilt), isSleeping (inferred).
-
-**Use cases:** save/load, replay, multiplayer server↔client sync.
-
----
-
-### Priority 38: Debug draw API
-
-**Effort: M | Impact: medium (DX) | Risk: low**
-
-Abstract debug-rendering interface following the Box2D `b2Draw` pattern. The engine
-traverses its internal state and calls user-provided draw callbacks — no concrete
-renderer ships in the core bundle.
-
-**Design:**
-
-- `DebugDraw` — abstract class with primitive draw methods:
-  `drawSegment`, `drawCircle`, `drawSolidCircle`, `drawPolygon`, `drawSolidPolygon`,
-  `drawPoint`, `drawTransform`
-- `Space.debugDraw(drawer, flags)` — walks bodies, shapes, constraints, contacts,
-  broadphase AABBs, and velocity vectors; calls the appropriate `drawer` methods
-- `DebugDrawFlags` bitmask — `SHAPES`, `JOINTS`, `CONTACTS`, `AABB`, `CENTER_OF_MASS`,
-  `VELOCITIES` (user picks which layers to render)
-- **No concrete renderer in the library** — keeps the bundle at 0 KB extra for users
-  who don't use debug draw
-
-**Reference implementations (docs/examples, not in core bundle):**
-
-- `CanvasDebugDraw` — HTML5 Canvas 2D context (~200 lines, in `docs/`)
-- `ThreeDebugDraw` — Three.js `LineSegments` overlay (~200 lines, in `docs/`)
-- `PixiDebugDraw` — PixiJS `Graphics` API (~200 lines, in `docs/`) — **highest priority**
-  reference impl; PixiJS is the #1 pure 2D renderer (~46.6k stars, ~403k npm/week) and
-  the most natural pairing for external physics engines
-- `P5DebugDraw` — p5.js immediate-mode drawing (~150 lines, in `docs/`) — optional,
-  targets the educational/creative-coding community (~23.5k stars)
-- All integrate with the existing `DemoRunner` 2D/3D toggle where applicable
-
-**Renderer ecosystem research (2026-03):**
-
-Best pairing targets (pure renderers, no built-in physics):
-- **PixiJS** — 46.6k stars, ~403k npm/week, WebGL/WebGPU. #1 target.
-- **p5.js** — 23.5k stars, ~40-66k npm/week, Canvas+WebGL. Educational reach.
-- **Two.js** — 8.5k stars, ~3k npm/week, SVG/Canvas/WebGL. Small community.
-
-Not targeted (built-in physics or non-physics use case):
-- Phaser (38k stars) — bundles Arcade Physics + Matter.js
-- Konva (14.2k stars) — UI/editor focus, not physics
-- Fabric.js (31k stars) — design tool/whiteboard focus
-- Excalibur / KAPLAY — self-contained with own physics
-
-**Why Box2D pattern over Rapier-style buffers:**
-
-- Semantic primitives (circle vs polygon vs point) give renderers more information
-- Fits naturally into Canvas 2D, Three.js, PixiJS, and p5.js pipelines
-- Matches the existing `DemoRunner` architecture (2D canvas + 3D WebGL)
-- Users can implement for any target (PixiJS, SVG, raw WebGL, etc.)
-
-**Bundle impact:** The abstract `DebugDraw` class + `Space.debugDraw()` traversal adds
-~5–8 KB minified to core (<1% of ~994 KB). Tree-shakeable if not imported.
-
----
-
-## Priority table
-
-| Priority                              | Effort | Impact  | Risk   | Status            |
-| ------------------------------------- | ------ | ------- | ------ | ----------------- |
-| P21 — Drop `__class__` / `$hxClasses` | S      | medium  | low    | ✅ Done           |
-| P22 — Minification                    | XS     | large   | none   | ✅ Done           |
-| P23 — `__zpp` → direct imports        | M      | large   | medium | ✅ Done           |
-| P24 — Namespace reduction             | S      | medium  | low    | ✅ Done           |
-| P25 — `Any` → real types              | XL     | largest | medium | ✅ Done           |
-| P26 — Tree shaking                    | L      | large   | high   | ✅ Done           |
-| P27 — HaxeShims audit                 | S      | small   | low    | ✅ Done           |
-| P28 — API ergonomics (28a+28b+28c)    | M      | DX      | low    | ✅ Done           |
-| P29 — Test coverage ≥80%              | L      | safety  | none   | 🔶 ~54.3%+ (Step 6 done, 3228 tests, Step 7 pending) |
-| P30 — TSDoc documentation             | L      | DX      | none   | ✅ Done           |
-| P31 — API ergonomics additions        | M      | DX      | low    | ✅ Done           |
-| P32 — Internal accessor cleanup       | S      | small   | low    | ✅ Done           |
-| P33 — Benchmark CI                    | M      | medium  | low    | ✅ Done           |
-| P34 — Granular tree shaking           | XL     | large   | high   | ❌ Cancelled      |
-| P35 — Type system improvements        | S      | DX      | low    | ✅ Done           |
-| P36 — Server-side + demo examples     | M      | medium  | low    | ⬜ Not started    |
-| P37 — Serialization API               | L      | medium  | medium | ✅ Done           |
-| P38 — Debug draw API                  | M      | DX      | low    | ✅ Done           |
+Full priority table and history: `.claude/docs/roadmap.md`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,7 +7,7 @@
 - **API docs**: https://newkrok.github.io/nape-js/api/index.html
 - **Demos**: https://newkrok.github.io/nape-js/examples.html
 - **License**: MIT
-- **Version**: 3.5.1
+- **Version**: 3.8.1
 
 ---
 


### PR DESCRIPTION
Split the monolithic CLAUDE.md into focused files:
- CLAUDE.md: concise project overview, build commands, pre-push checklist
- .claude/docs/architecture.md: internal patterns (registration, factories, ESM constraints)
- .claude/docs/roadmap.md: full priority table and task history

https://claude.ai/code/session_01JAMNdayENP8cosCBEXr2fj