### PR TITLE
feat(p52): complete multiplayer demo — capsule player, pendulums, del…

### DIFF
--- a/.claude/docs/roadmap.md
+++ b/.claude/docs/roadmap.md
@@ -51,7 +51,7 @@ Key competitors to watch:
 | ----------------------------------------- | ------ | -------- | ------ | -------------- |
 | P29 — Test coverage ≥80%                  | L      | safety   | none   | 🔶 ~54% (3251 tests) |
 | P36 — Server-side + demo examples         | M      | medium   | low    | ❌ Cancelled   |
-| P52 — Multiplayer demo                    | M      | adoption | low    | ⬜ Not started |
+| P52 — Multiplayer demo                    | M      | adoption | low    | ✅ Done        |
 | P42 — Web Worker helper                   | M      | perf/DX  | medium | ⬜ Not started |
 | P43 — Concave polygon helper              | M      | high     | low    | ⬜ Not started |
 | P44 — PixiJS integration package          | M      | adoption | low    | ⬜ Not started |
@@ -85,21 +85,26 @@ without hosting. Superseded by P52 which delivers a real hosted multiplayer demo
 
 ---
 
-## Planned: P52 — Multiplayer Demo
+## Done: P52 — Multiplayer Demo
 
 **Effort: M | Impact: adoption | Risk: low**
 
-A hosted, real-time multiplayer physics demo — the most effective way to showcase
-the engine to new users. Goals:
+A hosted, real-time multiplayer physics demo showcasing the engine to new users.
 
-- `docs/multiplayer.html` — dedicated page, linked from examples grid
-- Railway-hosted Node.js WebSocket server running nape-js physics at 60 Hz
-- Server-authoritative simulation: all physics runs server-side
-- Binary state broadcast each frame via P39 (`spaceToBinary`)
-- Small platformer scene: static walls/floor, one-way floating platform, scattered balls and boxes
-- Each connected player controls one character (circle), WASD/arrow keys
-- All players visible to each other in real-time
-- Player count indicator, ping display
+**Delivered:**
+- `docs/multiplayer.html` — client page, linked from examples grid, GitHub "View source" link
+- `server/index.js` — Railway-hosted Node.js WebSocket server, 60 Hz physics loop
+- `railway.toml` — Railway deploy config
+- Server-authoritative simulation (all physics server-side)
+- Custom binary delta frame protocol — only changed bodies sent each tick (vs full state)
+- Platformer scene: static walls/floor/ceiling, one-way platforms, scattered balls & boxes
+- 5 hanging pendulums via `DistanceJoint` (soft spring, pushable)
+- Player character: vertical `Capsule` shape (28×46px), WASD/arrow keys
+- Ground detection via `space.arbiters` + `isSleeping` fallback
+- Up to 8 players — 9th+ connection enters **spectator mode** (watches, no body)
+- Player count indicator, ping display (server-side pong response)
+- Player color badges, "you" indicator dot above own character
+- Reconnect on disconnect (players only)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,6 @@ iterator patterns, ESM constraints) see `.claude/docs/architecture.md`.
 | ECS adapter              | ⬜ Planned — P49 |
 | Spatial hash grid        | ⬜ Planned — P50 |
 | Sub-stepping solver      | ⬜ Planned — P51 (long-term) |
-| Multiplayer demo         | ⬜ Planned — P52 (hosztolt, WebSocket, Railway) |
+| Multiplayer demo         | ✅ Done — P52 (Railway WebSocket, `docs/multiplayer.html` + `server/`) |
 
 Full roadmap with details, competitor analysis, and history: `.claude/docs/roadmap.md`

--- a/docs/multiplayer.html
+++ b/docs/multiplayer.html
@@ -183,6 +183,10 @@
   <header class="mp-header">
     <a href="examples.html">&larr; Examples</a>
     <h1>Multiplayer Demo</h1>
+    <a href="https://github.com/NewKrok/nape-js/tree/master/server" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:6px;font-size:13px;">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+      View source
+    </a>
   </header>
 
   <main class="mp-main">
@@ -229,6 +233,7 @@ const H = canvas.height;
 let myPlayerId = null;
 let myBodyId = null;
 let myColorIdx = 0;
+let isSpectator = false;
 let playerColors = [];
 let playerMeta = []; // [{id, colorIdx, bodyId}]
 
@@ -316,13 +321,19 @@ function connect() {
 
 function handleJsonMessage(msg) {
   if (msg.type === "init") {
-    myPlayerId = msg.playerId;
-    myBodyId = msg.bodyId;
-    myColorIdx = msg.colorIdx;
+    isSpectator = !!msg.spectator;
+    myPlayerId = msg.playerId ?? null;
+    myBodyId = msg.bodyId ?? null;
+    myColorIdx = msg.colorIdx ?? 0;
     playerColors = msg.playerColors;
     staticBodies = msg.staticBodies;
     sceneObjects = msg.sceneObjects;
     playerMeta = msg.players;
+
+    if (isSpectator) {
+      setStatus(true, "Spectating");
+      document.getElementById("playerCountText").textContent = `${playerMeta.length} / 8 players`;
+    }
 
     // Pre-populate body state for scene objects
     for (const obj of sceneObjects) {
@@ -393,8 +404,19 @@ function getBodyColor(id) {
 }
 
 function drawRoundRect(x, y, w, h, r = 4) {
+  const l = x - w / 2, t = y - h / 2;
+  const rr = Math.min(r, w / 2, h / 2);
   ctx.beginPath();
-  ctx.roundRect(x - w/2, y - h/2, w, h, r);
+  ctx.moveTo(l + rr, t);
+  ctx.lineTo(l + w - rr, t);
+  ctx.arc(l + w - rr, t + rr,     rr, -Math.PI / 2, 0);
+  ctx.lineTo(l + w, t + h - rr);
+  ctx.arc(l + w - rr, t + h - rr, rr, 0,            Math.PI / 2);
+  ctx.lineTo(l + rr, t + h);
+  ctx.arc(l + rr,     t + h - rr, rr, Math.PI / 2,  Math.PI);
+  ctx.lineTo(l, t + rr);
+  ctx.arc(l + rr,     t + rr,     rr, Math.PI,       -Math.PI / 2);
+  ctx.closePath();
 }
 
 function render(alpha) {
@@ -443,16 +465,21 @@ function render(alpha) {
     const pm = playerMeta.find(p => p.bodyId === id);
 
     if (pm) {
-      // Player: circle
-      const r = 14;
+      // Player: vertical capsule
+      const pw = 14, ph = 23, pr = pw; // half-width, half-height, endcap radius
       ctx.beginPath();
-      ctx.arc(0, 0, r, 0, Math.PI * 2);
+      ctx.moveTo(-pw, -ph + pr);
+      ctx.lineTo(-pw,  ph - pr);
+      ctx.arc(0, ph - pr, pw, Math.PI, 0, true);
+      ctx.lineTo(pw, -ph + pr);
+      ctx.arc(0, -ph + pr, pw, 0, Math.PI, true);
+      ctx.closePath();
       ctx.fillStyle = c.fill; ctx.fill();
       ctx.strokeStyle = c.stroke; ctx.lineWidth = isMe ? 2.5 : 1.5; ctx.stroke();
       // "Me" indicator
       if (isMe) {
         ctx.beginPath();
-        ctx.arc(0, -r - 6, 4, 0, Math.PI * 2);
+        ctx.arc(0, -ph - 6, 4, 0, Math.PI * 2);
         ctx.fillStyle = c.stroke; ctx.fill();
       }
     } else if (obj) {
@@ -469,6 +496,25 @@ function render(alpha) {
     }
 
     ctx.restore();
+
+    // Kötél kirajzolása (rope) — ha lelógó elem, anchor fix pozíció
+    if (obj && obj.anchorX != null) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.moveTo(obj.anchorX, obj.anchorY);
+      ctx.lineTo(ix, iy);
+      ctx.strokeStyle = "rgba(120,160,200,0.5)";
+      ctx.lineWidth = 1.5;
+      ctx.setLineDash([4, 4]);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      // Anchor pont
+      ctx.beginPath();
+      ctx.arc(obj.anchorX, obj.anchorY, 3, 0, Math.PI * 2);
+      ctx.fillStyle = "#4a6070";
+      ctx.fill();
+      ctx.restore();
+    }
   }
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -16,8 +16,8 @@
 import { createServer } from "http";
 import { WebSocketServer } from "ws";
 import {
-  Space, Body, BodyType, Vec2, Circle, Polygon, Material,
-  CbType, InteractionType, PreListener, PreFlag,
+  Space, Body, BodyType, Vec2, Circle, Polygon, Capsule, Material,
+  CbType, InteractionType, PreListener, PreFlag, DistanceJoint,
 } from "@newkrok/nape-js";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -26,7 +26,8 @@ const PORT = process.env.PORT || 3000;
 const W = 900;
 const H = 500;
 const TICK_MS = 1000 / 60;
-const PLAYER_RADIUS = 14;
+const PLAYER_W = 28;   // capsule width (narrow side)
+const PLAYER_H = 46;   // capsule height (tall side, after PI/2 rotation)
 const PLAYER_MASS_MATERIAL = new Material(0.1, 0.5, 0.4, 2);
 const JUMP_FORCE = -480;
 const MOVE_FORCE = 220;
@@ -127,8 +128,34 @@ function spawnObject(x, y, shape /* "circle"|"box" */, size) {
   return { id, shape, size, x, y };
 }
 
+// ─── Spawn hanging objects (DistanceJoint pendulums) ─────────────────────────
+
+function spawnHanging(anchorX, anchorY, ropeLen, shape, size) {
+  const id = nextBodyId++;
+  const body = new Body(BodyType.DYNAMIC, new Vec2(anchorX, anchorY + ropeLen));
+  if (shape === "circle") {
+    body.shapes.add(new Circle(size, undefined, new Material(0.2, 0.4, 0.3, 1.5)));
+  } else {
+    body.shapes.add(new Polygon(Polygon.box(size, size), undefined, new Material(0.2, 0.4, 0.3, 1.5)));
+  }
+  body.space = space;
+  dynamicBodies.set(id, body);
+
+  // Static anchor body (invisible, just for the joint)
+  const anchor = new Body(BodyType.STATIC, new Vec2(anchorX, anchorY));
+  anchor.space = space;
+
+  const joint = new DistanceJoint(anchor, body, new Vec2(0, 0), new Vec2(0, 0), ropeLen, ropeLen);
+  joint.stiff = false;
+  joint.damping = 2;
+  joint.frequency = 4;
+  joint.space = space;
+
+  return { id, shape, size, x: anchorX, y: anchorY + ropeLen, anchorX, anchorY, ropeLen };
+}
+
 const sceneObjects = [
-  // Labdák
+  // Labdák — padlón
   spawnObject(200, 350, "circle", 14),
   spawnObject(400, 380, "circle", 10),
   spawnObject(650, 350, "circle", 16),
@@ -146,12 +173,19 @@ const sceneObjects = [
   spawnObject(W / 2 + 30, H * 0.65 - 30, "circle", 10),
   spawnObject(190,         H * 0.50 - 25, "box",    16),
   spawnObject(710,         H * 0.50 - 25, "circle", 11),
+  // Lelógó elemek — mennyezetről
+  spawnHanging(160,  WALL, 110, "circle", 16),
+  spawnHanging(450,  WALL,  90, "box",    20),
+  spawnHanging(740,  WALL, 120, "circle", 13),
+  spawnHanging(310,  WALL,  70, "box",    16),
+  spawnHanging(610,  WALL,  80, "circle", 11),
 ];
 
 // ─── Player management ────────────────────────────────────────────────────────
 
 let nextPlayerId = 1;
-const players = new Map(); // playerId → { ws, body, bodyId, colorIdx, keys, onGround }
+const players = new Map();    // playerId → { ws, body, bodyId, colorIdx, keys, onGround }
+const spectators = new Set(); // ws handles of spectator connections
 
 function spawnPlayer(ws) {
   if (players.size >= MAX_PLAYERS) return null;
@@ -160,9 +194,11 @@ function spawnPlayer(ws) {
   const colorIdx = (playerId - 1) % PLAYER_COLORS.length;
   const bodyId = nextBodyId++;
 
-  const spawnX = WALL + PLAYER_RADIUS + Math.random() * (W - WALL * 2 - PLAYER_RADIUS * 2);
+  const spawnX = WALL + PLAYER_W + Math.random() * (W - WALL * 2 - PLAYER_W * 2);
   const body = new Body(BodyType.DYNAMIC, new Vec2(spawnX, 60));
-  body.shapes.add(new Circle(PLAYER_RADIUS, undefined, PLAYER_MASS_MATERIAL));
+  const cap = new Capsule(PLAYER_H, PLAYER_W, undefined, PLAYER_MASS_MATERIAL);
+  cap.rotation = Math.PI / 2;
+  body.shapes.add(cap);
   body.shapes.at(0).cbTypes.add(playerType);
   // Prevent rotation so character stays upright
   body.allowRotation = false;
@@ -181,30 +217,33 @@ function removePlayer(playerId) {
   if (!player) return;
   player.body.space = null;
   dynamicBodies.delete(player.bodyId);
+  lastState.delete(player.bodyId);
   players.delete(playerId);
 }
 
 // ─── Ground detection via space arbiters ─────────────────────────────────────
-// Check space.arbiters for any arbiter involving this body with upward normal
+// A body is on the ground if it has a collision contact where the normal's Y
+// component (pointing away from the other body toward the player) is upward,
+// i.e. the floor pushes the player up (effNy < 0 in canvas coords where +y=down).
 
 function isOnGround(body) {
+  // Sleeping bodies have no active arbiters — treat as grounded if nearly stationary.
+  if (body.isSleeping) return true;
   try {
     const arbs = space.arbiters;
-    for (let i = 0; i < arbs.length; i++) {
+    const count = arbs.zpp_gl();
+    for (let i = 0; i < count; i++) {
       const arb = arbs.at(i);
       try {
         if (arb.body1 !== body && arb.body2 !== body) continue;
         const col = arb.collisionArbiter;
         if (!col) continue;
         const ny = col.normal.y;
-        // In canvas coords +y is down. The collision normal points from body1 → body2.
-        // We want a contact where the floor is below the player.
-        // The effective normal relative to the player is:
-        //   player = body2 → normal pushes player upward → ny < 0
-        //   player = body1 → normal pushes player downward, floor below → ny > 0
-        // Accept both orderings; only vertically-dominant contacts count.
-        const effNy = arb.body2 === body ? ny : -ny;
-        if (effNy < -0.5) return true;
+        // normal points from body1 → body2.
+        // If player is body1: effNy = -ny (floor pushes up → effNy < 0)
+        // If player is body2: effNy = ny  (normal already points into player upward)
+        const effNy = arb.body1 === body ? -ny : ny;
+        if (effNy < -0.3) return true;
       } catch (_) {}
     }
   } catch (_) {}
@@ -234,20 +273,40 @@ function applyPlayerInputs() {
   }
 }
 
-// ─── Build binary state frame ─────────────────────────────────────────────────
+// ─── Build binary state frame (delta — only changed bodies) ───────────────────
 // Format: [bodyCount: Uint16] + N × [id: Uint16, x: Float32, y: Float32, rot: Float32]
 // Total: 2 + N×14 bytes
 
+const POS_THRESHOLD = 0.1;   // px
+const ROT_THRESHOLD = 0.001; // rad
+const lastState = new Map(); // id → { x, y, rot }
+
 function buildStateFrame() {
-  const count = dynamicBodies.size;
-  const buf = Buffer.allocUnsafe(2 + count * 14);
-  buf.writeUInt16LE(count, 0);
-  let offset = 2;
+  const changed = [];
   for (const [id, body] of dynamicBodies) {
-    buf.writeUInt16LE(id, offset);       offset += 2;
-    buf.writeFloatLE(body.position.x, offset); offset += 4;
-    buf.writeFloatLE(body.position.y, offset); offset += 4;
-    buf.writeFloatLE(body.rotation,   offset); offset += 4;
+    const x   = body.position.x;
+    const y   = body.position.y;
+    const rot = body.rotation;
+    const prev = lastState.get(id);
+    if (
+      !prev ||
+      Math.abs(x - prev.x)     > POS_THRESHOLD ||
+      Math.abs(y - prev.y)     > POS_THRESHOLD ||
+      Math.abs(rot - prev.rot) > ROT_THRESHOLD
+    ) {
+      changed.push({ id, x, y, rot });
+      lastState.set(id, { x, y, rot });
+    }
+  }
+  if (changed.length === 0) return null;
+  const buf = Buffer.allocUnsafe(2 + changed.length * 14);
+  buf.writeUInt16LE(changed.length, 0);
+  let offset = 2;
+  for (const { id, x, y, rot } of changed) {
+    buf.writeUInt16LE(id, offset);     offset += 2;
+    buf.writeFloatLE(x,   offset);     offset += 4;
+    buf.writeFloatLE(y,   offset);     offset += 4;
+    buf.writeFloatLE(rot, offset);     offset += 4;
   }
   return buf;
 }
@@ -256,9 +315,10 @@ function buildStateFrame() {
 
 function broadcastBinary(buf) {
   for (const [, player] of players) {
-    if (player.ws.readyState === 1 /* OPEN */) {
-      player.ws.send(buf);
-    }
+    if (player.ws.readyState === 1 /* OPEN */) player.ws.send(buf);
+  }
+  for (const ws of spectators) {
+    if (ws.readyState === 1 /* OPEN */) ws.send(buf);
   }
 }
 
@@ -302,7 +362,7 @@ setInterval(() => {
   applyPlayerInputs();
   space.step(TICK_MS / 1000);
   const frame = buildStateFrame();
-  broadcastBinary(frame);
+  if (frame) broadcastBinary(frame);
 }, TICK_MS);
 
 // ─── HTTP + WebSocket server ──────────────────────────────────────────────────
@@ -331,12 +391,38 @@ const wss = new WebSocketServer({
 
 wss.on("connection", (ws) => {
   const result = spawnPlayer(ws);
+
+  // ── Spectator mode ────────────────────────────────────────────────────────
   if (!result) {
-    ws.send(JSON.stringify({ type: "error", message: "Server full" }));
-    ws.close();
+    spectators.add(ws);
+    console.log(`Spectator connected, total spectators: ${spectators.size}`);
+    ws.send(JSON.stringify({
+      type: "init",
+      spectator: true,
+      staticBodies,
+      sceneObjects,
+      playerColors: PLAYER_COLORS,
+      players: [...players.entries()].map(([id, p]) => ({ id, colorIdx: p.colorIdx, bodyId: p.bodyId })),
+    }));
+    broadcastPlayerList();
+
+    ws.on("message", (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        if (msg.type === "ping") ws.send(JSON.stringify({ type: "pong" }));
+      } catch (_) {}
+    });
+
+    ws.on("close", () => {
+      spectators.delete(ws);
+      console.log(`Spectator disconnected, total spectators: ${spectators.size}`);
+    });
+
+    ws.on("error", () => { spectators.delete(ws); });
     return;
   }
 
+  // ── Player mode ───────────────────────────────────────────────────────────
   const { playerId, bodyId, colorIdx } = result;
   console.log(`Player ${playerId} connected (body ${bodyId}), total: ${players.size}`);
 
@@ -349,6 +435,9 @@ wss.on("connection", (ws) => {
       if (msg.type === "input") {
         const player = players.get(playerId);
         if (player) player.keys = msg.keys;
+      }
+      if (msg.type === "ping") {
+        ws.send(JSON.stringify({ type: "pong" }));
       }
     } catch (_) {}
   });


### PR DESCRIPTION
…ta frames, spectator mode, jump fix, source link

- Player shape changed from circle to vertical Capsule (28×46px) with arc-based canvas draw
- 5 hanging DistanceJoint pendulums added to scene (pushable from ceiling)
- Delta binary frame protocol: only changed bodies broadcast each tick (POS_THRESHOLD=0.1, ROT_THRESHOLD=0.001)
- Spectator mode for 9th+ connections: receives frames, no physics body
- Fixed jump: correct arbiter count via zpp_gl(), normal direction formula, isSleeping fallback
- Fixed ping display: server now responds to { type: "ping" } with { type: "pong" }
- Fixed box rendering: replaced ctx.roundRect() with arc-based polyfill for browser compatibility
- Added GitHub source link in demo page header
- Updated CLAUDE.md and roadmap.md: P52 marked Done