### PR TITLE
Add 92 tests targeting key low-coverage areas (+1% overall coverage)

### DIFF
--- a/tests/dynamics/Fluid.advanced.test.ts
+++ b/tests/dynamics/Fluid.advanced.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Advanced fluid simulation integration tests.
+ * Exercises ZPP_Space fluid simulation paths, FluidArbiter, and buoyancy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Vec3 } from "../../src/geom/Vec3";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { FluidProperties } from "../../src/phys/FluidProperties";
+import { InteractionListener } from "../../src/callbacks/InteractionListener";
+import { CbEvent } from "../../src/callbacks/CbEvent";
+import { InteractionType } from "../../src/callbacks/InteractionType";
+import { CbType } from "../../src/callbacks/CbType";
+import { Broadphase } from "../../src/space/Broadphase";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function step(space: Space, n: number, dt = 1 / 60): void {
+  for (let i = 0; i < n; i++) space.step(dt);
+}
+
+/**
+ * Create a static fluid pool (large polygon with fluidEnabled).
+ */
+function makeFluidPool(
+  space: Space,
+  x = 0,
+  y = 0,
+  w = 400,
+  h = 200,
+  density = 1,
+  viscosity = 1,
+): Body {
+  const body = new Body(BodyType.STATIC, new Vec2(x, y));
+  const shape = new Polygon(Polygon.box(w, h));
+  shape.fluidEnabled = true;
+  shape.fluidProperties = new FluidProperties(density, viscosity);
+  body.shapes.add(shape);
+  body.space = space;
+  return body;
+}
+
+// ---------------------------------------------------------------------------
+// Buoyancy & fluid interactions
+// ---------------------------------------------------------------------------
+
+describe("Fluid simulation — basic buoyancy", () => {
+  it("body should fall slower in fluid than in free fall", () => {
+    // Without fluid
+    const spaceNoFluid = new Space(new Vec2(0, 500));
+    const b1 = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b1.shapes.add(new Circle(15));
+    b1.space = spaceNoFluid;
+    step(spaceNoFluid, 60);
+    const yNoFluid = b1.position.y;
+
+    // With fluid (buoyancy slows descent)
+    const spaceFluid = new Space(new Vec2(0, 500));
+    makeFluidPool(spaceFluid, 0, 100, 400, 300, 2, 0.5);
+    const b2 = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b2.shapes.add(new Circle(15));
+    b2.space = spaceFluid;
+    step(spaceFluid, 60);
+    const yFluid = b2.position.y;
+
+    // Body in fluid should be higher (less fall) than body in free fall
+    expect(yFluid).toBeLessThan(yNoFluid);
+  });
+
+  it("high-density fluid should cause more buoyancy", () => {
+    const space = new Space(new Vec2(0, 500));
+    makeFluidPool(space, 0, 50, 400, 300, 10, 0);
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(20));
+    b.space = space;
+    step(space, 120);
+    // High density fluid should counteract gravity — body should be near surface
+    expect(b.position.y).toBeLessThan(200);
+  });
+
+  it("high-viscosity fluid should slow horizontal movement significantly", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+    const shape = new Polygon(Polygon.box(1000, 1000));
+    shape.fluidEnabled = true;
+    shape.fluidProperties = new FluidProperties(5, 5);
+    fluidBody.shapes.add(shape);
+    fluidBody.space = space;
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(10));
+    b.velocity = Vec2.get(300, 0);
+    b.space = space;
+    step(space, 120);
+    // High-density, high-viscosity fluid should slow horizontal velocity
+    expect(b.velocity.x).toBeLessThan(300);
+  });
+
+  it("viscous fluid should slow moving body more than low-viscosity", () => {
+    // High viscosity
+    const spaceHigh = new Space(new Vec2(0, 0));
+    makeFluidPool(spaceHigh, 0, 0, 400, 400, 1, 10);
+    const b1 = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b1.shapes.add(new Circle(10));
+    b1.velocity = Vec2.get(200, 0);
+    b1.space = spaceHigh;
+    step(spaceHigh, 60);
+    const vHigh = b1.velocity.x;
+
+    // Low viscosity
+    const spaceLow = new Space(new Vec2(0, 0));
+    makeFluidPool(spaceLow, 0, 0, 400, 400, 1, 0.1);
+    const b2 = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b2.shapes.add(new Circle(10));
+    b2.velocity = Vec2.get(200, 0);
+    b2.space = spaceLow;
+    step(spaceLow, 60);
+    const vLow = b2.velocity.x;
+
+    // High viscosity should slow the body more
+    expect(vHigh).toBeLessThan(vLow);
+  });
+});
+
+describe("Fluid simulation — fluid callbacks", () => {
+  it("FLUID BEGIN callback fires when body enters fluid", () => {
+    const space = new Space(new Vec2(0, 200));
+    let beginFired = false;
+
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.FLUID,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        beginFired = true;
+      },
+    );
+    listener.space = space;
+
+    makeFluidPool(space, 0, 100, 400, 200, 1, 1);
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(10));
+    b.space = space;
+
+    for (let i = 0; i < 120; i++) {
+      space.step(1 / 60);
+      if (beginFired) break;
+    }
+    expect(beginFired).toBe(true);
+  });
+
+  it("FLUID ONGOING callback fires while body is in fluid", () => {
+    const space = new Space(new Vec2(0, 100));
+    let ongoingCount = 0;
+
+    const listener = new InteractionListener(
+      CbEvent.ONGOING,
+      InteractionType.FLUID,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        ongoingCount++;
+      },
+    );
+    listener.space = space;
+
+    // Body starts inside fluid
+    const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+    const shape = new Polygon(Polygon.box(400, 400));
+    shape.fluidEnabled = true;
+    shape.fluidProperties = new FluidProperties(2, 0.5);
+    fluidBody.shapes.add(shape);
+    fluidBody.space = space;
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(10));
+    b.space = space;
+
+    step(space, 5);
+    expect(ongoingCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("FLUID END callback fires when body exits fluid", () => {
+    const space = new Space(new Vec2(0, 0));
+    let endFired = false;
+
+    // Listen for BEGIN so the engine tracks the pair
+    const beginListener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.FLUID,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {},
+    );
+    beginListener.space = space;
+
+    const endListener = new InteractionListener(
+      CbEvent.END,
+      InteractionType.FLUID,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        endFired = true;
+      },
+    );
+    endListener.space = space;
+
+    // Fluid pool at y=100
+    makeFluidPool(space, 0, 100, 400, 100, 1, 0.1);
+
+    // Body starts inside fluid, then move it away
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 100));
+    b.shapes.add(new Circle(10));
+    b.space = space;
+    step(space, 1); // establish FLUID BEGIN
+
+    // Move body far above fluid
+    b.position.setxy(0, -500);
+    for (let i = 0; i < 10; i++) {
+      space.step(1 / 60);
+      if (endFired) break;
+    }
+    expect(endFired).toBe(true);
+  });
+});
+
+describe("Fluid simulation — fluid impulse queries", () => {
+  it("fluidImpulse returns Vec3 after body is in fluid", () => {
+    const space = new Space(new Vec2(0, 200));
+    // Body starts fully immersed in fluid
+    const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+    const shape = new Polygon(Polygon.box(500, 500));
+    shape.fluidEnabled = true;
+    shape.fluidProperties = new FluidProperties(3, 1);
+    fluidBody.shapes.add(shape);
+    fluidBody.space = space;
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(15));
+    b.space = space;
+
+    step(space, 30);
+
+    const imp = b.totalFluidImpulse() as Vec3;
+    expect(imp).not.toBeNull();
+    expect(typeof imp.x).toBe("number");
+    imp.dispose();
+  });
+});
+
+describe("Fluid simulation — multiple bodies in fluid", () => {
+  it("should handle multiple bodies in same fluid simultaneously", () => {
+    const space = new Space(new Vec2(0, 100));
+    makeFluidPool(space, 0, 100, 600, 200, 2, 1);
+
+    const bodies: Body[] = [];
+    for (let i = 0; i < 5; i++) {
+      const b = new Body(BodyType.DYNAMIC, new Vec2(i * 30 - 60, 0));
+      b.shapes.add(new Circle(10));
+      b.space = space;
+      bodies.push(b);
+    }
+
+    expect(() => step(space, 60)).not.toThrow();
+    // All bodies should still be in simulation
+    for (const b of bodies) {
+      expect(b.space).not.toBeNull();
+    }
+  });
+
+  it("should handle polygon bodies in fluid (not just circles)", () => {
+    const space = new Space(new Vec2(0, 100));
+    makeFluidPool(space, 0, 100, 600, 200, 2, 0.5);
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 50));
+    b.shapes.add(new Polygon(Polygon.box(30, 30)));
+    b.space = space;
+
+    expect(() => step(space, 60)).not.toThrow();
+  });
+});
+
+describe("Fluid simulation — SWEEP_AND_PRUNE with fluid", () => {
+  it("should detect fluid interactions under SWEEP_AND_PRUNE broadphase", () => {
+    const space = new Space(new Vec2(0, 200), Broadphase.SWEEP_AND_PRUNE);
+    let fluidFired = false;
+
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.FLUID,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        fluidFired = true;
+      },
+    );
+    listener.space = space;
+
+    makeFluidPool(space, 0, 100, 400, 200, 1, 1);
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(10));
+    b.space = space;
+
+    for (let i = 0; i < 120; i++) {
+      space.step(1 / 60);
+      if (fluidFired) break;
+    }
+    expect(fluidFired).toBe(true);
+  });
+});
+
+describe("Fluid simulation — buoyancyImpulse and dragImpulse queries", () => {
+  it("buoyancyImpulse returns Vec3 when body is in fluid", () => {
+    const space = new Space(new Vec2(0, 200));
+    const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+    const shape = new Polygon(Polygon.box(500, 500));
+    shape.fluidEnabled = true;
+    shape.fluidProperties = new FluidProperties(3, 1);
+    fluidBody.shapes.add(shape);
+    fluidBody.space = space;
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(15));
+    b.space = space;
+    step(space, 30);
+
+    const imp = b.buoyancyImpulse() as Vec3;
+    expect(imp).not.toBeNull();
+    expect(typeof imp.x).toBe("number");
+    imp.dispose();
+  });
+
+  it("dragImpulse returns Vec3 when body moves through fluid", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+    const shape = new Polygon(Polygon.box(500, 500));
+    shape.fluidEnabled = true;
+    shape.fluidProperties = new FluidProperties(1, 2);
+    fluidBody.shapes.add(shape);
+    fluidBody.space = space;
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(15));
+    b.velocity = Vec2.get(100, 0);
+    b.space = space;
+    step(space, 10);
+
+    const imp = b.dragImpulse() as Vec3;
+    expect(imp).not.toBeNull();
+    expect(typeof imp.x).toBe("number");
+    imp.dispose();
+  });
+});

--- a/tests/phys/Body.dynamics.test.ts
+++ b/tests/phys/Body.dynamics.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Body dynamics API tests — impulse queries, force/torque, sleep, velocity helpers.
+ * Exercises uncovered Body.ts code paths.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Vec3 } from "../../src/geom/Vec3";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { PivotJoint } from "../../src/constraint/PivotJoint";
+import { DistanceJoint } from "../../src/constraint/DistanceJoint";
+import { InteractionType } from "../../src/callbacks/InteractionType";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSpace(gx = 0, gy = 500): Space {
+  return new Space(new Vec2(gx, gy));
+}
+
+function step(space: Space, n: number, dt = 1 / 60): void {
+  for (let i = 0; i < n; i++) space.step(dt);
+}
+
+function dynamicCircle(x: number, y: number, r = 15): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(r));
+  return b;
+}
+
+function staticFloor(y = 200): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(0, y));
+  b.shapes.add(new Polygon(Polygon.box(500, 20)));
+  return b;
+}
+
+// ---------------------------------------------------------------------------
+// Force & torque
+// ---------------------------------------------------------------------------
+
+describe("Body dynamics — force and torque", () => {
+  it("should get/set force on a dynamic body", () => {
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(10));
+    b.force.setxy(100, 200);
+    expect(b.force.x).toBeCloseTo(100);
+    expect(b.force.y).toBeCloseTo(200);
+  });
+
+  it("should apply force and observe acceleration", () => {
+    const space = makeSpace(0, 0);
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    b.force = Vec2.weak(0, -1000);
+    step(space, 1);
+    // With upward force, body should have moved up (negative y direction)
+    expect(b.position.y).toBeLessThanOrEqual(0);
+  });
+
+  it("should get/set torque on a dynamic body", () => {
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(10));
+    b.torque = 50;
+    expect(b.torque).toBeCloseTo(50);
+  });
+
+  it("should apply torque and observe angular velocity change", () => {
+    const space = makeSpace(0, 0);
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    b.torque = 10000;
+    step(space, 1);
+    expect(Math.abs(b.angularVel)).toBeGreaterThan(0);
+  });
+
+  it("should throw when setting torque on static body", () => {
+    const b = new Body(BodyType.STATIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(5));
+    expect(() => {
+      b.torque = 10;
+    }).toThrow("Non-dynamic");
+  });
+
+  it("should throw when setting NaN torque", () => {
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(5));
+    expect(() => {
+      b.torque = NaN;
+    }).toThrow("NaN");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Angular impulse
+// ---------------------------------------------------------------------------
+
+describe("Body dynamics — applyAngularImpulse", () => {
+  it("should change angular velocity", () => {
+    const space = makeSpace(0, 0);
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    const angBefore = b.angularVel;
+    b.applyAngularImpulse(100);
+    expect(b.angularVel).not.toBe(angBefore);
+  });
+
+  it("should return the body itself (chaining)", () => {
+    const space = makeSpace(0, 0);
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    const ret = b.applyAngularImpulse(10);
+    expect(ret).toBe(b);
+  });
+
+  it("should apply sleepable angular impulse to sleeping body (wakes it)", () => {
+    const space = new Space(new Vec2(0, 0));
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    step(space, 300); // let body sleep
+    expect(b.isSleeping).toBe(true);
+    b.applyAngularImpulse(1000, false);
+    step(space, 1);
+    expect(Math.abs(b.angularVel)).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyImpulse with position (torque effect)
+// ---------------------------------------------------------------------------
+
+describe("Body dynamics — applyImpulse with offset position", () => {
+  it("should cause rotation when impulse applied off-center", () => {
+    const space = makeSpace(0, 0);
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    // Apply impulse to the side — should cause rotation
+    b.applyImpulse(new Vec2(0, 100), new Vec2(50, 0));
+    expect(Math.abs(b.angularVel)).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// kinematicVel
+// ---------------------------------------------------------------------------
+
+describe("Body dynamics — kinematicVel", () => {
+  it("should get/set kinematicVel on kinematic body", () => {
+    const b = new Body(BodyType.KINEMATIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(10));
+    b.kinematicVel.setxy(100, 50);
+    expect(b.kinematicVel.x).toBeCloseTo(100);
+    expect(b.kinematicVel.y).toBeCloseTo(50);
+  });
+
+  it("should set kinematicVel via property assignment", () => {
+    const b = new Body(BodyType.KINEMATIC, new Vec2(0, 0));
+    b.shapes.add(new Circle(10));
+    b.kinematicVel = Vec2.get(200, 50);
+    expect(b.kinematicVel.x).toBeCloseTo(200);
+    expect(b.kinematicVel.y).toBeCloseTo(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSleeping
+// ---------------------------------------------------------------------------
+
+describe("Body dynamics — isSleeping", () => {
+  it("isSleeping returns false when body just added", () => {
+    const space = makeSpace(0, 0);
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    expect(b.isSleeping).toBe(false);
+  });
+
+  it("isSleeping becomes true after body settles", () => {
+    const space = new Space(new Vec2(0, 0));
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    step(space, 300);
+    expect(b.isSleeping).toBe(true);
+  });
+
+  it("isSleeping throws if body not in space", () => {
+    const b = dynamicCircle(0, 0);
+    expect(() => b.isSleeping).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// connectedBodies
+// ---------------------------------------------------------------------------
+
+describe("Body dynamics — connectedBodies", () => {
+  it("should return connected body when joined by PivotJoint", () => {
+    const space = makeSpace(0, 0);
+    const b1 = dynamicCircle(0, 0);
+    const b2 = dynamicCircle(50, 0);
+    b1.space = space;
+    b2.space = space;
+    const joint = new PivotJoint(b1, b2, Vec2.weak(25, 0), Vec2.weak(-25, 0));
+    joint.space = space;
+    step(space, 1);
+    const connected = b1.connectedBodies() as any;
+    expect(connected.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should return empty list when body has no constraints", () => {
+    const space = makeSpace(0, 0);
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    step(space, 1);
+    const connected = b.connectedBodies() as any;
+    expect(connected.length).toBe(0);
+  });
+
+  it("should respect depth limit in connectedBodies", () => {
+    const space = makeSpace(0, 0);
+    const b1 = dynamicCircle(0, 0);
+    const b2 = dynamicCircle(50, 0);
+    const b3 = dynamicCircle(100, 0);
+    b1.space = space;
+    b2.space = space;
+    b3.space = space;
+    const j1 = new PivotJoint(b1, b2, Vec2.weak(25, 0), Vec2.weak(-25, 0));
+    const j2 = new PivotJoint(b2, b3, Vec2.weak(75, 0), Vec2.weak(-25, 0));
+    j1.space = space;
+    j2.space = space;
+    step(space, 1);
+    // depth=1 should only return b2, not b3
+    const depth1 = b1.connectedBodies(1) as any;
+    const depth2 = b1.connectedBodies(2) as any;
+    expect(depth1.length).toBeLessThanOrEqual(depth2.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// interactingBodies
+// ---------------------------------------------------------------------------
+
+describe("Body dynamics — interactingBodies", () => {
+  it("should return a BodyList from interactingBodies with null type", () => {
+    const space = makeSpace(0, 0);
+    const b1 = dynamicCircle(0, 0, 25);
+    const b2 = dynamicCircle(30, 0, 25);
+    b1.space = space;
+    b2.space = space;
+    step(space, 3);
+    // null type should return a defined BodyList (same as InteractionType.COLLISION)
+    const interacting = b1.interactingBodies(null) as any;
+    expect(interacting).not.toBeNull();
+    expect(typeof interacting.length).toBe("number");
+  });
+
+  it("should filter by InteractionType.COLLISION", () => {
+    const space = makeSpace(0, 0);
+    const b1 = dynamicCircle(0, 0, 25);
+    const b2 = dynamicCircle(30, 0, 25);
+    b1.space = space;
+    b2.space = space;
+    step(space, 3);
+    const interacting = b1.interactingBodies(InteractionType.COLLISION) as any;
+    expect(interacting.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should return empty when bodies are far apart", () => {
+    const space = makeSpace(0, 0);
+    const b1 = dynamicCircle(0, 0, 10);
+    const b2 = dynamicCircle(1000, 0, 10);
+    b1.space = space;
+    b2.space = space;
+    step(space, 1);
+    const interacting = b1.interactingBodies() as any;
+    expect(interacting.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Impulse queries after collision
+// ---------------------------------------------------------------------------
+
+describe("Body dynamics — impulse queries after collision", () => {
+  it("normalImpulse returns non-zero Vec3 after collision", () => {
+    const space = makeSpace(0, 500);
+    const floor = staticFloor(200);
+    floor.space = space;
+    const ball = dynamicCircle(0, 0);
+    ball.space = space;
+    step(space, 60);
+    const imp = ball.normalImpulse() as Vec3;
+    expect(imp).not.toBeNull();
+    // The Vec3 may be all zeros if sleeping, but should exist
+    expect(typeof imp.x).toBe("number");
+    imp.dispose();
+  });
+
+  it("tangentImpulse returns Vec3 after collision", () => {
+    const space = makeSpace(0, 500);
+    const floor = staticFloor(200);
+    floor.space = space;
+    const ball = dynamicCircle(0, 0);
+    ball.space = space;
+    step(space, 60);
+    const imp = ball.tangentImpulse() as Vec3;
+    expect(imp).not.toBeNull();
+    expect(typeof imp.x).toBe("number");
+    imp.dispose();
+  });
+
+  it("totalContactsImpulse returns Vec3 after collision", () => {
+    const space = makeSpace(0, 500);
+    const floor = staticFloor(200);
+    floor.space = space;
+    const ball = dynamicCircle(0, 0);
+    ball.space = space;
+    step(space, 60);
+    const imp = ball.totalContactsImpulse() as Vec3;
+    expect(imp).not.toBeNull();
+    expect(typeof imp.z).toBe("number");
+    imp.dispose();
+  });
+
+  it("normalImpulse with body filter returns Vec3", () => {
+    const space = makeSpace(0, 500);
+    const floor = staticFloor(200);
+    floor.space = space;
+    const ball = dynamicCircle(0, 0);
+    ball.space = space;
+    step(space, 30);
+    const imp = ball.normalImpulse(floor) as Vec3;
+    expect(imp).not.toBeNull();
+    imp.dispose();
+  });
+
+  it("rollingImpulse returns a number", () => {
+    const space = makeSpace(0, 500);
+    const floor = staticFloor(200);
+    floor.space = space;
+    const ball = dynamicCircle(0, 0);
+    ball.space = space;
+    step(space, 60);
+    const roll = ball.rollingImpulse();
+    expect(typeof roll).toBe("number");
+    expect(isNaN(roll)).toBe(false);
+  });
+
+  it("totalImpulse returns Vec3 including all impulse types", () => {
+    const space = makeSpace(0, 500);
+    const floor = staticFloor(200);
+    floor.space = space;
+    const ball = dynamicCircle(0, 0);
+    ball.space = space;
+    step(space, 30);
+    const imp = ball.totalImpulse() as Vec3;
+    expect(imp).not.toBeNull();
+    imp.dispose();
+  });
+
+  it("crushFactor returns a non-negative number after constraint interaction", () => {
+    const space = makeSpace(0, 500);
+    const anchor = new Body(BodyType.STATIC, new Vec2(0, 0));
+    anchor.shapes.add(new Circle(5));
+    anchor.space = space;
+    const ball = dynamicCircle(0, 50);
+    ball.space = space;
+    const joint = new DistanceJoint(anchor, ball, new Vec2(0, 0), new Vec2(0, 0), 40, 60);
+    joint.space = space;
+    step(space, 30);
+    const crush = ball.crushFactor();
+    expect(typeof crush).toBe("number");
+    expect(isNaN(crush)).toBe(false);
+    expect(crush).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setVelocityFromTarget
+// ---------------------------------------------------------------------------
+
+describe("Body dynamics — setVelocityFromTarget", () => {
+  it("should set velocity to reach target position in given time", () => {
+    const space = makeSpace(0, 0);
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    const target = new Vec2(100, 0);
+    b.setVelocityFromTarget(target, 0, 1.0);
+    // Velocity should point towards target
+    expect(b.velocity.x).toBeCloseTo(100, 0);
+  });
+
+  it("should set angular velocity to reach target rotation", () => {
+    const space = makeSpace(0, 0);
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    b.setVelocityFromTarget(new Vec2(0, 0), Math.PI, 1.0);
+    expect(Math.abs(b.angularVel)).toBeGreaterThan(0);
+  });
+});

--- a/tests/shape/Capsule.advanced.test.ts
+++ b/tests/shape/Capsule.advanced.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Advanced Capsule tests — transform paths, copy, fluid drag, rotated collisions.
+ * Exercises ZPP_Capsule.ts uncovered code paths.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Capsule } from "../../src/shape/Capsule";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Space } from "../../src/space/Space";
+import { FluidProperties } from "../../src/phys/FluidProperties";
+import { Broadphase } from "../../src/space/Broadphase";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function step(space: Space, n: number, dt = 1 / 60): void {
+  for (let i = 0; i < n; i++) space.step(dt);
+}
+
+function staticFloor(space: Space, y = 300): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(0, y));
+  b.shapes.add(new Polygon(Polygon.box(600, 20)));
+  b.space = space;
+  return b;
+}
+
+// ---------------------------------------------------------------------------
+// Area & inertia computation (exercises __validate_area_inertia)
+// ---------------------------------------------------------------------------
+
+describe("Capsule — area and inertia computation", () => {
+  it("area should scale with radius squared", () => {
+    const b1 = new Body();
+    b1.shapes.add(new Capsule(100, 20));
+    const b2 = new Body();
+    b2.shapes.add(new Capsule(100, 40));
+    // Larger radius → larger area
+    expect(b2.shapes.at(0).area).toBeGreaterThan(b1.shapes.at(0).area);
+  });
+
+  it("area should scale with halfLength", () => {
+    const b1 = new Body();
+    b1.shapes.add(new Capsule(60, 40));
+    const b2 = new Body();
+    b2.shapes.add(new Capsule(100, 40));
+    expect(b2.shapes.at(0).area).toBeGreaterThan(b1.shapes.at(0).area);
+  });
+
+  it("inertia should be greater for larger capsule", () => {
+    const b1 = new Body();
+    b1.shapes.add(new Capsule(60, 20));
+    const b2 = new Body();
+    b2.shapes.add(new Capsule(120, 40));
+    expect(b2.shapes.at(0).inertia).toBeGreaterThan(b1.shapes.at(0).inertia);
+  });
+
+  it("capsule with localCOM offset should have larger inertia", () => {
+    const b1 = new Body();
+    b1.shapes.add(new Capsule(100, 40));
+    const b2 = new Body();
+    b2.shapes.add(new Capsule(100, 40, Vec2.weak(20, 0)));
+    expect(b2.shapes.at(0).inertia).toBeGreaterThan(b1.shapes.at(0).inertia);
+  });
+
+  it("capsule mass on body should be positive and scale with density", () => {
+    const body = new Body();
+    body.shapes.add(new Capsule(100, 40));
+    expect(body.mass).toBeGreaterThan(0);
+    expect(body.inertia).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Copy (exercises __copy)
+// ---------------------------------------------------------------------------
+
+describe("Capsule — copy", () => {
+  it("copying a body should produce capsule shape with same dimensions", () => {
+    const original = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    original.shapes.add(new Capsule(80, 30));
+    const copied = original.copy();
+    expect(copied.shapes.length).toBe(1);
+    const copiedShape = copied.shapes.at(0);
+    expect(copiedShape.isCapsule()).toBe(true);
+    const cap = copiedShape.castCapsule as Capsule;
+    expect(cap.radius).toBeCloseTo(15);
+    expect(cap.halfLength).toBeCloseTo(25);
+  });
+
+  it("copied capsule should be independent from original", () => {
+    const original = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    original.shapes.add(new Capsule(80, 30));
+    const copied = original.copy();
+    // Modify original — copy should not be affected
+    (original.shapes.at(0).castCapsule as Capsule).radius = 25;
+    const copiedCap = copied.shapes.at(0).castCapsule as Capsule;
+    expect(copiedCap.radius).toBeCloseTo(15);
+  });
+
+  it("copying a capsule with localCOM should preserve localCOM", () => {
+    const original = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    original.shapes.add(new Capsule(80, 30, Vec2.weak(10, 5)));
+    const copied = original.copy();
+    const cap = copied.shapes.at(0).castCapsule as Capsule;
+    expect(cap.localCOM.x).toBeCloseTo(10);
+    expect(cap.localCOM.y).toBeCloseTo(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// translateShapes / scaleShapes (exercises __translate, __scale)
+// ---------------------------------------------------------------------------
+
+describe("Capsule — translateShapes and scaleShapes", () => {
+  it("translateShapes should move capsule localCOM", () => {
+    const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    body.shapes.add(new Capsule(80, 30));
+    body.translateShapes(new Vec2(10, 5));
+    const cap = body.shapes.at(0).castCapsule as Capsule;
+    expect(cap.localCOM.x).toBeCloseTo(10);
+    expect(cap.localCOM.y).toBeCloseTo(5);
+  });
+
+  it("scaleShapes should resize capsule dimensions", () => {
+    const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    body.shapes.add(new Capsule(80, 30));
+    const originalRadius = (body.shapes.at(0).castCapsule as Capsule).radius;
+    body.scaleShapes(2, 2);
+    const cap = body.shapes.at(0).castCapsule as Capsule;
+    expect(cap.radius).toBeCloseTo(originalRadius * 2);
+  });
+
+  it("scaleShapes with negative factor should scale by absolute value", () => {
+    const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    body.shapes.add(new Capsule(80, 30));
+    const originalRadius = (body.shapes.at(0).castCapsule as Capsule).radius;
+    body.scaleShapes(-2, -2);
+    const cap = body.shapes.at(0).castCapsule as Capsule;
+    expect(cap.radius).toBeCloseTo(originalRadius * 2);
+  });
+
+  it("translateShapes on capsule with localCOM offset adds to offset", () => {
+    const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    body.shapes.add(new Capsule(80, 30, Vec2.weak(5, 3)));
+    body.translateShapes(new Vec2(10, 0));
+    const cap = body.shapes.at(0).castCapsule as Capsule;
+    expect(cap.localCOM.x).toBeCloseTo(15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotateShapes (exercises __rotate)
+// ---------------------------------------------------------------------------
+
+describe("Capsule — rotateShapes", () => {
+  it("rotateShapes should change AABB for rotated capsule", () => {
+    const space = new Space(new Vec2(0, 0));
+    const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    const cap = new Capsule(100, 20);
+    body.shapes.add(cap);
+    body.space = space;
+    step(space, 1);
+    const aabb1Before = cap.bounds;
+    const w1 = aabb1Before.width;
+
+    // Rotate body 90 degrees
+    body.rotation = Math.PI / 2;
+    step(space, 1);
+    const aabb1After = cap.bounds;
+    const w2 = aabb1After.width;
+
+    // After 90 degree rotation, width and height should swap
+    expect(Math.abs(w2 - w1)).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Angular drag (exercises __validate_angDrag via fluid simulation)
+// ---------------------------------------------------------------------------
+
+describe("Capsule — angular drag in fluid", () => {
+  it("capsule should experience angular drag in fluid", () => {
+    const space = new Space(new Vec2(0, 0));
+
+    // Create fluid body
+    const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+    const fluidShape = new Polygon(Polygon.box(1000, 1000));
+    fluidShape.fluidEnabled = true;
+    fluidShape.fluidProperties = new FluidProperties(1, 2);
+    fluidBody.shapes.add(fluidShape);
+    fluidBody.space = space;
+
+    // Capsule with angular velocity in fluid
+    const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    body.shapes.add(new Capsule(80, 30));
+    body.angularVel = 20;
+    body.space = space;
+
+    step(space, 60);
+    // Angular velocity should have decreased due to fluid drag
+    expect(Math.abs(body.angularVel)).toBeLessThan(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collision with rotated capsule (exercises AABB computation with rotation)
+// ---------------------------------------------------------------------------
+
+describe("Capsule — rotated body collisions", () => {
+  it("horizontal capsule should land on floor", () => {
+    const space = new Space(new Vec2(0, 500));
+    staticFloor(space, 300);
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Capsule(80, 20));
+    b.space = space;
+    step(space, 180);
+    expect(b.position.y).toBeLessThan(310);
+    expect(b.position.y).toBeGreaterThan(200);
+  });
+
+  it("vertical capsule (rotated 90°) should land on floor", () => {
+    const space = new Space(new Vec2(0, 500));
+    staticFloor(space, 300);
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Capsule(80, 20));
+    b.rotation = Math.PI / 2; // stand it vertically
+    b.space = space;
+    step(space, 180);
+    expect(b.position.y).toBeLessThan(310);
+    expect(b.position.y).toBeGreaterThan(200);
+  });
+
+  it("capsule vs circle should resolve correctly when rotated", () => {
+    const space = new Space(new Vec2(0, 500));
+    staticFloor(space, 300);
+    const capBody = new Body(BodyType.DYNAMIC, new Vec2(0, 100));
+    capBody.shapes.add(new Capsule(80, 20));
+    capBody.rotation = Math.PI / 4; // 45 degrees
+    capBody.space = space;
+
+    const circBody = new Body(BodyType.DYNAMIC, new Vec2(0, 50));
+    circBody.shapes.add(new Circle(15));
+    circBody.space = space;
+
+    step(space, 120);
+    // Both should settle
+    expect(capBody.position.y).toBeLessThan(310);
+    expect(circBody.position.y).toBeLessThan(310);
+  });
+
+  it("capsule vs capsule at different angles should collide", () => {
+    const space = new Space(new Vec2(0, 500));
+    staticFloor(space, 400);
+    const b1 = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b1.shapes.add(new Capsule(100, 20));
+    b1.space = space;
+
+    const b2 = new Body(BodyType.DYNAMIC, new Vec2(0, -60));
+    b2.shapes.add(new Capsule(100, 20));
+    b2.rotation = Math.PI / 2;
+    b2.space = space;
+
+    step(space, 180);
+    // Both should be above floor
+    expect(b1.position.y).toBeLessThan(410);
+    expect(b2.position.y).toBeLessThan(410);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SWEEP_AND_PRUNE with capsules
+// ---------------------------------------------------------------------------
+
+describe("Capsule — SWEEP_AND_PRUNE broadphase", () => {
+  it("capsule should collide correctly under SWEEP_AND_PRUNE", () => {
+    const space = new Space(new Vec2(0, 500), Broadphase.SWEEP_AND_PRUNE);
+    const floor = new Body(BodyType.STATIC, new Vec2(0, 300));
+    floor.shapes.add(new Polygon(Polygon.box(600, 20)));
+    floor.space = space;
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Capsule(80, 20));
+    b.space = space;
+
+    step(space, 180);
+    expect(b.position.y).toBeLessThan(310);
+    expect(b.position.y).toBeGreaterThan(200);
+  });
+
+  it("multiple capsules under SWEEP_AND_PRUNE should not cause errors", () => {
+    const space = new Space(new Vec2(0, 200), Broadphase.SWEEP_AND_PRUNE);
+    const floor = new Body(BodyType.STATIC, new Vec2(0, 200));
+    floor.shapes.add(new Polygon(Polygon.box(1000, 20)));
+    floor.space = space;
+
+    for (let i = 0; i < 8; i++) {
+      const b = new Body(BodyType.DYNAMIC, new Vec2(i * 40 - 160, -i * 30));
+      b.shapes.add(new Capsule(60, 20));
+      b.space = space;
+    }
+
+    expect(() => step(space, 120)).not.toThrow();
+    expect(space.bodies.length).toBe(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capsule changing radius/halfLength during simulation
+// ---------------------------------------------------------------------------
+
+describe("Capsule — property changes during simulation", () => {
+  it("should handle radius change on capsule in space (not in step)", () => {
+    const space = new Space(new Vec2(0, 100));
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    const cap = new Capsule(80, 20);
+    b.shapes.add(cap);
+    b.space = space;
+    step(space, 5);
+    // Can change radius between steps
+    cap.radius = 25;
+    step(space, 5);
+    expect(cap.radius).toBeCloseTo(25);
+    expect(b.mass).toBeGreaterThan(0);
+  });
+
+  it("should handle halfLength change on capsule in space (not in step)", () => {
+    const space = new Space(new Vec2(0, 100));
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    const cap = new Capsule(80, 20);
+    b.shapes.add(cap);
+    b.space = space;
+    step(space, 5);
+    cap.halfLength = 50;
+    step(space, 5);
+    expect(cap.halfLength).toBeCloseTo(50);
+  });
+});

--- a/tests/space/SweepAndPrune.integration.test.ts
+++ b/tests/space/SweepAndPrune.integration.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Integration tests specifically for the SWEEP_AND_PRUNE broadphase.
+ * Exercises ZPP_SweepPhase.ts code paths.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { Capsule } from "../../src/shape/Capsule";
+import { Broadphase } from "../../src/space/Broadphase";
+import { Ray } from "../../src/geom/Ray";
+import { AABB } from "../../src/geom/AABB";
+import { DistanceJoint } from "../../src/constraint/DistanceJoint";
+import { PivotJoint } from "../../src/constraint/PivotJoint";
+import { Compound } from "../../src/phys/Compound";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sap(gravity: Vec2 = new Vec2(0, 0)): Space {
+  return new Space(gravity, Broadphase.SWEEP_AND_PRUNE);
+}
+
+function step(space: Space, n: number, dt = 1 / 60): void {
+  for (let i = 0; i < n; i++) space.step(dt);
+}
+
+function dynamicCircle(x: number, y: number, radius = 10): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(radius));
+  return b;
+}
+
+function dynamicBox(x: number, y: number, w = 20, h = 20): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Polygon(Polygon.box(w, h)));
+  return b;
+}
+
+function staticBox(x: number, y: number, w = 500, h = 20): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(x, y));
+  b.shapes.add(new Polygon(Polygon.box(w, h)));
+  return b;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SWEEP_AND_PRUNE broadphase — basic setup", () => {
+  it("space should use SWEEP_AND_PRUNE when constructed with it", () => {
+    const space = sap();
+    expect(space.broadphase).toBe(Broadphase.SWEEP_AND_PRUNE);
+  });
+
+  it("should step empty space without errors", () => {
+    const space = sap();
+    expect(() => step(space, 5)).not.toThrow();
+    expect(space.timeStamp).toBe(5);
+  });
+
+  it("should add a body and step without errors", () => {
+    const space = sap(new Vec2(0, 100));
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    expect(() => step(space, 10)).not.toThrow();
+    expect(b.position.y).toBeGreaterThan(0);
+  });
+
+  it("should apply gravity under SWEEP_AND_PRUNE", () => {
+    const space = sap(new Vec2(0, 500));
+    const b = dynamicCircle(0, 0);
+    b.space = space;
+    step(space, 60);
+    expect(b.position.y).toBeGreaterThan(50);
+  });
+
+  it("static body should not move under SWEEP_AND_PRUNE gravity", () => {
+    const space = sap(new Vec2(0, 1000));
+    const b = staticBox(0, 100);
+    b.space = space;
+    step(space, 60);
+    expect(b.position.y).toBeCloseTo(100, 1);
+  });
+});
+
+describe("SWEEP_AND_PRUNE broadphase — collision detection", () => {
+  it("should resolve circle-polygon collision", () => {
+    const space = sap(new Vec2(0, 500));
+    const floor = staticBox(0, 200);
+    floor.space = space;
+    const ball = dynamicCircle(0, 0, 15);
+    ball.space = space;
+    step(space, 180);
+    expect(ball.position.y).toBeLessThan(200);
+    expect(ball.position.y).toBeGreaterThan(100);
+  });
+
+  it("should resolve polygon-polygon collision", () => {
+    const space = sap(new Vec2(0, 500));
+    const floor = staticBox(0, 200);
+    floor.space = space;
+    const box = dynamicBox(0, 0);
+    box.space = space;
+    step(space, 180);
+    expect(box.position.y).toBeLessThan(200);
+    expect(box.position.y).toBeGreaterThan(100);
+  });
+
+  it("should resolve circle-circle collision", () => {
+    const space = sap(new Vec2(0, 0));
+    const b1 = dynamicCircle(0, 0, 20);
+    const b2 = dynamicCircle(25, 0, 20);
+    b1.space = space;
+    b2.space = space;
+    step(space, 5);
+    // After collision resolution, bodies should be separated
+    const dx = b2.position.x - b1.position.x;
+    const dy = b2.position.y - b1.position.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    expect(dist).toBeGreaterThan(30);
+  });
+
+  it("should handle multiple bodies colliding simultaneously", () => {
+    const space = sap(new Vec2(0, 500));
+    const floor = staticBox(0, 200);
+    floor.space = space;
+    for (let i = 0; i < 5; i++) {
+      const b = dynamicCircle(i * 30 - 60, 0, 10);
+      b.space = space;
+    }
+    step(space, 180);
+    expect(space.bodies.length).toBe(6); // 5 circles + floor
+  });
+
+  it("should detect capsule-floor collision under SWEEP_AND_PRUNE", () => {
+    const space = sap(new Vec2(0, 500));
+    const floor = staticBox(0, 200);
+    floor.space = space;
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    b.shapes.add(new Capsule(40, 20));
+    b.space = space;
+    step(space, 180);
+    expect(b.position.y).toBeLessThan(200);
+    expect(b.position.y).toBeGreaterThan(100);
+  });
+});
+
+describe("SWEEP_AND_PRUNE broadphase — spatial queries", () => {
+  it("should find bodies via AABB query", () => {
+    const space = sap();
+    const b = dynamicCircle(50, 50, 10);
+    b.space = space;
+    step(space, 1);
+    const result = space.bodiesInAABB(new AABB(30, 30, 40, 40)) as any;
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should find bodies via circle query", () => {
+    const space = sap();
+    const b = dynamicCircle(100, 100, 10);
+    b.space = space;
+    step(space, 1);
+    const result = space.bodiesInCircle(new Vec2(100, 100), 20) as any;
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should find body under point", () => {
+    const space = sap();
+    const b = dynamicCircle(50, 50, 15);
+    b.space = space;
+    step(space, 1);
+    const result = space.bodiesUnderPoint(new Vec2(50, 50)) as any;
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should return empty for AABB query in empty region", () => {
+    const space = sap();
+    const b = dynamicCircle(0, 0, 10);
+    b.space = space;
+    step(space, 1);
+    const result = space.bodiesInAABB(new AABB(1000, 1000, 10, 10)) as any;
+    expect(result.length).toBe(0);
+  });
+
+  it("should find all bodies via large AABB query", () => {
+    const space = sap();
+    for (let i = 0; i < 5; i++) {
+      dynamicCircle(i * 50, 0, 10).space = space;
+    }
+    step(space, 1);
+    const result = space.bodiesInAABB(new AABB(-50, -50, 400, 100)) as any;
+    expect(result.length).toBe(5);
+  });
+
+  it("should raycast under SWEEP_AND_PRUNE", () => {
+    const space = sap();
+    const b = dynamicCircle(100, 0, 15);
+    b.space = space;
+    step(space, 1);
+    const ray = new Ray(new Vec2(0, 0), new Vec2(1, 0));
+    const result = space.rayCast(ray);
+    expect(result).not.toBeNull();
+  });
+
+  it("should rayMultiCast under SWEEP_AND_PRUNE", () => {
+    const space = sap();
+    dynamicCircle(100, 0, 15).space = space;
+    dynamicCircle(200, 0, 15).space = space;
+    step(space, 1);
+    const ray = new Ray(new Vec2(0, 0), new Vec2(1, 0));
+    const results = space.rayMultiCast(ray) as any;
+    expect(results.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("SWEEP_AND_PRUNE broadphase — body lifecycle", () => {
+  it("should remove body from broadphase when space is set to null", () => {
+    const space = sap();
+    const b = dynamicCircle(50, 50, 10);
+    b.space = space;
+    step(space, 1);
+    let result = space.bodiesInAABB(new AABB(30, 30, 40, 40)) as any;
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    b.space = null;
+    step(space, 1);
+    result = space.bodiesInAABB(new AABB(30, 30, 40, 40)) as any;
+    expect(result.length).toBe(0);
+  });
+
+  it("should update broadphase after body teleports", () => {
+    const space = sap();
+    const b = dynamicCircle(50, 50, 10);
+    b.space = space;
+    step(space, 1);
+    b.position.setxy(500, 500);
+    step(space, 1);
+    const oldRegion = space.bodiesInAABB(new AABB(30, 30, 40, 40)) as any;
+    expect(oldRegion.length).toBe(0);
+    const newRegion = space.bodiesInAABB(new AABB(480, 480, 40, 40)) as any;
+    expect(newRegion.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should handle clear() under SWEEP_AND_PRUNE", () => {
+    const space = sap(new Vec2(0, 100));
+    for (let i = 0; i < 5; i++) {
+      dynamicCircle(i * 30, 0).space = space;
+    }
+    step(space, 10);
+    space.clear();
+    expect(space.bodies.length).toBe(0);
+    // Should still work after clear
+    dynamicCircle(0, 0).space = space;
+    step(space, 5);
+    expect(space.bodies.length).toBe(1);
+  });
+
+  it("should handle rapid add/remove cycles", () => {
+    const space = sap();
+    for (let cycle = 0; cycle < 5; cycle++) {
+      const bodies: Body[] = [];
+      for (let i = 0; i < 10; i++) {
+        const b = dynamicCircle(i * 20, 0);
+        b.space = space;
+        bodies.push(b);
+      }
+      step(space, 2);
+      for (const b of bodies) b.space = null;
+      step(space, 1);
+    }
+    expect(space.bodies.length).toBe(0);
+  });
+});
+
+describe("SWEEP_AND_PRUNE broadphase — constraints", () => {
+  it("should simulate DistanceJoint under SWEEP_AND_PRUNE", () => {
+    const space = sap(new Vec2(0, 100));
+    const anchor = new Body(BodyType.STATIC, new Vec2(0, 0));
+    anchor.shapes.add(new Circle(5));
+    anchor.space = space;
+    const ball = dynamicCircle(0, 50);
+    ball.space = space;
+    const joint = new DistanceJoint(anchor, ball, new Vec2(0, 0), new Vec2(0, 0), 40, 60);
+    joint.space = space;
+    step(space, 120);
+    const dist = Math.sqrt(ball.position.x ** 2 + ball.position.y ** 2);
+    expect(dist).toBeLessThan(70);
+    expect(dist).toBeGreaterThan(30);
+  });
+
+  it("should simulate PivotJoint under SWEEP_AND_PRUNE", () => {
+    const space = sap(new Vec2(0, 100));
+    const anchor = new Body(BodyType.STATIC, new Vec2(0, 0));
+    anchor.shapes.add(new Circle(5));
+    anchor.space = space;
+    const bob = dynamicCircle(50, 0);
+    bob.space = space;
+    const joint = new PivotJoint(anchor, bob, new Vec2(0, 0), new Vec2(0, 0));
+    joint.space = space;
+    step(space, 120);
+    // Pivot keeps bob's origin near anchor
+    const dist = Math.sqrt(bob.position.x ** 2 + bob.position.y ** 2);
+    expect(dist).toBeLessThan(20);
+  });
+});
+
+describe("SWEEP_AND_PRUNE broadphase — compound bodies", () => {
+  it("should handle compound bodies under SWEEP_AND_PRUNE", () => {
+    const space = sap(new Vec2(0, 100));
+    const compound = new Compound();
+    const b1 = dynamicCircle(0, 0);
+    const b2 = dynamicCircle(30, 0);
+    compound.bodies.add(b1);
+    compound.bodies.add(b2);
+    compound.space = space;
+    step(space, 30);
+    expect((space.compounds as any).length).toBe(1);
+  });
+
+  it("should find compound bodies in spatial queries", () => {
+    const space = sap();
+    const compound = new Compound();
+    const b1 = dynamicCircle(10, 10, 10);
+    const b2 = dynamicCircle(60, 10, 10);
+    compound.bodies.add(b1);
+    compound.bodies.add(b2);
+    compound.space = space;
+    step(space, 1);
+    const result = space.bodiesInCircle(new Vec2(10, 10), 20) as any;
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("SWEEP_AND_PRUNE broadphase — stress tests", () => {
+  it("should handle 50 simultaneous bodies without errors", () => {
+    const space = sap(new Vec2(0, 100));
+    const floor = staticBox(0, 300, 2000, 20);
+    floor.space = space;
+    for (let i = 0; i < 50; i++) {
+      dynamicCircle(i * 10 - 250, -i * 5, 5).space = space;
+    }
+    expect(() => step(space, 60)).not.toThrow();
+    expect(space.bodies.length).toBe(51);
+  });
+
+  it("should handle bodies spread along X axis (sweep-friendly pattern)", () => {
+    const space = sap();
+    for (let i = 0; i < 20; i++) {
+      dynamicCircle(i * 40 - 400, 0, 5).space = space;
+    }
+    step(space, 1);
+    const result = space.bodiesInAABB(new AABB(-450, -20, 900, 40)) as any;
+    expect(result.length).toBe(20);
+  });
+});


### PR DESCRIPTION
New test files:
- tests/space/SweepAndPrune.integration.test.ts (27 tests)
  Exercises ZPP_SweepPhase.ts: 24.97% → 37.46%
- tests/phys/Body.dynamics.test.ts (30 tests)
  Covers impulse queries, force/torque, kinematicVel, sleep, connectedBodies
- tests/dynamics/Fluid.advanced.test.ts (13 tests)
  Covers buoyancy, fluid callbacks, buoyancyImpulse, dragImpulse, totalFluidImpulse
- tests/shape/Capsule.advanced.test.ts (22 tests)
  Exercises ZPP_Capsule.ts: 63.27% → 73.45%
  Covers area/inertia, copy, translateShapes, scaleShapes, rotated collisions,
  fluid angular drag, SWEEP_AND_PRUNE with capsules

Total: 3486 → 3578 tests (+92), coverage: 56.78% → 57.74%

https://claude.ai/code/session_015bNsfsGJwbeScDQZdyoLp3