### PR TITLE
P46: Hot-path optimization — deduplicate, pool bypass fix, O(1) pair removal, type narrowing

### DIFF
--- a/src/native/dynamics/ZPP_ColArbiter.ts
+++ b/src/native/dynamics/ZPP_ColArbiter.ts
@@ -89,7 +89,7 @@ export class ZPP_ColArbiter extends ZPP_Arbiter {
   surfacey = 0.0;
 
   // --- Instance: collision geometry ---
-  ptype: any = null;
+  ptype: number = 0;
   lnormx = 0.0;
   lnormy = 0.0;
   lproj = 0.0;
@@ -103,10 +103,10 @@ export class ZPP_ColArbiter extends ZPP_Arbiter {
   __ref_vertex = 0;
 
   // --- Instance: contact point cache ---
-  c1: any = null;
-  oc1: any = null;
-  c2: any = null;
-  oc2: any = null;
+  c1: ZPP_IContact = null as unknown as ZPP_IContact;
+  oc1: ZPP_Contact = null as unknown as ZPP_Contact;
+  c2: ZPP_IContact = null as unknown as ZPP_IContact;
+  oc2: ZPP_Contact = null as unknown as ZPP_Contact;
   hc2 = false;
   hpc2 = false;
 

--- a/src/native/geom/ZPP_Collide.ts
+++ b/src/native/geom/ZPP_Collide.ts
@@ -37,12 +37,12 @@ export class ZPP_Collide {
   /** Internal list for flow collision segments (ZNPList_ZPP_Vec2). */
   static flowsegs: any = null;
 
-  static circleContains(c: any, p: any) {
+  static circleContains(c: any, p: ZPP_Vec2) {
     const dx = p.x - c.worldCOMx;
     const dy = p.y - c.worldCOMy;
     return dx * dx + dy * dy < c.radius * c.radius;
   }
-  static polyContains(s: any, p: any) {
+  static polyContains(s: any, p: ZPP_Vec2) {
     let retvar;
     retvar = true;
     let cx_ite = s.edges.head;
@@ -1641,18 +1641,7 @@ export class ZPP_Collide {
                   const T = min2;
                   const cx = u2.x + (v4.x - u2.x) * T;
                   const cy = u2.y + (v4.y - u2.y) * T;
-                  let ret;
-                  if (ZPP_Vec2.zpp_pool == null) {
-                    ret = new ZPP_Vec2();
-                  } else {
-                    ret = ZPP_Vec2.zpp_pool;
-                    ZPP_Vec2.zpp_pool = ret.next;
-                    ret.next = null;
-                  }
-                  ret.weak = false;
-                  ret._immutable = false;
-                  ret.x = cx;
-                  ret.y = cy;
+                  const ret = ZPP_Vec2.get(cx, cy);
                   fst_vert = ret;
                   ZPP_Collide.flowpoly.add(fst_vert);
                   poly1 = true;
@@ -1754,18 +1743,7 @@ export class ZPP_Collide {
                     const T1 = min3;
                     const cx1 = u2.x + (v5.x - u2.x) * T1;
                     const cy1 = u2.y + (v5.y - u2.y) * T1;
-                    let ret1;
-                    if (ZPP_Vec2.zpp_pool == null) {
-                      ret1 = new ZPP_Vec2();
-                    } else {
-                      ret1 = ZPP_Vec2.zpp_pool;
-                      ZPP_Vec2.zpp_pool = ret1.next;
-                      ret1.next = null;
-                    }
-                    ret1.weak = false;
-                    ret1._immutable = false;
-                    ret1.x = cx1;
-                    ret1.y = cy1;
+                    const ret1 = ZPP_Vec2.get(cx1, cy1);
                     fst_vert = ret1;
                     ZPP_Collide.flowpoly.add(fst_vert);
                     poly1 = true;
@@ -1945,18 +1923,7 @@ export class ZPP_Collide {
                     break;
                   }
                   const tmp8 = ZPP_Collide.flowpoly;
-                  let ret2;
-                  if (ZPP_Vec2.zpp_pool == null) {
-                    ret2 = new ZPP_Vec2();
-                  } else {
-                    ret2 = ZPP_Vec2.zpp_pool;
-                    ZPP_Vec2.zpp_pool = ret2.next;
-                    ret2.next = null;
-                  }
-                  ret2.weak = false;
-                  ret2._immutable = false;
-                  ret2.x = cx2;
-                  ret2.y = cy2;
+                  const ret2 = ZPP_Vec2.get(cx2, cy2);
                   tmp8.add(ret2);
                   if (fst_vert == null) {
                     fst_vert = ZPP_Collide.flowpoly.head.elt;
@@ -2133,18 +2100,7 @@ export class ZPP_Collide {
                     break;
                   }
                   const tmp13 = ZPP_Collide.flowpoly;
-                  let ret3;
-                  if (ZPP_Vec2.zpp_pool == null) {
-                    ret3 = new ZPP_Vec2();
-                  } else {
-                    ret3 = ZPP_Vec2.zpp_pool;
-                    ZPP_Vec2.zpp_pool = ret3.next;
-                    ret3.next = null;
-                  }
-                  ret3.weak = false;
-                  ret3._immutable = false;
-                  ret3.x = cx3;
-                  ret3.y = cy3;
+                  const ret3 = ZPP_Vec2.get(cx3, cy3);
                   tmp13.add(ret3);
                   if (fst_vert == null) {
                     fst_vert = ZPP_Collide.flowpoly.head.elt;
@@ -2441,18 +2397,7 @@ export class ZPP_Collide {
                         break;
                       }
                       const tmp15 = ZPP_Collide.flowpoly;
-                      let ret4;
-                      if (ZPP_Vec2.zpp_pool == null) {
-                        ret4 = new ZPP_Vec2();
-                      } else {
-                        ret4 = ZPP_Vec2.zpp_pool;
-                        ZPP_Vec2.zpp_pool = ret4.next;
-                        ret4.next = null;
-                      }
-                      ret4.weak = false;
-                      ret4._immutable = false;
-                      ret4.x = cx4;
-                      ret4.y = cy4;
+                      const ret4 = ZPP_Vec2.get(cx4, cy4);
                       tmp15.add(ret4);
                       state = 2;
                     }
@@ -2496,18 +2441,7 @@ export class ZPP_Collide {
                             cx_ite12 = beg_ite2;
                             break;
                           }
-                          let ret5;
-                          if (ZPP_Vec2.zpp_pool == null) {
-                            ret5 = new ZPP_Vec2();
-                          } else {
-                            ret5 = ZPP_Vec2.zpp_pool;
-                            ZPP_Vec2.zpp_pool = ret5.next;
-                            ret5.next = null;
-                          }
-                          ret5.weak = false;
-                          ret5._immutable = false;
-                          ret5.x = cx5;
-                          ret5.y = cy5;
+                          const ret5 = ZPP_Vec2.get(cx5, cy5);
                           const cp = ret5;
                           ZPP_Collide.flowsegs.add(ZPP_Collide.flowpoly.head.elt);
                           ZPP_Collide.flowsegs.add(cp);
@@ -2561,18 +2495,7 @@ export class ZPP_Collide {
                               cx_ite12 = beg_ite2;
                               break;
                             }
-                            let ret6;
-                            if (ZPP_Vec2.zpp_pool == null) {
-                              ret6 = new ZPP_Vec2();
-                            } else {
-                              ret6 = ZPP_Vec2.zpp_pool;
-                              ZPP_Vec2.zpp_pool = ret6.next;
-                              ret6.next = null;
-                            }
-                            ret6.weak = false;
-                            ret6._immutable = false;
-                            ret6.x = cx6;
-                            ret6.y = cy6;
+                            const ret6 = ZPP_Vec2.get(cx6, cy6);
                             const cp1 = ret6;
                             if (ZPP_Collide.flowpoly.head != null) {
                               ZPP_Collide.flowsegs.add(ZPP_Collide.flowpoly.head.elt);
@@ -2589,18 +2512,7 @@ export class ZPP_Collide {
                               cx7 = u10.x + (v17.x - u10.x) * T7;
                               cy7 = u10.y + (v17.y - u10.y) * T7;
                               const tmp17 = ZPP_Collide.flowpoly;
-                              let ret7;
-                              if (ZPP_Vec2.zpp_pool == null) {
-                                ret7 = new ZPP_Vec2();
-                              } else {
-                                ret7 = ZPP_Vec2.zpp_pool;
-                                ZPP_Vec2.zpp_pool = ret7.next;
-                                ret7.next = null;
-                              }
-                              ret7.weak = false;
-                              ret7._immutable = false;
-                              ret7.x = cx7;
-                              ret7.y = cy7;
+                              const ret7 = ZPP_Vec2.get(cx7, cy7);
                               tmp17.add(ret7);
                             }
                           }
@@ -2646,18 +2558,7 @@ export class ZPP_Collide {
                             cx_ite12 = beg_ite2;
                             break;
                           }
-                          let ret8;
-                          if (ZPP_Vec2.zpp_pool == null) {
-                            ret8 = new ZPP_Vec2();
-                          } else {
-                            ret8 = ZPP_Vec2.zpp_pool;
-                            ZPP_Vec2.zpp_pool = ret8.next;
-                            ret8.next = null;
-                          }
-                          ret8.weak = false;
-                          ret8._immutable = false;
-                          ret8.x = cx8;
-                          ret8.y = cy8;
+                          const ret8 = ZPP_Vec2.get(cx8, cy8);
                           const cp2 = ret8;
                           ZPP_Collide.flowsegs.add(ZPP_Collide.flowpoly.head.elt);
                           ZPP_Collide.flowsegs.add(cp2);
@@ -2711,18 +2612,7 @@ export class ZPP_Collide {
                               cx_ite12 = beg_ite2;
                               break;
                             }
-                            let ret9;
-                            if (ZPP_Vec2.zpp_pool == null) {
-                              ret9 = new ZPP_Vec2();
-                            } else {
-                              ret9 = ZPP_Vec2.zpp_pool;
-                              ZPP_Vec2.zpp_pool = ret9.next;
-                              ret9.next = null;
-                            }
-                            ret9.weak = false;
-                            ret9._immutable = false;
-                            ret9.x = cx9;
-                            ret9.y = cy9;
+                            const ret9 = ZPP_Vec2.get(cx9, cy9);
                             const cp3 = ret9;
                             if (ZPP_Collide.flowpoly.head != null) {
                               ZPP_Collide.flowsegs.add(ZPP_Collide.flowpoly.head.elt);
@@ -2739,18 +2629,7 @@ export class ZPP_Collide {
                               cx10 = u10.x + (v18.x - u10.x) * T10;
                               cy10 = u10.y + (v18.y - u10.y) * T10;
                               const tmp19 = ZPP_Collide.flowpoly;
-                              let ret10;
-                              if (ZPP_Vec2.zpp_pool == null) {
-                                ret10 = new ZPP_Vec2();
-                              } else {
-                                ret10 = ZPP_Vec2.zpp_pool;
-                                ZPP_Vec2.zpp_pool = ret10.next;
-                                ret10.next = null;
-                              }
-                              ret10.weak = false;
-                              ret10._immutable = false;
-                              ret10.x = cx10;
-                              ret10.y = cy10;
+                              const ret10 = ZPP_Vec2.get(cx10, cy10);
                               tmp19.add(ret10);
                             }
                           }
@@ -2967,7 +2846,7 @@ export class ZPP_Collide {
   // ===========================================================================
 
   /** Point-in-capsule containment test. */
-  static capsuleContains(cap: any, p: any): boolean {
+  static capsuleContains(cap: any, p: ZPP_Vec2): boolean {
     const t = ZPP_Collide._closestT(cap.spine1x, cap.spine1y, cap.spine2x, cap.spine2y, p.x, p.y);
     const cx = cap.spine1x + t * (cap.spine2x - cap.spine1x);
     const cy = cap.spine1y + t * (cap.spine2y - cap.spine1y);
@@ -3071,8 +2950,8 @@ export class ZPP_Collide {
    * Create or reuse a contact in the arbiter's contact list.
    * Returns the contact, or null if creation failed.
    */
-  private static _getOrCreateContact(arb: any, hash: number, stamp: number): any {
-    let c: any = null;
+  private static _getOrCreateContact(arb: ZPP_ColArbiter, hash: number, stamp: number): ZPP_Contact {
+    let c: ZPP_Contact | null = null;
     let cx_ite = arb.contacts.next;
     while (cx_ite != null) {
       if (hash == cx_ite.hash) {
@@ -3116,7 +2995,7 @@ export class ZPP_Collide {
   static _capsuleContactCollide(
     s1: ZPP_Shape,
     s2: ZPP_Shape,
-    arb: any,
+    arb: ZPP_ColArbiter,
     rev: boolean,
     napeNs: any,
   ): boolean {
@@ -3135,7 +3014,7 @@ export class ZPP_Collide {
   }
 
   /** Circle vs Capsule contact generation. */
-  static _circleCapsuleContact(circ: any, cap: any, arb: any, rev: boolean, napeNs: any): boolean {
+  static _circleCapsuleContact(circ: any, cap: any, arb: ZPP_ColArbiter, rev: boolean, napeNs: any): boolean {
     // Find closest point on capsule spine to circle center
     const t = ZPP_Collide._closestT(
       cap.spine1x,

--- a/src/native/geom/ZPP_Collide.ts
+++ b/src/native/geom/ZPP_Collide.ts
@@ -2950,7 +2950,11 @@ export class ZPP_Collide {
    * Create or reuse a contact in the arbiter's contact list.
    * Returns the contact, or null if creation failed.
    */
-  private static _getOrCreateContact(arb: ZPP_ColArbiter, hash: number, stamp: number): ZPP_Contact {
+  private static _getOrCreateContact(
+    arb: ZPP_ColArbiter,
+    hash: number,
+    stamp: number,
+  ): ZPP_Contact {
     let c: ZPP_Contact | null = null;
     let cx_ite = arb.contacts.next;
     while (cx_ite != null) {
@@ -3014,7 +3018,13 @@ export class ZPP_Collide {
   }
 
   /** Circle vs Capsule contact generation. */
-  static _circleCapsuleContact(circ: any, cap: any, arb: ZPP_ColArbiter, rev: boolean, napeNs: any): boolean {
+  static _circleCapsuleContact(
+    circ: any,
+    cap: any,
+    arb: ZPP_ColArbiter,
+    rev: boolean,
+    napeNs: any,
+  ): boolean {
     // Find closest point on capsule spine to circle center
     const t = ZPP_Collide._closestT(
       cap.spine1x,
@@ -3282,7 +3292,13 @@ export class ZPP_Collide {
   }
 
   /** Polygon vs Capsule contact generation. */
-  static _polyCapsuleContact(poly: any, cap: any, arb: ZPP_ColArbiter, rev: boolean, napeNs: any): boolean {
+  static _polyCapsuleContact(
+    poly: any,
+    cap: any,
+    arb: ZPP_ColArbiter,
+    rev: boolean,
+    napeNs: any,
+  ): boolean {
     // SAT phase 1: polygon edge normals vs capsule
     // For each edge, the minimum separation is min(proj(spine1), proj(spine2)) - edge.gprojection - cap.radius
     let bestDist = -1e100;

--- a/src/native/geom/ZPP_Collide.ts
+++ b/src/native/geom/ZPP_Collide.ts
@@ -3034,7 +3034,7 @@ export class ZPP_Collide {
 
     if (distSqr > minDist * minDist) return false;
 
-    let co: any;
+    let co: ZPP_Contact;
     if (distSqr < napeNs.Config.epsilon * napeNs.Config.epsilon) {
       // Overlapping centers
       const cpx = (circ.worldCOMx + cx) * 0.5;
@@ -3094,7 +3094,7 @@ export class ZPP_Collide {
   static _capsuleCapsuleContact(
     cap1: any,
     cap2: any,
-    arb: any,
+    arb: ZPP_ColArbiter,
     rev: boolean,
     napeNs: any,
   ): boolean {
@@ -3282,7 +3282,7 @@ export class ZPP_Collide {
   }
 
   /** Polygon vs Capsule contact generation. */
-  static _polyCapsuleContact(poly: any, cap: any, arb: any, rev: boolean, napeNs: any): boolean {
+  static _polyCapsuleContact(poly: any, cap: any, arb: ZPP_ColArbiter, rev: boolean, napeNs: any): boolean {
     // SAT phase 1: polygon edge normals vs capsule
     // For each edge, the minimum separation is min(proj(spine1), proj(spine2)) - edge.gprojection - cap.radius
     let bestDist = -1e100;
@@ -3638,7 +3638,7 @@ export class ZPP_Collide {
 
     if (other.type == 2) {
       // capsule-capsule fluid: simple overlap estimation
-      const cap2 = other.type == 2 ? (other as any).capsule : other;
+      const cap2 = other.capsule;
       const [t1, t2] = ZPP_Collide._closestTT(
         cap.spine1x,
         cap.spine1y,
@@ -3670,7 +3670,7 @@ export class ZPP_Collide {
     // and approximate overlap
     if (other.type == 0) {
       // capsule-circle fluid
-      const circ = other.circle || (other as any).circle;
+      const circ = other.circle;
       const t = ZPP_Collide._closestT(
         cap.spine1x,
         cap.spine1y,
@@ -3696,7 +3696,7 @@ export class ZPP_Collide {
 
     // capsule-polygon fluid: simplified
     // Test if capsule overlaps polygon using SAT, estimate overlap area
-    const poly = other.polygon || (other as any).polygon;
+    const poly = other.polygon;
     let minPen = 1e100;
     let penNx = 0,
       penNy = 0;

--- a/src/native/geom/ZPP_SweepDistance.ts
+++ b/src/native/geom/ZPP_SweepDistance.ts
@@ -2338,33 +2338,9 @@ export class ZPP_SweepDistance {
   }
   static distanceBody(b1: ZPP_Body, b2: ZPP_Body, w1: ZPP_Vec2, w2: ZPP_Vec2) {
     const napeNs = getNape();
-    let t1;
-    if (ZPP_Vec2.zpp_pool == null) {
-      t1 = new ZPP_Vec2();
-    } else {
-      t1 = ZPP_Vec2.zpp_pool;
-      ZPP_Vec2.zpp_pool = t1.next;
-      t1.next = null;
-    }
-    t1.weak = false;
-    let t2;
-    if (ZPP_Vec2.zpp_pool == null) {
-      t2 = new ZPP_Vec2();
-    } else {
-      t2 = ZPP_Vec2.zpp_pool;
-      ZPP_Vec2.zpp_pool = t2.next;
-      t2.next = null;
-    }
-    t2.weak = false;
-    let ax;
-    if (ZPP_Vec2.zpp_pool == null) {
-      ax = new ZPP_Vec2();
-    } else {
-      ax = ZPP_Vec2.zpp_pool;
-      ZPP_Vec2.zpp_pool = ax.next;
-      ax.next = null;
-    }
-    ax.weak = false;
+    const t1 = ZPP_Vec2.get(0, 0);
+    const t2 = ZPP_Vec2.get(0, 0);
+    const ax = ZPP_Vec2.get(0, 0);
     let min = 1e100;
     let cx_ite = b1.shapes.head;
     while (cx_ite != null) {

--- a/src/native/geom/ZPP_ToiEvent.ts
+++ b/src/native/geom/ZPP_ToiEvent.ts
@@ -33,9 +33,9 @@ export class ZPP_ToiEvent {
   kinematic: boolean = false;
 
   constructor() {
-    this.c1 = new ZPP_Vec2();
-    this.c2 = new ZPP_Vec2();
-    this.axis = new ZPP_Vec2();
+    this.c1 = ZPP_Vec2.get(0, 0);
+    this.c2 = ZPP_Vec2.get(0, 0);
+    this.axis = ZPP_Vec2.get(0, 0);
   }
 
   // --- Pool methods ---

--- a/src/native/phys/ZPP_Body.ts
+++ b/src/native/phys/ZPP_Body.ts
@@ -560,7 +560,7 @@ export class ZPP_Body {
     this.zip_worldCOM = true;
   }
 
-  pos_invalidate(pos: any): void {
+  pos_invalidate(pos: ZPP_Vec2): void {
     this.immutable_midstep("Body::position");
     if (this.type === 1 && this.space != null) {
       throw new Error("Error: Cannot move a static object once inside a Space");
@@ -578,7 +578,7 @@ export class ZPP_Body {
     this.wrap_pos.zpp_inner.y = this.posy;
   }
 
-  vel_invalidate(vel: any): void {
+  vel_invalidate(vel: ZPP_Vec2): void {
     if (this.type === 1) {
       throw new Error("Error: Static body cannot have its velocity set.");
     }
@@ -592,7 +592,7 @@ export class ZPP_Body {
     this.wrap_vel.zpp_inner.y = this.vely;
   }
 
-  kinvel_invalidate(vel: any): void {
+  kinvel_invalidate(vel: ZPP_Vec2): void {
     this.kinvelx = vel.x;
     this.kinvely = vel.y;
     this.wake();
@@ -603,7 +603,7 @@ export class ZPP_Body {
     this.wrap_kinvel.zpp_inner.y = this.kinvely;
   }
 
-  svel_invalidate(vel: any): void {
+  svel_invalidate(vel: ZPP_Vec2): void {
     this.svelx = vel.x;
     this.svely = vel.y;
     this.wake();
@@ -614,7 +614,7 @@ export class ZPP_Body {
     this.wrap_svel.zpp_inner.y = this.svely;
   }
 
-  force_invalidate(force: any): void {
+  force_invalidate(force: ZPP_Vec2): void {
     if (this.type !== 2) {
       throw new Error("Error: Non-dynamic body cannot have force applied.");
     }
@@ -633,7 +633,7 @@ export class ZPP_Body {
   private _setupVec2Wrapper(
     x: number,
     y: number,
-    _invalidateFn: ((vec: any) => void) | null,
+    _invalidateFn: ((vec: ZPP_Vec2) => void) | null,
     _validateFn: (() => void) | null,
   ): any {
     const nape = ZPP_Body._nape;
@@ -1326,7 +1326,7 @@ export class ZPP_Body {
     s.zpp_inner.removedFromBody();
   }
 
-  shapes_invalidate(_param: any): void {
+  shapes_invalidate(_param: unknown): void {
     this.invalidate_shapes();
   }
 

--- a/src/native/phys/ZPP_Body.ts
+++ b/src/native/phys/ZPP_Body.ts
@@ -30,7 +30,7 @@ export class ZPP_Body {
   static bodyset: any = null;
   static cur_graph_depth: number = 0;
 
-  static bodysetlt(a: any, b: any): boolean {
+  static bodysetlt(a: ZPP_Body, b: ZPP_Body): boolean {
     return a.id < b.id;
   }
 
@@ -55,9 +55,9 @@ export class ZPP_Body {
   // --- ZPP_Interactor fields (base class, not extracted) ---
   outer_i: any = null;
   id: number = 0;
-  userData: any = null;
+  userData: Record<string, unknown> | null = null;
   ishape: any = null;
-  ibody: any = null;
+  ibody: ZPP_Body | null = null;
   icompound: any = null;
   wrap_cbTypes: any = null;
   cbSet: any = null;

--- a/src/native/space/ZPP_AABBPair.ts
+++ b/src/native/space/ZPP_AABBPair.ts
@@ -22,6 +22,8 @@ export class ZPP_AABBPair {
   di = 0;
   arb: any = null; // ZPP_Arbiter — circular
   next: ZPP_AABBPair | null = null;
+  /** Previous pointer in the global broadphase pairs list (doubly-linked for O(1) removal). */
+  gprev: ZPP_AABBPair | null = null;
 
   // ========== Pool callbacks ==========
 
@@ -30,5 +32,6 @@ export class ZPP_AABBPair {
   free(): void {
     this.n1 = this.n2 = null;
     this.sleeping = false;
+    this.gprev = null;
   }
 }

--- a/src/native/space/ZPP_DynAABBPhase.ts
+++ b/src/native/space/ZPP_DynAABBPhase.ts
@@ -3707,7 +3707,14 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== shapesInCircle ==========
 
-  shapesInCircle(x: number, y: number, r: number, containment: boolean, filter: any, output: any): any {
+  shapesInCircle(
+    x: number,
+    y: number,
+    r: number,
+    containment: boolean,
+    filter: any,
+    output: any,
+  ): any {
     this.sync_broadphase();
     (this as any).updateCircShape(x, y, r);
     const ab = this.circShape.zpp_inner.aabb;
@@ -3805,7 +3812,14 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== bodiesInCircle ==========
 
-  bodiesInCircle(x: number, y: number, r: number, containment: boolean, filter: any, output: any): any {
+  bodiesInCircle(
+    x: number,
+    y: number,
+    r: number,
+    containment: boolean,
+    filter: any,
+    output: any,
+  ): any {
     this.sync_broadphase();
     (this as any).updateCircShape(x, y, r);
     const ab = this.circShape.zpp_inner.aabb;

--- a/src/native/space/ZPP_DynAABBPhase.ts
+++ b/src/native/space/ZPP_DynAABBPhase.ts
@@ -46,9 +46,31 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
     this.dtree = new ZPP_AABBTree();
   }
 
+  /** Prepend a pair to the global doubly-linked pairs list. */
+  private _linkPair(p: ZPP_AABBPair): void {
+    p.gprev = null;
+    p.next = this.pairs;
+    if (this.pairs != null) this.pairs.gprev = p;
+    this.pairs = p;
+  }
+
+  /** Unlink a pair from the global doubly-linked pairs list. */
+  private _unlinkPair(p: ZPP_AABBPair): void {
+    if (p.gprev != null) {
+      p.gprev.next = p.next;
+    } else {
+      this.pairs = p.next;
+    }
+    if (p.next != null) {
+      p.next.gprev = p.gprev;
+    }
+    p.gprev = null;
+    p.next = null;
+  }
+
   // ========== dyn ==========
 
-  dyn(shape: any): any {
+  dyn(shape: any): boolean {
     if (shape.body.type == 1) {
       return false;
     } else {
@@ -58,7 +80,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== __insert ==========
 
-  __insert(shape: any): any {
+  __insert(shape: any): void {
     let node;
     if (ZPP_AABBNode.zpp_pool == null) {
       node = new ZPP_AABBNode();
@@ -87,7 +109,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== __remove ==========
 
-  __remove(shape: any): any {
+  __remove(shape: any): void {
     const node = shape.node;
     if (!node.first_sync) {
       if (node.dyn) {
@@ -133,49 +155,25 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
       cur1!.mnext = null;
       node.moved = false;
     }
-    let pre2 = null;
-    let cur2 = this.pairs;
-    while (cur2 != null) {
-      const nxt = cur2.next;
-      if (cur2.n1 == node || cur2.n2 == node) {
-        if (pre2 == null) {
-          this.pairs = nxt;
-        } else {
-          pre2.next = nxt;
-        }
-        if (cur2.arb != null) {
-          cur2.arb.pair = null;
-        }
-        cur2.arb = null;
-        cur2.n1.shape.pairs.remove(cur2);
-        cur2.n2.shape.pairs.remove(cur2);
-        const o = cur2;
-        o.n1 = o.n2 = null;
-        o.sleeping = false;
-        o.next = ZPP_AABBPair.zpp_pool;
-        ZPP_AABBPair.zpp_pool = o;
-        cur2 = nxt;
-        continue;
-      }
-      pre2 = cur2;
-      cur2 = nxt;
-    }
     while (shape.pairs.head != null) {
-      const cur3 = shape.pairs.pop_unsafe();
-      if (cur3.n1 == node) {
-        cur3.n2.shape.pairs.remove(cur3);
+      const pair = shape.pairs.pop_unsafe();
+      if (!pair.sleeping) {
+        this._unlinkPair(pair);
+      }
+      if (pair.n1 == node) {
+        pair.n2.shape.pairs.remove(pair);
       } else {
-        cur3.n1.shape.pairs.remove(cur3);
+        pair.n1.shape.pairs.remove(pair);
       }
-      if (cur3.arb != null) {
-        cur3.arb.pair = null;
+      if (pair.arb != null) {
+        pair.arb.pair = null;
       }
-      cur3.arb = null;
-      const o1 = cur3;
-      o1.n1 = o1.n2 = null;
-      o1.sleeping = false;
-      o1.next = ZPP_AABBPair.zpp_pool;
-      ZPP_AABBPair.zpp_pool = o1;
+      pair.arb = null;
+      pair.n1 = pair.n2 = null;
+      pair.sleeping = false;
+      pair.gprev = null;
+      pair.next = ZPP_AABBPair.zpp_pool;
+      ZPP_AABBPair.zpp_pool = pair;
     }
     const o2 = node;
     o2.height = -1;
@@ -199,7 +197,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== __sync ==========
 
-  __sync(shape: any): any {
+  __sync(shape: any): void {
     const node = shape.node;
     if (!node.synced) {
       if (!this.space.continuous) {
@@ -370,7 +368,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== sync_broadphase ==========
 
-  sync_broadphase(): any {
+  sync_broadphase(): void {
     this.space.validation();
     if (this.syncs != null) {
       if (this.moves == null) {
@@ -1691,7 +1689,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== broadphase ==========
 
-  broadphase(space: any, discrete: any): any {
+  broadphase(space: any, discrete: boolean): void {
     let node = this.syncs;
     while (node != null) {
       const shape = node.shape;
@@ -2393,8 +2391,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
               if (p1 != null) {
                 if (p1.sleeping) {
                   p1.sleeping = false;
-                  p1.next = this.pairs;
-                  this.pairs = p1;
+                  this._linkPair(p1);
                   p1.first = true;
                 }
                 continue;
@@ -2410,8 +2407,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
               p1.n2 = node3;
               p1.id = id;
               p1.di = di;
-              p1.next = this.pairs;
-              this.pairs = p1;
+              this._linkPair(p1);
               p1.first = true;
               const _this35 = lshape.pairs;
               let ret2;
@@ -2509,8 +2505,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
               if (p2 != null) {
                 if (p2.sleeping) {
                   p2.sleeping = false;
-                  p2.next = this.pairs;
-                  this.pairs = p2;
+                  this._linkPair(p2);
                   p2.first = true;
                 }
                 continue;
@@ -2526,8 +2521,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
               p2.n2 = node4;
               p2.id = id1;
               p2.di = di1;
-              p2.next = this.pairs;
-              this.pairs = p2;
+              this._linkPair(p2);
               p2.first = true;
               const _this37 = lshape.pairs;
               let ret5;
@@ -2639,8 +2633,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
               if (p3 != null) {
                 if (p3.sleeping) {
                   p3.sleeping = false;
-                  p3.next = this.pairs;
-                  this.pairs = p3;
+                  this._linkPair(p3);
                   p3.first = true;
                 }
                 continue;
@@ -2656,8 +2649,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
               p3.n2 = node5;
               p3.id = id2;
               p3.di = di2;
-              p3.next = this.pairs;
-              this.pairs = p3;
+              this._linkPair(p3);
               p3.first = true;
               const _this39 = lshape1.pairs;
               let ret9;
@@ -2755,8 +2747,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
               if (p4 != null) {
                 if (p4.sleeping) {
                   p4.sleeping = false;
-                  p4.next = this.pairs;
-                  this.pairs = p4;
+                  this._linkPair(p4);
                   p4.first = true;
                 }
                 continue;
@@ -2772,8 +2763,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
               p4.n2 = node6;
               p4.id = id3;
               p4.di = di3;
-              p4.next = this.pairs;
-              this.pairs = p4;
+              this._linkPair(p4);
               p4.first = true;
               const _this41 = lshape1.pairs;
               let ret12;
@@ -2827,7 +2817,6 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
         }
       }
     }
-    let pre = null;
     let cur = this.pairs;
     while (cur != null) {
       let tmp;
@@ -2844,93 +2833,19 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
         tmp = false;
       }
       if (tmp) {
-        if (pre == null) {
-          this.pairs = cur.next;
-        } else {
-          pre.next = cur.next;
-        }
-        const _this44 = cur.n1.shape.pairs;
-        let pre1 = null;
-        let cur1 = _this44.head;
-        let ret14 = false;
-        while (cur1 != null) {
-          if (cur1.elt == cur) {
-            let old;
-            let ret15;
-            if (pre1 == null) {
-              old = _this44.head;
-              ret15 = old.next;
-              _this44.head = ret15;
-              if (_this44.head == null) {
-                _this44.pushmod = true;
-              }
-            } else {
-              old = pre1.next;
-              ret15 = old.next;
-              pre1.next = ret15;
-              if (ret15 == null) {
-                _this44.pushmod = true;
-              }
-            }
-            const o4 = old;
-            o4.elt = null;
-            o4.next = ZPP_DynAABBPhase._zpp.util.ZNPNode_ZPP_AABBPair.zpp_pool;
-            ZPP_DynAABBPhase._zpp.util.ZNPNode_ZPP_AABBPair.zpp_pool = o4;
-            _this44.modified = true;
-            _this44.length--;
-            _this44.pushmod = true;
-            ret14 = true;
-            break;
-          }
-          pre1 = cur1;
-          cur1 = cur1.next;
-        }
-        const _this45 = cur.n2.shape.pairs;
-        let pre2 = null;
-        let cur2 = _this45.head;
-        let ret16 = false;
-        while (cur2 != null) {
-          if (cur2.elt == cur) {
-            let old1;
-            let ret17;
-            if (pre2 == null) {
-              old1 = _this45.head;
-              ret17 = old1.next;
-              _this45.head = ret17;
-              if (_this45.head == null) {
-                _this45.pushmod = true;
-              }
-            } else {
-              old1 = pre2.next;
-              ret17 = old1.next;
-              pre2.next = ret17;
-              if (ret17 == null) {
-                _this45.pushmod = true;
-              }
-            }
-            const o5 = old1;
-            o5.elt = null;
-            o5.next = ZPP_DynAABBPhase._zpp.util.ZNPNode_ZPP_AABBPair.zpp_pool;
-            ZPP_DynAABBPhase._zpp.util.ZNPNode_ZPP_AABBPair.zpp_pool = o5;
-            _this45.modified = true;
-            _this45.length--;
-            _this45.pushmod = true;
-            ret16 = true;
-            break;
-          }
-          pre2 = cur2;
-          cur2 = cur2.next;
-        }
         const nxt = cur.next;
+        this._unlinkPair(cur);
+        cur.n1.shape.pairs.remove(cur);
+        cur.n2.shape.pairs.remove(cur);
         if (cur.arb != null) {
           cur.arb.pair = null;
         }
         cur.arb = null;
-        const o6 = cur;
-        o6.n1 = o6.n2 = null;
-        o6.sleeping = false;
-        o6.next = ZPP_AABBPair.zpp_pool;
-        ZPP_AABBPair.zpp_pool = o6;
+        cur.n1 = cur.n2 = null;
+        cur.sleeping = false;
+        cur.gprev = null;
+        cur.next = ZPP_AABBPair.zpp_pool;
+        ZPP_AABBPair.zpp_pool = cur;
         cur = nxt;
         continue;
       }
@@ -2944,12 +2859,9 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
           (b23.component.sleeping || b23.type == 1)
         ) {
           cur.sleeping = true;
-          if (pre == null) {
-            this.pairs = cur.next;
-          } else {
-            pre.next = cur.next;
-          }
-          cur = cur.next;
+          const sleepNext = cur.next;
+          this._unlinkPair(cur);
+          cur = sleepNext;
           continue;
         }
       }
@@ -2982,14 +2894,13 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
           cur.arb.pair = cur;
         }
       }
-      pre = cur;
       cur = cur.next;
     }
   }
 
   // ========== clear ==========
 
-  clear(): any {
+  clear(): void {
     while (this.syncs != null) {
       const next = this.syncs.snext;
       this.syncs.snext = null;
@@ -3012,89 +2923,18 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
     }
     while (this.pairs != null) {
       const nxt = this.pairs.next;
-      if (this.pairs.arb != null) {
-        this.pairs.arb.pair = null;
+      const p = this.pairs;
+      if (p.arb != null) {
+        p.arb.pair = null;
       }
-      this.pairs.arb = null;
-      const _this = this.pairs.n1.shape.pairs;
-      const obj = this.pairs;
-      let pre = null;
-      let cur = _this.head;
-      let ret = false;
-      while (cur != null) {
-        if (cur.elt == obj) {
-          let old;
-          let ret1;
-          if (pre == null) {
-            old = _this.head;
-            ret1 = old.next;
-            _this.head = ret1;
-            if (_this.head == null) {
-              _this.pushmod = true;
-            }
-          } else {
-            old = pre.next;
-            ret1 = old.next;
-            pre.next = ret1;
-            if (ret1 == null) {
-              _this.pushmod = true;
-            }
-          }
-          const o = old;
-          o.elt = null;
-          o.next = ZPP_DynAABBPhase._zpp.util.ZNPNode_ZPP_AABBPair.zpp_pool;
-          ZPP_DynAABBPhase._zpp.util.ZNPNode_ZPP_AABBPair.zpp_pool = o;
-          _this.modified = true;
-          _this.length--;
-          _this.pushmod = true;
-          ret = true;
-          break;
-        }
-        pre = cur;
-        cur = cur.next;
-      }
-      const _this1 = this.pairs.n2.shape.pairs;
-      const obj1 = this.pairs;
-      let pre1 = null;
-      let cur1 = _this1.head;
-      let ret2 = false;
-      while (cur1 != null) {
-        if (cur1.elt == obj1) {
-          let old1;
-          let ret3;
-          if (pre1 == null) {
-            old1 = _this1.head;
-            ret3 = old1.next;
-            _this1.head = ret3;
-            if (_this1.head == null) {
-              _this1.pushmod = true;
-            }
-          } else {
-            old1 = pre1.next;
-            ret3 = old1.next;
-            pre1.next = ret3;
-            if (ret3 == null) {
-              _this1.pushmod = true;
-            }
-          }
-          const o1 = old1;
-          o1.elt = null;
-          o1.next = ZPP_DynAABBPhase._zpp.util.ZNPNode_ZPP_AABBPair.zpp_pool;
-          ZPP_DynAABBPhase._zpp.util.ZNPNode_ZPP_AABBPair.zpp_pool = o1;
-          _this1.modified = true;
-          _this1.length--;
-          _this1.pushmod = true;
-          ret2 = true;
-          break;
-        }
-        pre1 = cur1;
-        cur1 = cur1.next;
-      }
-      const o2 = this.pairs;
-      o2.n1 = o2.n2 = null;
-      o2.sleeping = false;
-      o2.next = ZPP_AABBPair.zpp_pool;
-      ZPP_AABBPair.zpp_pool = o2;
+      p.arb = null;
+      p.n1.shape.pairs.remove(p);
+      p.n2.shape.pairs.remove(p);
+      p.n1 = p.n2 = null;
+      p.sleeping = false;
+      p.gprev = null;
+      p.next = ZPP_AABBPair.zpp_pool;
+      ZPP_AABBPair.zpp_pool = p;
       this.pairs = nxt;
     }
     this.dtree.clear();
@@ -3103,7 +2943,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== shapesUnderPoint ==========
 
-  shapesUnderPoint(x: any, y: any, filter: any, output: any): any {
+  shapesUnderPoint(x: number, y: number, filter: any, output: any): any {
     this.sync_broadphase();
     let ret;
     if (ZPP_Vec2.zpp_pool == null) {
@@ -3212,7 +3052,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== bodiesUnderPoint ==========
 
-  bodiesUnderPoint(x: any, y: any, filter: any, output: any): any {
+  bodiesUnderPoint(x: number, y: number, filter: any, output: any): any {
     this.sync_broadphase();
     let ret;
     if (ZPP_Vec2.zpp_pool == null) {
@@ -3327,7 +3167,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== shapesInAABB ==========
 
-  shapesInAABB(aabb: any, strict: any, containment: any, filter: any, output: any): any {
+  shapesInAABB(aabb: any, strict: boolean, containment: boolean, filter: any, output: any): any {
     this.sync_broadphase();
     (this as any).updateAABBShape(aabb);
     const ab = this.aabbShape.zpp_inner.aabb;
@@ -3575,7 +3415,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== bodiesInAABB ==========
 
-  bodiesInAABB(aabb: any, strict: any, containment: any, filter: any, output: any): any {
+  bodiesInAABB(aabb: any, strict: boolean, containment: boolean, filter: any, output: any): any {
     this.sync_broadphase();
     (this as any).updateAABBShape(aabb);
     const ab = this.aabbShape.zpp_inner.aabb;
@@ -3867,7 +3707,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== shapesInCircle ==========
 
-  shapesInCircle(x: any, y: any, r: any, containment: any, filter: any, output: any): any {
+  shapesInCircle(x: number, y: number, r: number, containment: boolean, filter: any, output: any): any {
     this.sync_broadphase();
     (this as any).updateCircShape(x, y, r);
     const ab = this.circShape.zpp_inner.aabb;

--- a/src/native/space/ZPP_DynAABBPhase.ts
+++ b/src/native/space/ZPP_DynAABBPhase.ts
@@ -3805,7 +3805,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== bodiesInCircle ==========
 
-  bodiesInCircle(x: any, y: any, r: any, containment: any, filter: any, output: any): any {
+  bodiesInCircle(x: number, y: number, r: number, containment: boolean, filter: any, output: any): any {
     this.sync_broadphase();
     (this as any).updateCircShape(x, y, r);
     const ab = this.circShape.zpp_inner.aabb;
@@ -3927,7 +3927,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== shapesInShape ==========
 
-  shapesInShape(shp: any, containment: any, filter: any, output: any): any {
+  shapesInShape(shp: any, containment: boolean, filter: any, output: any): any {
     this.sync_broadphase();
     (this as any).validateShape(shp);
     const ab = shp.aabb;
@@ -4025,7 +4025,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== bodiesInShape ==========
 
-  bodiesInShape(shp: any, containment: any, filter: any, output: any): any {
+  bodiesInShape(shp: any, containment: boolean, filter: any, output: any): any {
     this.sync_broadphase();
     (this as any).validateShape(shp);
     const ab = shp.aabb;
@@ -4141,7 +4141,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== rayCast ==========
 
-  rayCast(ray: any, inner: any, filter: any): any {
+  rayCast(ray: any, inner: boolean, filter: any): any {
     if (this.openlist == null) {
       this.openlist = new ZPP_DynAABBPhase._zpp.util.ZNPList_ZPP_AABBNode();
     }
@@ -4351,7 +4351,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
 
   // ========== rayMultiCast ==========
 
-  rayMultiCast(ray: any, inner: any, filter: any, output: any): any {
+  rayMultiCast(ray: any, inner: boolean, filter: any, output: any): any {
     if (this.openlist == null) {
       this.openlist = new ZPP_DynAABBPhase._zpp.util.ZNPList_ZPP_AABBNode();
     }

--- a/src/native/space/ZPP_Space.ts
+++ b/src/native/space/ZPP_Space.ts
@@ -40,8 +40,8 @@ export class ZPP_Space {
   // --- Instance fields ---
   outer: any = null;
   userData: any = null;
-  gravityx: any = null;
-  gravityy: any = null;
+  gravityx: number = 0;
+  gravityy: number = 0;
   wrap_gravity: any = null;
   bodies: any = null;
   wrap_bodies: any = null;
@@ -52,12 +52,12 @@ export class ZPP_Space {
   kinematics: any = null;
   bphase: any = null;
   __static: any = null;
-  global_lin_drag: any = null;
-  global_ang_drag: any = null;
-  stamp: any = null;
-  midstep: any = null;
-  time: any = null;
-  sortcontacts: any = null;
+  global_lin_drag: number = 0;
+  global_ang_drag: number = 0;
+  stamp: number = 0;
+  midstep: boolean = false;
+  time: number = 0;
+  sortcontacts: boolean = false;
   c_arbiters_true: any = null;
   c_arbiters_false: any = null;
   f_arbiters: any = null;
@@ -75,9 +75,9 @@ export class ZPP_Space {
   callbackset_list: any = null;
   cbsets: any = null;
   convexShapeList: any = null;
-  pre_dt: any = null;
+  pre_dt: number = 0;
   toiEvents: any = null;
-  continuous: any = null;
+  continuous: boolean = false;
   precb: any = null;
   prelisteners: any = null;
   mrca1: any = null;
@@ -3173,7 +3173,34 @@ export class ZPP_Space {
     return cb;
   }
 
-  step(deltaTime: any, velocityIterations: any, positionIterations: any) {
+  /** Invalidate shapes on bodies whose position or rotation changed. */
+  private _invalidateBodyList(list: any): void {
+    let node = list.head;
+    while (node != null) {
+      const body = node.elt;
+      const upos = !(body.posx == body.pre_posx && body.posy == body.pre_posy);
+      const urot = body.pre_rot != body.rot;
+      if (upos || urot) {
+        if (urot) {
+          body.zip_axis = true;
+        }
+        let sn = body.shapes.head;
+        while (sn != null) {
+          const s = sn.elt;
+          if (s.type == 1) {
+            s.polygon.invalidate_gverts();
+            s.polygon.invalidate_gaxi();
+          }
+          s.invalidate_worldCOM();
+          sn = sn.next;
+        }
+        body.zip_worldCOM = true;
+      }
+      node = node.next;
+    }
+  }
+
+  step(deltaTime: number, velocityIterations: number, positionIterations: number) {
     if (this.midstep) {
       throw new Error(
         "Error: ... REALLY?? you're going to call space.step() inside of space.step()? COME ON!!",
@@ -3279,74 +3306,8 @@ export class ZPP_Space {
       this.continuousCollisions(deltaTime);
       this.continuous = false;
       this.iteratePos(positionIterations);
-      let cx_ite2 = this.kinematics.head;
-      while (cx_ite2 != null) {
-        const cur2 = cx_ite2.elt;
-        const upos = !(cur2.posx == cur2.pre_posx && cur2.posy == cur2.pre_posy);
-        const urot = cur2.pre_rot != cur2.rot;
-        if (upos) {
-          let cx_ite3 = cur2.shapes.head;
-          while (cx_ite3 != null) {
-            const s = cx_ite3.elt;
-            if (s.type == 1) {
-              s.polygon.invalidate_gverts();
-              s.polygon.invalidate_gaxi();
-            }
-            s.invalidate_worldCOM();
-            cx_ite3 = cx_ite3.next;
-          }
-          cur2.zip_worldCOM = true;
-        }
-        if (urot) {
-          cur2.zip_axis = true;
-          let cx_ite4 = cur2.shapes.head;
-          while (cx_ite4 != null) {
-            const s1 = cx_ite4.elt;
-            if (s1.type == 1) {
-              s1.polygon.invalidate_gverts();
-              s1.polygon.invalidate_gaxi();
-            }
-            s1.invalidate_worldCOM();
-            cx_ite4 = cx_ite4.next;
-          }
-          cur2.zip_worldCOM = true;
-        }
-        cx_ite2 = cx_ite2.next;
-      }
-      let cx_ite5 = this.live.head;
-      while (cx_ite5 != null) {
-        const cur3 = cx_ite5.elt;
-        const upos1 = !(cur3.posx == cur3.pre_posx && cur3.posy == cur3.pre_posy);
-        const urot1 = cur3.pre_rot != cur3.rot;
-        if (upos1) {
-          let cx_ite6 = cur3.shapes.head;
-          while (cx_ite6 != null) {
-            const s2 = cx_ite6.elt;
-            if (s2.type == 1) {
-              s2.polygon.invalidate_gverts();
-              s2.polygon.invalidate_gaxi();
-            }
-            s2.invalidate_worldCOM();
-            cx_ite6 = cx_ite6.next;
-          }
-          cur3.zip_worldCOM = true;
-        }
-        if (urot1) {
-          cur3.zip_axis = true;
-          let cx_ite7 = cur3.shapes.head;
-          while (cx_ite7 != null) {
-            const s3 = cx_ite7.elt;
-            if (s3.type == 1) {
-              s3.polygon.invalidate_gverts();
-              s3.polygon.invalidate_gaxi();
-            }
-            s3.invalidate_worldCOM();
-            cx_ite7 = cx_ite7.next;
-          }
-          cur3.zip_worldCOM = true;
-        }
-        cx_ite5 = cx_ite5.next;
-      }
+      this._invalidateBodyList(this.kinematics);
+      this._invalidateBodyList(this.live);
       let pre = null;
       let cx_ite8 = this.staticsleep.head;
       while (cx_ite8 != null) {
@@ -3550,7 +3511,7 @@ export class ZPP_Space {
     }
   }
 
-  continuousCollisions(deltaTime: any) {
+  continuousCollisions(deltaTime: number) {
     const MAX_VEL = (2 * Math.PI) / deltaTime;
     this.bphase.broadphase(this, false);
     let curTimeAlpha = 0.0;
@@ -7123,7 +7084,7 @@ export class ZPP_Space {
     }
   }
 
-  updateVel(dt: any) {
+  updateVel(dt: number) {
     let pre = null;
     const linDrag = 1 - dt * this.global_lin_drag;
     const angDrag = 1 - dt * this.global_ang_drag;
@@ -7148,7 +7109,7 @@ export class ZPP_Space {
     }
   }
 
-  updatePos(dt: any) {
+  updatePos(dt: number) {
     const MAX_VEL = (2 * Math.PI) / dt;
     let cx_ite = this.live.head;
     while (cx_ite != null) {
@@ -7686,7 +7647,7 @@ export class ZPP_Space {
     }
   }
 
-  presteparb(arb: any, dt: any, cont?: any) {
+  presteparb(arb: ZPP_Arbiter, dt: number, cont?: boolean) {
     if (cont == null) {
       cont = false;
     }
@@ -9116,7 +9077,45 @@ export class ZPP_Space {
     return false;
   }
 
-  prestep(dt: any) {
+  /** Iterate a single arbiter list, removing arbiters that fail prestep. */
+  private _prestepArbiterList(arbs: any, nodePool: any, dt: number): void {
+    let pre = null;
+    let arbite = arbs.head;
+    while (arbite != null) {
+      const arb = arbite.elt;
+      if (this.presteparb(arb, dt)) {
+        let old;
+        let ret;
+        if (pre == null) {
+          old = arbs.head;
+          ret = old.next;
+          arbs.head = ret;
+          if (arbs.head == null) {
+            arbs.pushmod = true;
+          }
+        } else {
+          old = pre.next;
+          ret = old.next;
+          pre.next = ret;
+          if (ret == null) {
+            arbs.pushmod = true;
+          }
+        }
+        old.elt = null;
+        old.next = nodePool.zpp_pool;
+        nodePool.zpp_pool = old;
+        arbs.modified = true;
+        arbs.length--;
+        arbs.pushmod = true;
+        arbite = ret;
+        continue;
+      }
+      pre = arbite;
+      arbite = arbite.next;
+    }
+  }
+
+  prestep(dt: number) {
     let pre = null;
     let cx_ite = this.live_constraints.head;
     while (cx_ite != null) {
@@ -9198,110 +9197,8 @@ export class ZPP_Space {
         pre1 = null;
       }
     }
-    let pre2 = null;
-    let arbs1 = this.f_arbiters;
-    let arbite1 = arbs1.head;
-    let fst1 = false;
-    if (fst1 && arbite1 == null) {
-      fst1 = false;
-      arbs1 = null;
-      pre2 = null;
-    }
-    while (arbite1 != null) {
-      const arb1 = arbite1.elt;
-      if (this.presteparb(arb1, dt)) {
-        let old1;
-        let ret1;
-        if (pre2 == null) {
-          old1 = arbs1.head;
-          ret1 = old1.next;
-          arbs1.head = ret1;
-          if (arbs1.head == null) {
-            arbs1.pushmod = true;
-          }
-        } else {
-          old1 = pre2.next;
-          ret1 = old1.next;
-          pre2.next = ret1;
-          if (ret1 == null) {
-            arbs1.pushmod = true;
-          }
-        }
-        const o1 = old1;
-        o1.elt = null;
-        o1.next = ZPP_Space._zpp.util.ZNPNode_ZPP_FluidArbiter.zpp_pool;
-        ZPP_Space._zpp.util.ZNPNode_ZPP_FluidArbiter.zpp_pool = o1;
-        arbs1.modified = true;
-        arbs1.length--;
-        arbs1.pushmod = true;
-        arbite1 = ret1;
-        if (fst1 && arbite1 == null) {
-          fst1 = false;
-          arbs1 = null;
-          pre2 = null;
-        }
-        continue;
-      }
-      pre2 = arbite1;
-      arbite1 = arbite1.next;
-      if (fst1 && arbite1 == null) {
-        fst1 = false;
-        arbs1 = null;
-        pre2 = null;
-      }
-    }
-    let pre3 = null;
-    let arbs2 = this.s_arbiters;
-    let arbite2 = arbs2.head;
-    let fst2 = false;
-    if (fst2 && arbite2 == null) {
-      fst2 = false;
-      arbs2 = null;
-      pre3 = null;
-    }
-    while (arbite2 != null) {
-      const arb2 = arbite2.elt;
-      if (this.presteparb(arb2, dt)) {
-        let old2;
-        let ret2;
-        if (pre3 == null) {
-          old2 = arbs2.head;
-          ret2 = old2.next;
-          arbs2.head = ret2;
-          if (arbs2.head == null) {
-            arbs2.pushmod = true;
-          }
-        } else {
-          old2 = pre3.next;
-          ret2 = old2.next;
-          pre3.next = ret2;
-          if (ret2 == null) {
-            arbs2.pushmod = true;
-          }
-        }
-        const o2 = old2;
-        o2.elt = null;
-        o2.next = ZPP_Space._zpp.util.ZNPNode_ZPP_SensorArbiter.zpp_pool;
-        ZPP_Space._zpp.util.ZNPNode_ZPP_SensorArbiter.zpp_pool = o2;
-        arbs2.modified = true;
-        arbs2.length--;
-        arbs2.pushmod = true;
-        arbite2 = ret2;
-        if (fst2 && arbite2 == null) {
-          fst2 = false;
-          arbs2 = null;
-          pre3 = null;
-        }
-        continue;
-      }
-      pre3 = arbite2;
-      arbite2 = arbite2.next;
-      if (fst2 && arbite2 == null) {
-        fst2 = false;
-        arbs2 = null;
-        pre3 = null;
-      }
-    }
+    this._prestepArbiterList(this.f_arbiters, ZPP_Space._zpp.util.ZNPNode_ZPP_FluidArbiter, dt);
+    this._prestepArbiterList(this.s_arbiters, ZPP_Space._zpp.util.ZNPNode_ZPP_SensorArbiter, dt);
   }
 
   warmStart() {
@@ -9370,7 +9267,7 @@ export class ZPP_Space {
     }
   }
 
-  iterateVel(times: any) {
+  iterateVel(times: number) {
     let _g = 0;
     const _g1 = times;
     while (_g < _g1) {

--- a/src/native/space/ZPP_Space.ts
+++ b/src/native/space/ZPP_Space.ts
@@ -9535,7 +9535,7 @@ export class ZPP_Space {
     }
   }
 
-  iteratePos(times: any) {
+  iteratePos(times: number) {
     let _g = 0;
     const _g1 = times;
     while (_g < _g1) {

--- a/src/native/space/ZPP_SweepPhase.ts
+++ b/src/native/space/ZPP_SweepPhase.ts
@@ -374,19 +374,7 @@ export class ZPP_SweepPhase extends ZPP_Broadphase {
   shapesUnderPoint(x: number, y: number, filter: any, output: any): any {
     this.sync_broadphase();
 
-    let ret: any;
-    if (ZPP_Vec2.zpp_pool == null) {
-      ret = new ZPP_Vec2();
-    } else {
-      ret = ZPP_Vec2.zpp_pool;
-      ZPP_Vec2.zpp_pool = ret.next;
-      ret.next = null;
-    }
-    ret.weak = false;
-    ret._immutable = false;
-    ret.x = x;
-    ret.y = y;
-    const v = ret;
+    const v = ZPP_Vec2.get(x, y);
 
     const ret1 = output == null ? new ZPP_SweepPhase._nape.shape.ShapeList() : output;
 
@@ -435,19 +423,7 @@ export class ZPP_SweepPhase extends ZPP_Broadphase {
   bodiesUnderPoint(x: number, y: number, filter: any, output: any): any {
     this.sync_broadphase();
 
-    let ret: any;
-    if (ZPP_Vec2.zpp_pool == null) {
-      ret = new ZPP_Vec2();
-    } else {
-      ret = ZPP_Vec2.zpp_pool;
-      ZPP_Vec2.zpp_pool = ret.next;
-      ret.next = null;
-    }
-    ret.weak = false;
-    ret._immutable = false;
-    ret.x = x;
-    ret.y = y;
-    const v = ret;
+    const v = ZPP_Vec2.get(x, y);
 
     const ret1 = output == null ? new ZPP_SweepPhase._nape.phys.BodyList() : output;
 

--- a/tests/native/space/ZPP_Broadphase.integration.test.ts
+++ b/tests/native/space/ZPP_Broadphase.integration.test.ts
@@ -476,3 +476,142 @@ describe("ZPP_Broadphase — edge cases", () => {
     expect(() => space.step(1 / 60)).not.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// 8. DynAABBPhase pair-list consistency on shape/body removal (P46)
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Broadphase — pair-list consistency on removal (P46)", () => {
+  it("removing one overlapping body keeps pairs consistent", () => {
+    const space = makeSpace(Broadphase.DYNAMIC_AABB_TREE, 0);
+    const _a = dynamicCircle(space, 0, 0, 20);
+    const b = dynamicCircle(space, 15, 0, 20);
+    const _c = dynamicCircle(space, 30, 0, 20);
+    space.step(1 / 60);
+    // All three overlap — broadphase should have created pairs
+    b.space = null;
+    // Stepping after removal must not crash or leave dangling pairs
+    expect(() => space.step(1 / 60)).not.toThrow();
+    expect(space.bodies.length).toBe(2);
+    // a and c still overlap, simulation continues correctly
+    expect(() => {
+      for (let i = 0; i < 10; i++) space.step(1 / 60);
+    }).not.toThrow();
+  });
+
+  it("removing all overlapping bodies one by one after step", () => {
+    const space = makeSpace(Broadphase.DYNAMIC_AABB_TREE, 0);
+    const bodies: Body[] = [];
+    for (let i = 0; i < 5; i++) {
+      bodies.push(dynamicCircle(space, i * 10, 0, 15));
+    }
+    space.step(1 / 60);
+    // Remove bodies one by one, stepping between each
+    for (const b of bodies) {
+      b.space = null;
+      expect(() => space.step(1 / 60)).not.toThrow();
+    }
+    expect(space.bodies.length).toBe(0);
+  });
+
+  it("removing all overlapping bodies at once between steps", () => {
+    const space = makeSpace(Broadphase.DYNAMIC_AABB_TREE, 0);
+    const bodies: Body[] = [];
+    for (let i = 0; i < 5; i++) {
+      bodies.push(dynamicCircle(space, i * 10, 0, 15));
+    }
+    space.step(1 / 60);
+    // Remove all at once without stepping between
+    for (const b of bodies) {
+      b.space = null;
+    }
+    expect(space.bodies.length).toBe(0);
+    expect(() => space.step(1 / 60)).not.toThrow();
+  });
+
+  it("sleeping pairs are cleaned up correctly on removal", () => {
+    const space = makeSpace(Broadphase.DYNAMIC_AABB_TREE, 0);
+    // Create overlapping bodies, let them settle so pairs go to sleep
+    const floor = new Body(BodyType.STATIC, new Vec2(0, 100));
+    floor.shapes.add(new Polygon(Polygon.box(200, 20)));
+    floor.space = space;
+    const a = dynamicCircle(space, -5, 0, 10);
+    const _b = dynamicCircle(space, 5, 0, 10);
+    // Step many times to let bodies settle and pairs go to sleep
+    for (let i = 0; i < 120; i++) space.step(1 / 60);
+    // Remove one settled body — sleeping pairs must be cleaned
+    a.space = null;
+    expect(() => {
+      for (let i = 0; i < 30; i++) space.step(1 / 60);
+    }).not.toThrow();
+    expect(space.bodies.length).toBe(2); // floor + b
+  });
+
+  it("rapid add-remove-add cycles keep broadphase consistent", () => {
+    const space = makeSpace(Broadphase.DYNAMIC_AABB_TREE, 500);
+    const floor = new Body(BodyType.STATIC, new Vec2(0, 200));
+    floor.shapes.add(new Polygon(Polygon.box(400, 20)));
+    floor.space = space;
+
+    for (let cycle = 0; cycle < 5; cycle++) {
+      const bodies: Body[] = [];
+      for (let i = 0; i < 8; i++) {
+        bodies.push(dynamicCircle(space, (i - 4) * 15, 0, 10));
+      }
+      space.step(1 / 60);
+      // Remove half the bodies
+      for (let i = 0; i < 4; i++) {
+        bodies[i].space = null;
+      }
+      space.step(1 / 60);
+      // Remove the rest
+      for (let i = 4; i < 8; i++) {
+        bodies[i].space = null;
+      }
+    }
+    expect(() => space.step(1 / 60)).not.toThrow();
+    expect(space.bodies.length).toBe(1); // only floor remains
+  });
+
+  it("shape removal from multi-shape body keeps pairs consistent", () => {
+    const space = makeSpace(Broadphase.DYNAMIC_AABB_TREE, 0);
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    const c1 = new Circle(15);
+    const c2 = new Circle(15);
+    c2.localPosition = new Vec2(20, 0);
+    b.shapes.add(c1);
+    b.shapes.add(c2);
+    b.space = space;
+
+    // Add an overlapping body
+    dynamicCircle(space, 10, 0, 15);
+    space.step(1 / 60);
+
+    // Remove one shape from the multi-shape body
+    (b.shapes as any).remove(c1);
+    expect(b.shapes.length).toBe(1);
+    expect(() => {
+      for (let i = 0; i < 10; i++) space.step(1 / 60);
+    }).not.toThrow();
+  });
+
+  it("removing body during active collision does not corrupt pairs", () => {
+    const space = makeSpace(Broadphase.DYNAMIC_AABB_TREE, 500);
+    const floor = new Body(BodyType.STATIC, new Vec2(0, 60));
+    floor.shapes.add(new Polygon(Polygon.box(200, 20)));
+    floor.space = space;
+
+    // Drop bodies so they're actively colliding with the floor
+    const a = dynamicCircle(space, -10, 0, 10);
+    const b = dynamicCircle(space, 10, 0, 10);
+    for (let i = 0; i < 30; i++) space.step(1 / 60);
+
+    // Both should be touching the floor — remove one mid-collision
+    a.space = null;
+    expect(() => {
+      for (let i = 0; i < 30; i++) space.step(1 / 60);
+    }).not.toThrow();
+    // b should still interact with floor
+    expect(b.position.y).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
- Extract _invalidateBodyList() helper in step() — eliminates ~60 lines of copy-paste
  body invalidation for kinematics and live bodies
- Extract _prestepArbiterList() helper in prestep() — deduplicates fluid/sensor
  arbiter iteration with node-pool return (~100 lines removed)
- Replace inline pool-check patterns with ZPP_Vec2.get() calls in ZPP_Collide (11),
  ZPP_SweepDistance (3), ZPP_SweepPhase (2), ZPP_ToiEvent (3) — reduces code and
  ensures consistent pool usage
- Add gprev doubly-linked pointer to ZPP_AABBPair for O(1) pair unlinking;
  refactor DynAABBPhase.__remove to iterate shape.pairs instead of scanning
  the entire global pairs list (O(n) → O(k) where k = pairs per shape)
- Add _linkPair/_unlinkPair helpers to DynAABBPhase; update all 8 insertion
  points and 3 removal points to use doubly-linked operations
- Begin any→concrete type narrowing in ZPP_Body and ZPP_ColArbiter hot-path fields

https://claude.ai/code/session_018wo88pXfdBKecqsCL9SRBo