### PR TITLE
Add 146 coverage tests across 7 new test files (4315 → 4461)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ A fully typed TypeScript 2D physics engine — modernized rewrite of the origina
 - **Fluid simulation** — buoyancy and drag via fluid-enabled shapes (unique among JS engines)
 - **Serialization** — JSON (`spaceToJSON` / `spaceFromJSON`) + binary (`spaceToBinary` / `spaceFromBinary`) for save/load/multiplayer rollback
 - **Debug draw** — abstract `DebugDraw` interface (Box2D pattern), reference impls for Canvas/Three.js/PixiJS/p5.js
-- **~87 KB** minified ESM bundle (~16 KB gzip), TSDoc documented, 4315 tests
+- **~87 KB** minified ESM bundle (~16 KB gzip), TSDoc documented, 4461 tests
 
 ## Build & Test
 
@@ -63,7 +63,7 @@ iterator patterns, ESM constraints) see `docs/guides/architecture.md`.
 | What                     | Status |
 | ------------------------ | ------ |
 | Haxe modernization       | ✅ Complete — pure TypeScript, fully typed |
-| Test coverage            | 🔶 ~60% statements (4315 tests), target ≥80% |
+| Test coverage            | 🔶 ~60% statements (4461 tests), target ≥80% |
 | Serialization API        | ✅ Done — `@newkrok/nape-js/serialization` |
 | Binary snapshots         | ✅ Done — `spaceToBinary` / `spaceFromBinary` (P39) |
 | Debug draw API           | ✅ Done — abstract `DebugDraw` + `Space.debugDraw()` |

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ present, with automatic `postMessage` fallback otherwise.
 ```bash
 npm install
 npm run build      # tsup → dist/ (ESM + CJS + DTS)
-npm test           # vitest — 4315 tests across 188 files
+npm test           # vitest — 4461 tests across 195 files
 npm run benchmark  # Performance benchmarks
 ```
 

--- a/tests/constraint/Constraint.copy.test.ts
+++ b/tests/constraint/Constraint.copy.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Circle } from "../../src/shape/Circle";
+import { PivotJoint } from "../../src/constraint/PivotJoint";
+import { DistanceJoint } from "../../src/constraint/DistanceJoint";
+import { MotorJoint } from "../../src/constraint/MotorJoint";
+import { AngleJoint } from "../../src/constraint/AngleJoint";
+import { WeldJoint } from "../../src/constraint/WeldJoint";
+import { LineJoint } from "../../src/constraint/LineJoint";
+
+describe("Constraint copy & toString — coverage", () => {
+  function makeBody(x = 0, y = 0): Body {
+    const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+    b.shapes.add(new Circle(5));
+    return b;
+  }
+
+  describe("PivotJoint", () => {
+    it("should copy PivotJoint", () => {
+      const b1 = makeBody(0, 0);
+      const b2 = makeBody(50, 0);
+      const pj = new PivotJoint(b1, b2, new Vec2(0, 0), new Vec2(0, 0));
+      pj.maxForce = 500;
+      pj.stiff = false;
+      pj.frequency = 10;
+      pj.damping = 0.5;
+
+      const copy = pj.copy();
+      expect(copy.maxForce).toBeCloseTo(500);
+      expect(copy.stiff).toBe(false);
+      expect(copy.frequency).toBeCloseTo(10);
+      expect(copy.damping).toBeCloseTo(0.5);
+    });
+
+    it("should have toString", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const pj = new PivotJoint(b1, b2, new Vec2(1, 2), new Vec2(3, 4));
+      const str = pj.toString();
+      expect(str).toBeDefined();
+      expect(typeof str).toBe("string");
+    });
+
+    it("should throw on NaN anchor", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const pj = new PivotJoint(b1, b2, new Vec2(0, 0), new Vec2(0, 0));
+      expect(() => {
+        pj.anchor1 = new Vec2(NaN, 0);
+      }).toThrow();
+    });
+  });
+
+  describe("DistanceJoint", () => {
+    it("should copy DistanceJoint", () => {
+      const b1 = makeBody(0, 0);
+      const b2 = makeBody(100, 0);
+      const dj = new DistanceJoint(b1, b2, new Vec2(0, 0), new Vec2(0, 0), 50, 150);
+      dj.stiff = false;
+      dj.frequency = 8;
+
+      const copy = dj.copy();
+      expect(copy.jointMin).toBeCloseTo(50);
+      expect(copy.jointMax).toBeCloseTo(150);
+    });
+
+    it("should have toString", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const dj = new DistanceJoint(b1, b2, new Vec2(0, 0), new Vec2(0, 0), 10, 50);
+      const str = dj.toString();
+      expect(str).toBeDefined();
+    });
+
+    it("should throw on NaN jointMin", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const dj = new DistanceJoint(b1, b2, new Vec2(0, 0), new Vec2(0, 0), 10, 50);
+      expect(() => {
+        dj.jointMin = NaN;
+      }).toThrow();
+    });
+
+    it("should throw on NaN jointMax", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const dj = new DistanceJoint(b1, b2, new Vec2(0, 0), new Vec2(0, 0), 10, 50);
+      expect(() => {
+        dj.jointMax = NaN;
+      }).toThrow();
+    });
+  });
+
+  describe("MotorJoint", () => {
+    it("should copy MotorJoint", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const mj = new MotorJoint(b1, b2, 3.14, 2.0);
+      mj.maxForce = 1000;
+
+      const copy = mj.copy();
+      expect(copy.rate).toBeCloseTo(3.14);
+      expect(copy.ratio).toBeCloseTo(2.0);
+      expect(copy.maxForce).toBeCloseTo(1000);
+    });
+
+    it("should have toString", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const mj = new MotorJoint(b1, b2, 1.0);
+      const str = mj.toString();
+      expect(str).toBeDefined();
+    });
+
+    it("should throw on NaN rate", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const mj = new MotorJoint(b1, b2, 1.0);
+      expect(() => {
+        mj.rate = NaN;
+      }).toThrow();
+    });
+
+    it("should throw on NaN ratio", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const mj = new MotorJoint(b1, b2, 1.0);
+      expect(() => {
+        mj.ratio = NaN;
+      }).toThrow();
+    });
+  });
+
+  describe("AngleJoint", () => {
+    it("should copy AngleJoint", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const aj = new AngleJoint(b1, b2, -Math.PI, Math.PI);
+
+      const copy = aj.copy();
+      expect(copy.jointMin).toBeCloseTo(-Math.PI);
+      expect(copy.jointMax).toBeCloseTo(Math.PI);
+    });
+
+    it("should have toString", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const aj = new AngleJoint(b1, b2, 0, Math.PI);
+      expect(aj.toString()).toBeDefined();
+    });
+  });
+
+  describe("WeldJoint", () => {
+    it("should copy WeldJoint", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const wj = new WeldJoint(b1, b2, new Vec2(0, 0), new Vec2(10, 0));
+
+      const copy = wj.copy();
+      expect(copy).toBeDefined();
+    });
+
+    it("should have toString", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const wj = new WeldJoint(b1, b2, new Vec2(0, 0), new Vec2(0, 0));
+      expect(wj.toString()).toBeDefined();
+    });
+  });
+
+  describe("LineJoint", () => {
+    it("should copy LineJoint", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const lj = new LineJoint(b1, b2, new Vec2(0, 0), new Vec2(0, 0), new Vec2(1, 0), -50, 50);
+
+      const copy = lj.copy();
+      expect(copy.jointMin).toBeCloseTo(-50);
+      expect(copy.jointMax).toBeCloseTo(50);
+    });
+
+    it("should have toString", () => {
+      const b1 = makeBody();
+      const b2 = makeBody();
+      const lj = new LineJoint(b1, b2, new Vec2(0, 0), new Vec2(0, 0), new Vec2(1, 0), -50, 50);
+      expect(lj.toString()).toBeDefined();
+    });
+  });
+
+  describe("breakUnderForce / removeOnBreak", () => {
+    it("should break a constraint when force exceeds maxForce", () => {
+      const space = new Space(new Vec2(0, 500));
+      const anchor = new Body(BodyType.STATIC, new Vec2(0, 0));
+      anchor.shapes.add(new Circle(5));
+      anchor.space = space;
+
+      const bob = new Body(BodyType.DYNAMIC, new Vec2(0, 100));
+      bob.shapes.add(new Circle(10));
+      bob.space = space;
+
+      const dj = new DistanceJoint(anchor, bob, new Vec2(0, 0), new Vec2(0, 0), 50, 50);
+      dj.stiff = true;
+      dj.breakUnderForce = true;
+      dj.maxForce = 0.001; // Very low — will break immediately
+      dj.removeOnBreak = true;
+      dj.space = space;
+
+      for (let i = 0; i < 30; i++) space.step(1 / 60, 5, 5);
+
+      // Constraint should have been removed
+      expect(dj.space).toBeNull();
+    });
+  });
+});

--- a/tests/dynamics/InteractionGroup.coverage.test.ts
+++ b/tests/dynamics/InteractionGroup.coverage.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { InteractionGroup } from "../../src/dynamics/InteractionGroup";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Circle } from "../../src/shape/Circle";
+// Side-effect imports
+import "../../src/callbacks/PreFlag";
+import "../../src/dynamics/CollisionArbiter";
+import "../../src/dynamics/FluidArbiter";
+
+describe("InteractionGroup — coverage", () => {
+  describe("interactors getter", () => {
+    it("should have internal interactors data when body is assigned", () => {
+      const group = new InteractionGroup();
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      body.shapes.add(new Circle(10));
+      body.group = group;
+
+      // interactors getter requires zpp_nape bootstrap for list wrapping,
+      // but we can verify the internal state
+      expect(group.zpp_inner.interactors).toBeDefined();
+    });
+  });
+
+  describe("groups getter", () => {
+    it("should have internal groups data when child is assigned", () => {
+      const parent = new InteractionGroup();
+      const child = new InteractionGroup();
+      child.group = parent;
+
+      // groups getter requires full zpp_nape bootstrap for list wrapping,
+      // but we can verify the internal state
+      expect(parent.zpp_inner.groups).toBeDefined();
+    });
+  });
+
+  describe("ignore flag suppresses collisions", () => {
+    it("should prevent collision when bodies share an ignore group", () => {
+      const space = new Space(new Vec2(0, 500));
+      const group = new InteractionGroup(true); // ignore = true
+
+      const ball1 = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      ball1.shapes.add(new Circle(20));
+      ball1.group = group;
+      ball1.space = space;
+
+      const ball2 = new Body(BodyType.DYNAMIC, new Vec2(0, 30));
+      ball2.shapes.add(new Circle(20));
+      ball2.group = group;
+      ball2.space = space;
+
+      for (let i = 0; i < 10; i++) space.step(1 / 60, 5, 5);
+
+      // With ignore=true, no collision arbiters between the two
+      let hasArbiter = false;
+      try {
+        const arb = space.arbiters.at(0);
+        if (
+          (arb.body1 === ball1 && arb.body2 === ball2) ||
+          (arb.body1 === ball2 && arb.body2 === ball1)
+        ) {
+          hasArbiter = true;
+        }
+      } catch {
+        // No arbiters — expected
+      }
+      expect(hasArbiter).toBe(false);
+    });
+  });
+
+  describe("_wrap edge cases", () => {
+    it("should wrap legacy object with zpp_inner", () => {
+      const g = new InteractionGroup(true);
+      const legacy = { zpp_inner: g.zpp_inner };
+      const wrapped = InteractionGroup._wrap(legacy);
+      expect(wrapped).toBeInstanceOf(InteractionGroup);
+      expect(wrapped.ignore).toBe(true);
+    });
+
+    it("should return null for unknown object", () => {
+      const result = InteractionGroup._wrap({ foo: "bar" });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("parent-child hierarchy", () => {
+    it("should support multi-level hierarchy", () => {
+      const grandparent = new InteractionGroup();
+      const parent = new InteractionGroup();
+      const child = new InteractionGroup();
+
+      parent.group = grandparent;
+      child.group = parent;
+
+      expect(child.group).toBe(parent);
+      expect(parent.group).toBe(grandparent);
+      expect(grandparent.group).toBeNull();
+    });
+  });
+});

--- a/tests/geom/AABB.coverage.test.ts
+++ b/tests/geom/AABB.coverage.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from "vitest";
+import { AABB } from "../../src/geom/AABB";
+import { Vec2 } from "../../src/geom/Vec2";
+
+describe("AABB — additional coverage", () => {
+  // --- fromPoints ---
+
+  describe("fromPoints", () => {
+    it("should create AABB from a single point", () => {
+      const aabb = AABB.fromPoints([new Vec2(5, 10)]);
+      expect(aabb.x).toBeCloseTo(5);
+      expect(aabb.y).toBeCloseTo(10);
+      expect(aabb.width).toBeCloseTo(0);
+      expect(aabb.height).toBeCloseTo(0);
+    });
+
+    it("should create AABB enclosing multiple points", () => {
+      const aabb = AABB.fromPoints([
+        new Vec2(1, 2),
+        new Vec2(5, 8),
+        new Vec2(-3, 4),
+        new Vec2(2, -1),
+      ]);
+      expect(aabb.x).toBeCloseTo(-3);
+      expect(aabb.y).toBeCloseTo(-1);
+      expect(aabb.width).toBeCloseTo(8); // 5 - (-3)
+      expect(aabb.height).toBeCloseTo(9); // 8 - (-1)
+    });
+
+    it("should create AABB from two points", () => {
+      const aabb = AABB.fromPoints([new Vec2(0, 0), new Vec2(10, 20)]);
+      expect(aabb.x).toBeCloseTo(0);
+      expect(aabb.y).toBeCloseTo(0);
+      expect(aabb.width).toBeCloseTo(10);
+      expect(aabb.height).toBeCloseTo(20);
+    });
+
+    it("should handle points with negative coordinates", () => {
+      const aabb = AABB.fromPoints([new Vec2(-10, -20), new Vec2(-5, -3)]);
+      expect(aabb.x).toBeCloseTo(-10);
+      expect(aabb.y).toBeCloseTo(-20);
+      expect(aabb.width).toBeCloseTo(5);
+      expect(aabb.height).toBeCloseTo(17);
+    });
+
+    it("should throw on null array", () => {
+      expect(() => AABB.fromPoints(null as unknown as Vec2[])).toThrow(
+        "requires at least one point",
+      );
+    });
+
+    it("should throw on empty array", () => {
+      expect(() => AABB.fromPoints([])).toThrow("requires at least one point");
+    });
+
+    it("should throw when first element is null", () => {
+      expect(() => AABB.fromPoints([null as unknown as Vec2])).toThrow("cannot contain null Vec2");
+    });
+
+    it("should throw when a subsequent element is null", () => {
+      expect(() => AABB.fromPoints([new Vec2(0, 0), null as unknown as Vec2])).toThrow(
+        "cannot contain null Vec2",
+      );
+    });
+
+    it("should throw when first Vec2 is disposed", () => {
+      const v = Vec2.weak(1, 2);
+      v.dispose();
+      expect(() => AABB.fromPoints([v])).toThrow("disposed");
+    });
+
+    it("should throw when a subsequent Vec2 is disposed", () => {
+      const v = Vec2.weak(1, 2);
+      v.dispose();
+      expect(() => AABB.fromPoints([new Vec2(0, 0), v])).toThrow("disposed");
+    });
+
+    it("should return an AABB instance", () => {
+      const aabb = AABB.fromPoints([new Vec2(0, 0), new Vec2(1, 1)]);
+      expect(aabb).toBeInstanceOf(AABB);
+    });
+
+    it("should handle collinear points", () => {
+      const aabb = AABB.fromPoints([new Vec2(0, 0), new Vec2(5, 0), new Vec2(10, 0)]);
+      expect(aabb.x).toBeCloseTo(0);
+      expect(aabb.y).toBeCloseTo(0);
+      expect(aabb.width).toBeCloseTo(10);
+      expect(aabb.height).toBeCloseTo(0);
+    });
+  });
+
+  // --- equals ---
+
+  describe("equals", () => {
+    it("should return true for identical AABBs", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = new AABB(1, 2, 3, 4);
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("should return false for different AABBs", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = new AABB(5, 6, 7, 8);
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it("should return false when only x differs", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = new AABB(2, 2, 3, 4);
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it("should return false when only y differs", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = new AABB(1, 3, 3, 4);
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it("should return false when only width differs", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = new AABB(1, 2, 5, 4);
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it("should return false when only height differs", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = new AABB(1, 2, 3, 5);
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it("should return true within epsilon tolerance", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = new AABB(1.05, 2.05, 2.95, 3.95);
+      expect(a.equals(b, 0.1)).toBe(true);
+    });
+
+    it("should return false when difference exceeds epsilon", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = new AABB(1.2, 2, 3, 4);
+      expect(a.equals(b, 0.1)).toBe(false);
+    });
+
+    it("should return false for null", () => {
+      const a = new AABB(1, 2, 3, 4);
+      expect(a.equals(null as unknown as AABB)).toBe(false);
+    });
+
+    it("should return true when comparing AABB to itself", () => {
+      const a = new AABB(1, 2, 3, 4);
+      expect(a.equals(a)).toBe(true);
+    });
+
+    it("should use default epsilon of 0", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = new AABB(1, 2, 3, 4);
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("should handle zero-size AABBs", () => {
+      const a = new AABB(5, 5, 0, 0);
+      const b = new AABB(5, 5, 0, 0);
+      expect(a.equals(b)).toBe(true);
+    });
+  });
+
+  // --- clone ---
+
+  describe("clone", () => {
+    it("should return a copy with same bounds", () => {
+      const a = new AABB(10, 20, 30, 40);
+      const b = a.clone();
+      expect(b.x).toBeCloseTo(10);
+      expect(b.y).toBeCloseTo(20);
+      expect(b.width).toBeCloseTo(30);
+      expect(b.height).toBeCloseTo(40);
+    });
+
+    it("should return a new independent instance", () => {
+      const a = new AABB(10, 20, 30, 40);
+      const b = a.clone();
+      b.x = 99;
+      expect(a.x).toBeCloseTo(10);
+      expect(b.x).toBeCloseTo(99);
+    });
+
+    it("should return an AABB instance", () => {
+      const a = new AABB(1, 2, 3, 4);
+      expect(a.clone()).toBeInstanceOf(AABB);
+    });
+
+    it("should produce a result equal to the original", () => {
+      const a = new AABB(1, 2, 3, 4);
+      const b = a.clone();
+      expect(a.equals(b)).toBe(true);
+    });
+  });
+
+  // --- max setter with valid Vec2 ---
+
+  describe("max setter", () => {
+    it("should set max via direct component manipulation", () => {
+      const box = new AABB(10, 20, 30, 40);
+      // Use internal manipulation since max wrapper requires getmax() init
+      box.zpp_inner.maxx = 50;
+      box.zpp_inner.maxy = 70;
+      expect(box.max.x).toBeCloseTo(50);
+      expect(box.max.y).toBeCloseTo(70);
+      expect(box.width).toBeCloseTo(40); // 50 - 10
+      expect(box.height).toBeCloseTo(50); // 70 - 20
+    });
+
+    it("should handle zero dimensions via internal manipulation", () => {
+      const box = new AABB(10, 20, 30, 40);
+      box.zpp_inner.maxx = 10;
+      box.zpp_inner.maxy = 20;
+      expect(box.width).toBeCloseTo(0);
+      expect(box.height).toBeCloseTo(0);
+    });
+  });
+
+  // --- Constructor edge cases ---
+
+  describe("constructor edge cases", () => {
+    it("should accept zero width and height", () => {
+      const box = new AABB(5, 10, 0, 0);
+      expect(box.x).toBeCloseTo(5);
+      expect(box.y).toBeCloseTo(10);
+      expect(box.width).toBeCloseTo(0);
+      expect(box.height).toBeCloseTo(0);
+    });
+
+    it("should accept negative width in constructor (stored as-is)", () => {
+      // Constructor does not validate width >= 0; it just sets maxx = x + width
+      const box = new AABB(10, 10, -5, 10);
+      expect(box.zpp_inner.minx).toBeCloseTo(10);
+      expect(box.zpp_inner.maxx).toBeCloseTo(5); // 10 + (-5)
+    });
+
+    it("should accept large values", () => {
+      const box = new AABB(1e6, 1e6, 1e6, 1e6);
+      expect(box.x).toBeCloseTo(1e6);
+      expect(box.width).toBeCloseTo(1e6);
+    });
+  });
+});

--- a/tests/misc/EnumTypes.coverage.test.ts
+++ b/tests/misc/EnumTypes.coverage.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { ArbiterType } from "../../src/dynamics/ArbiterType";
+import { BodyType } from "../../src/phys/BodyType";
+import { ShapeType } from "../../src/shape/ShapeType";
+import { ListenerType } from "../../src/callbacks/ListenerType";
+import { ZPP_Flags } from "../../src/native/util/ZPP_Flags";
+
+describe("ArbiterType coverage", () => {
+  it("COLLISION singleton returns 'COLLISION'", () => {
+    expect(ArbiterType.COLLISION.toString()).toBe("COLLISION");
+  });
+
+  it("SENSOR singleton returns 'SENSOR'", () => {
+    expect(ArbiterType.SENSOR.toString()).toBe("SENSOR");
+  });
+
+  it("FLUID singleton returns 'FLUID'", () => {
+    expect(ArbiterType.FLUID.toString()).toBe("FLUID");
+  });
+
+  it("singletons are stable across accesses", () => {
+    expect(ArbiterType.COLLISION).toBe(ArbiterType.COLLISION);
+    expect(ArbiterType.SENSOR).toBe(ArbiterType.SENSOR);
+    expect(ArbiterType.FLUID).toBe(ArbiterType.FLUID);
+  });
+
+  it("throws when constructed without internal flag", () => {
+    expect(() => new ArbiterType()).toThrow("Cannot instantiate ArbiterType derp!");
+  });
+
+  it("unknown instance toString() returns empty string", () => {
+    ZPP_Flags.internal = true;
+    const unknown = new ArbiterType();
+    ZPP_Flags.internal = false;
+    expect(unknown.toString()).toBe("");
+  });
+});
+
+describe("BodyType coverage", () => {
+  it("STATIC singleton returns 'STATIC'", () => {
+    expect(BodyType.STATIC.toString()).toBe("STATIC");
+  });
+
+  it("DYNAMIC singleton returns 'DYNAMIC'", () => {
+    expect(BodyType.DYNAMIC.toString()).toBe("DYNAMIC");
+  });
+
+  it("KINEMATIC singleton returns 'KINEMATIC'", () => {
+    expect(BodyType.KINEMATIC.toString()).toBe("KINEMATIC");
+  });
+
+  it("singletons are stable across accesses", () => {
+    expect(BodyType.STATIC).toBe(BodyType.STATIC);
+    expect(BodyType.DYNAMIC).toBe(BodyType.DYNAMIC);
+    expect(BodyType.KINEMATIC).toBe(BodyType.KINEMATIC);
+  });
+
+  it("throws when constructed without internal flag", () => {
+    expect(() => new BodyType()).toThrow("Cannot instantiate BodyType derp!");
+  });
+
+  it("unknown instance toString() returns empty string", () => {
+    ZPP_Flags.internal = true;
+    const unknown = new BodyType();
+    ZPP_Flags.internal = false;
+    expect(unknown.toString()).toBe("");
+  });
+});
+
+describe("ShapeType coverage", () => {
+  it("CIRCLE singleton returns 'CIRCLE'", () => {
+    expect(ShapeType.CIRCLE.toString()).toBe("CIRCLE");
+  });
+
+  it("POLYGON singleton returns 'POLYGON'", () => {
+    expect(ShapeType.POLYGON.toString()).toBe("POLYGON");
+  });
+
+  it("CAPSULE singleton returns 'CAPSULE'", () => {
+    expect(ShapeType.CAPSULE.toString()).toBe("CAPSULE");
+  });
+
+  it("singletons are stable across accesses", () => {
+    expect(ShapeType.CIRCLE).toBe(ShapeType.CIRCLE);
+    expect(ShapeType.POLYGON).toBe(ShapeType.POLYGON);
+    expect(ShapeType.CAPSULE).toBe(ShapeType.CAPSULE);
+  });
+
+  it("throws when constructed without internal flag", () => {
+    expect(() => new ShapeType()).toThrow("Cannot instantiate ShapeType derp!");
+  });
+
+  it("unknown instance toString() returns empty string", () => {
+    ZPP_Flags.internal = true;
+    const unknown = new ShapeType();
+    ZPP_Flags.internal = false;
+    expect(unknown.toString()).toBe("");
+  });
+});
+
+describe("ListenerType coverage", () => {
+  it("BODY singleton returns 'BODY'", () => {
+    expect(ListenerType.BODY.toString()).toBe("BODY");
+  });
+
+  it("CONSTRAINT singleton returns 'CONSTRAINT'", () => {
+    expect(ListenerType.CONSTRAINT.toString()).toBe("CONSTRAINT");
+  });
+
+  it("INTERACTION singleton returns 'INTERACTION'", () => {
+    expect(ListenerType.INTERACTION.toString()).toBe("INTERACTION");
+  });
+
+  it("PRE singleton returns 'PRE'", () => {
+    expect(ListenerType.PRE.toString()).toBe("PRE");
+  });
+
+  it("singletons are stable across accesses", () => {
+    expect(ListenerType.BODY).toBe(ListenerType.BODY);
+    expect(ListenerType.CONSTRAINT).toBe(ListenerType.CONSTRAINT);
+    expect(ListenerType.INTERACTION).toBe(ListenerType.INTERACTION);
+    expect(ListenerType.PRE).toBe(ListenerType.PRE);
+  });
+
+  it("all types are distinct", () => {
+    const types = [
+      ListenerType.BODY,
+      ListenerType.CONSTRAINT,
+      ListenerType.INTERACTION,
+      ListenerType.PRE,
+    ];
+    for (let i = 0; i < types.length; i++) {
+      for (let j = i + 1; j < types.length; j++) {
+        expect(types[i]).not.toBe(types[j]);
+      }
+    }
+  });
+
+  it("throws when constructed without internal flag", () => {
+    expect(() => new ListenerType()).toThrow("Cannot instantiate ListenerType derp!");
+  });
+
+  it("unknown instance toString() returns empty string", () => {
+    ZPP_Flags.internal = true;
+    const unknown = new ListenerType();
+    ZPP_Flags.internal = false;
+    expect(unknown.toString()).toBe("");
+  });
+});

--- a/tests/phys/FluidProperties.coverage.test.ts
+++ b/tests/phys/FluidProperties.coverage.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { FluidProperties } from "../../src/phys/FluidProperties";
+import { Vec2 } from "../../src/geom/Vec2";
+import { ZPP_FluidProperties } from "../../src/native/phys/ZPP_FluidProperties";
+
+describe("FluidProperties — coverage", () => {
+  describe("gravity setter/getter", () => {
+    it("should set gravity then verify it exists", () => {
+      const fp = new FluidProperties();
+      fp.gravity = new Vec2(0, -100);
+      expect(fp.gravity).not.toBeNull();
+      expect(fp.gravity.x).toBeCloseTo(0);
+      expect(fp.gravity.y).toBeCloseTo(-100);
+    });
+
+    it("should clear gravity by setting wrap_gravity to null", () => {
+      const fp = new FluidProperties();
+      fp.gravity = new Vec2(0, -100);
+      expect(fp.gravity).not.toBeNull();
+      // Use internal path to clear (full dispose needs zpp_nape bootstrap)
+      fp.zpp_inner.wrap_gravity = null;
+      expect(fp.gravity).toBeNull();
+    });
+
+    it("should update gravity from one Vec2 to another", () => {
+      const fp = new FluidProperties();
+      fp.gravity = new Vec2(0, -100);
+      fp.gravity = new Vec2(10, -200);
+      expect(fp.gravity.x).toBeCloseTo(10);
+      expect(fp.gravity.y).toBeCloseTo(-200);
+    });
+
+    it("should set gravity then set same values (no-op branch)", () => {
+      const fp = new FluidProperties();
+      fp.gravity = new Vec2(5, 10);
+      // Setting same values should still work
+      fp.gravity = new Vec2(5, 10);
+      expect(fp.gravity.x).toBeCloseTo(5);
+      expect(fp.gravity.y).toBeCloseTo(10);
+    });
+  });
+
+  describe("copy with gravity", () => {
+    it("should copy FluidProperties with gravity set", () => {
+      const fp = new FluidProperties(2.0, 0.5);
+      fp.gravity = new Vec2(0, -200);
+      const copy = fp.copy();
+
+      expect(copy.density).toBeCloseTo(2.0);
+      expect(copy.viscosity).toBeCloseTo(0.5);
+      expect(copy.gravity).not.toBeNull();
+      expect(copy.gravity.x).toBeCloseTo(0);
+      expect(copy.gravity.y).toBeCloseTo(-200);
+    });
+
+    it("should copy FluidProperties without gravity", () => {
+      const fp = new FluidProperties(3.0, 1.5);
+      const copy = fp.copy();
+      expect(copy.density).toBeCloseTo(3.0);
+      expect(copy.viscosity).toBeCloseTo(1.5);
+      expect(copy.gravity).toBeNull();
+    });
+  });
+
+  describe("_wrap edge cases", () => {
+    it("should wrap legacy object with zpp_inner", () => {
+      const fp = new FluidProperties(2.0, 0.5);
+      const legacy = { zpp_inner: fp.zpp_inner };
+      const wrapped = FluidProperties._wrap(legacy);
+      expect(wrapped).toBeInstanceOf(FluidProperties);
+      expect(wrapped.density).toBeCloseTo(2.0);
+    });
+
+    it("should return null for unknown object", () => {
+      const result = FluidProperties._wrap({ foo: "bar" });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("pool reuse", () => {
+    it("should reuse pooled ZPP_FluidProperties instances", () => {
+      // Create and grab inner
+      const fp1 = new FluidProperties(1.0, 1.0);
+      const inner1 = fp1.zpp_inner;
+
+      // Return to pool
+      inner1.next = ZPP_FluidProperties.zpp_pool;
+      ZPP_FluidProperties.zpp_pool = inner1;
+
+      // Next creation should reuse
+      const fp2 = new FluidProperties(5.0, 2.0);
+      expect(fp2.zpp_inner).toBe(inner1);
+      expect(fp2.density).toBeCloseTo(5.0);
+    });
+  });
+
+  // shapes getter requires full zpp_nape bootstrap — tested in integration tests
+
+  describe("toString", () => {
+    it("should include gravity in string when set", () => {
+      const fp = new FluidProperties(1.5, 0.8);
+      fp.gravity = new Vec2(0, -100);
+      const str = fp.toString();
+      expect(str).toContain("density:");
+      expect(str).toContain("1.5");
+      expect(str).toContain("viscosity:");
+      expect(str).toContain("0.8");
+      expect(str).toContain("gravity:");
+    });
+  });
+});

--- a/tests/shape/Shape.coverage.test.ts
+++ b/tests/shape/Shape.coverage.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from "vitest";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { Capsule } from "../../src/shape/Capsule";
+import { ShapeType } from "../../src/shape/ShapeType";
+import { Material } from "../../src/phys/Material";
+import { InteractionFilter } from "../../src/dynamics/InteractionFilter";
+import { Space } from "../../src/space/Space";
+
+// Side-effect imports
+import "../../src/callbacks/PreFlag";
+import "../../src/dynamics/CollisionArbiter";
+import "../../src/dynamics/FluidArbiter";
+
+describe("Shape — coverage", () => {
+  describe("common properties", () => {
+    it("should get/set sensorEnabled", () => {
+      const shape = new Circle(10);
+      expect(shape.sensorEnabled).toBe(false);
+      shape.sensorEnabled = true;
+      expect(shape.sensorEnabled).toBe(true);
+    });
+
+    it("should get/set material", () => {
+      const shape = new Circle(10);
+      const mat = new Material(0.5, 0.3, 0.3, 1);
+      shape.material = mat;
+      expect(shape.material.elasticity).toBeCloseTo(0.5);
+    });
+
+    it("should get/set filter", () => {
+      const shape = new Circle(10);
+      const filter = new InteractionFilter();
+      shape.filter = filter;
+      expect(shape.filter).toBeDefined();
+    });
+
+    it("should get body reference after adding to body", () => {
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      const shape = new Circle(10);
+      body.shapes.add(shape);
+      expect(shape.body).toBe(body);
+    });
+
+    it("should get null body when not attached", () => {
+      const shape = new Circle(10);
+      expect(shape.body).toBeNull();
+    });
+
+    it("should get bounds after body is in space", () => {
+      const space = new Space(new Vec2(0, 0));
+      const body = new Body(BodyType.DYNAMIC, new Vec2(50, 50));
+      const shape = new Circle(10);
+      body.shapes.add(shape);
+      body.space = space;
+      space.step(1 / 60, 1, 1);
+
+      const bounds = shape.bounds;
+      expect(bounds).toBeDefined();
+      expect(bounds.width).toBeGreaterThan(0);
+    });
+
+    it("should get/set userData", () => {
+      const shape = new Circle(10);
+      shape.userData.tag = "test";
+      expect(shape.userData.tag).toBe("test");
+    });
+  });
+
+  describe("Circle", () => {
+    it("should get/set radius", () => {
+      const c = new Circle(10);
+      expect(c.radius).toBeCloseTo(10);
+      c.radius = 20;
+      expect(c.radius).toBeCloseTo(20);
+    });
+
+    it("should throw on NaN radius", () => {
+      const c = new Circle(10);
+      expect(() => {
+        c.radius = NaN;
+      }).toThrow();
+    });
+
+    it("should throw on negative radius", () => {
+      const c = new Circle(10);
+      expect(() => {
+        c.radius = -5;
+      }).toThrow();
+    });
+
+    it("should get type as CIRCLE", () => {
+      const c = new Circle(10);
+      expect(c.type).toBe(ShapeType.CIRCLE);
+    });
+
+    it("should get/set localCOM", () => {
+      const c = new Circle(10);
+      c.localCOM = new Vec2(5, 5);
+      expect(c.localCOM.x).toBeCloseTo(5);
+      expect(c.localCOM.y).toBeCloseTo(5);
+    });
+
+    it("should have toString", () => {
+      const c = new Circle(10);
+      expect(c.toString()).toBeDefined();
+    });
+
+    it("should copy circle", () => {
+      const c = new Circle(15);
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      body.shapes.add(c);
+      const bodyClone = body.copy();
+      expect(bodyClone.shapes.at(0).type).toBe(ShapeType.CIRCLE);
+    });
+  });
+
+  describe("Polygon", () => {
+    it("should get type as POLYGON", () => {
+      const p = new Polygon(Polygon.box(20, 20));
+      expect(p.type).toBe(ShapeType.POLYGON);
+    });
+
+    it("should get localVerts", () => {
+      const p = new Polygon(Polygon.box(20, 20));
+      const verts = p.localVerts;
+      expect(verts).toBeDefined();
+      expect(verts.length).toBe(4);
+    });
+
+    it("should get worldVerts when attached to body in space", () => {
+      const space = new Space(new Vec2(0, 0));
+      const body = new Body(BodyType.DYNAMIC, new Vec2(100, 100));
+      const p = new Polygon(Polygon.box(20, 20));
+      body.shapes.add(p);
+      body.space = space;
+      space.step(1 / 60, 1, 1);
+
+      const wverts = p.worldVerts;
+      expect(wverts).toBeDefined();
+      expect(wverts.length).toBe(4);
+    });
+
+    it("should create regular polygon", () => {
+      const verts = Polygon.regular(50, 50, 6);
+      expect(verts).toBeDefined();
+      const p = new Polygon(verts);
+      expect(p.localVerts.length).toBe(6);
+    });
+
+    it("should create rect", () => {
+      const verts = Polygon.rect(10, 20, 30, 40);
+      expect(verts).toBeDefined();
+      const p = new Polygon(verts);
+      expect(p.localVerts.length).toBe(4);
+    });
+
+    it("should have toString", () => {
+      const p = new Polygon(Polygon.box(20, 20));
+      expect(p.toString()).toBeDefined();
+    });
+
+    it("should get edges", () => {
+      const p = new Polygon(Polygon.box(20, 20));
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      body.shapes.add(p);
+      const edges = p.edges;
+      expect(edges).toBeDefined();
+      expect(edges.length).toBe(4);
+    });
+
+    it("should copy polygon via body", () => {
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      body.shapes.add(new Polygon(Polygon.box(20, 20)));
+      const copy = body.copy();
+      expect(copy.shapes.length).toBe(1);
+    });
+  });
+
+  describe("Capsule", () => {
+    it("should create capsule with width and height", () => {
+      const c = new Capsule(60, 20);
+      expect(c).toBeDefined();
+      expect(c.type).toBe(ShapeType.CAPSULE);
+    });
+
+    it("should get width and height", () => {
+      const c = new Capsule(60, 20);
+      expect(c.width).toBeCloseTo(60);
+      expect(c.height).toBeCloseTo(20);
+    });
+
+    it("should get/set radius", () => {
+      const c = new Capsule(60, 20);
+      expect(c.radius).toBeCloseTo(10); // height/2
+      c.radius = 15;
+      expect(c.radius).toBeCloseTo(15);
+    });
+
+    it("should have toString", () => {
+      const c = new Capsule(60, 20);
+      expect(c.toString()).toBeDefined();
+    });
+
+    it("should copy capsule via body", () => {
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      body.shapes.add(new Capsule(60, 20));
+      const copy = body.copy();
+      expect(copy.shapes.length).toBe(1);
+      expect(copy.shapes.at(0).type).toBe(ShapeType.CAPSULE);
+    });
+  });
+
+  describe("Edge", () => {
+    it("should iterate edges of a polygon", () => {
+      const p = new Polygon(Polygon.box(20, 20));
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      body.shapes.add(p);
+
+      const edges = p.edges;
+      expect(edges.length).toBe(4);
+
+      for (let i = 0; i < edges.length; i++) {
+        const edge = edges.at(i);
+        expect(edge).toBeDefined();
+        expect(edge.length).toBeGreaterThan(0);
+        expect(edge.localNormal).toBeDefined();
+      }
+    });
+
+    it("should get edge polygon reference", () => {
+      const p = new Polygon(Polygon.box(20, 20));
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      body.shapes.add(p);
+
+      const edge = p.edges.at(0);
+      expect(edge.polygon).toBe(p);
+    });
+
+    it("should get local vertices of edge", () => {
+      const p = new Polygon(Polygon.box(20, 20));
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      body.shapes.add(p);
+
+      const edge = p.edges.at(0);
+      expect(edge.localVertex1).toBeDefined();
+      expect(edge.localVertex2).toBeDefined();
+    });
+
+    it("should get world vertices when in space", () => {
+      const space = new Space(new Vec2(0, 0));
+      const body = new Body(BodyType.DYNAMIC, new Vec2(100, 100));
+      const p = new Polygon(Polygon.box(20, 20));
+      body.shapes.add(p);
+      body.space = space;
+      space.step(1 / 60, 1, 1);
+
+      const edge = p.edges.at(0);
+      expect(edge.worldVertex1).toBeDefined();
+      expect(edge.worldVertex2).toBeDefined();
+      expect(edge.worldNormal).toBeDefined();
+    });
+
+    it("should have toString", () => {
+      const p = new Polygon(Polygon.box(20, 20));
+      const body = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      body.shapes.add(p);
+      const edge = p.edges.at(0);
+      expect(edge.toString()).toBeDefined();
+    });
+  });
+});

--- a/tests/space/Broadphase.coverage.test.ts
+++ b/tests/space/Broadphase.coverage.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { Broadphase } from "../../src/space/Broadphase";
+import { AABB } from "../../src/geom/AABB";
+
+// Side-effect imports
+import "../../src/callbacks/PreFlag";
+import "../../src/dynamics/CollisionArbiter";
+import "../../src/dynamics/FluidArbiter";
+
+function makeBodies(space: Space, count: number, spread = 200): Body[] {
+  const bodies: Body[] = [];
+  for (let i = 0; i < count; i++) {
+    const b = new Body(
+      BodyType.DYNAMIC,
+      new Vec2(((i % 10) * spread) / 10, (Math.floor(i / 10) * spread) / 10),
+    );
+    b.shapes.add(new Circle(5));
+    b.space = space;
+    bodies.push(b);
+  }
+  return bodies;
+}
+
+describe("Broadphase — coverage", () => {
+  const broadphaseTypes = [
+    { name: "DYNAMIC_AABB_TREE", type: Broadphase.DYNAMIC_AABB_TREE },
+    { name: "SWEEP_AND_PRUNE", type: Broadphase.SWEEP_AND_PRUNE },
+    { name: "SPATIAL_HASH", type: Broadphase.SPATIAL_HASH },
+  ];
+
+  describe.each(broadphaseTypes)("$name", ({ type }) => {
+    it("should handle many bodies added and stepped", () => {
+      const space = new Space(new Vec2(0, 100), type);
+      makeBodies(space, 20);
+      for (let i = 0; i < 10; i++) space.step(1 / 60, 3, 3);
+      expect(space.bodies.length).toBe(20);
+    });
+
+    it("should handle body removal during simulation", () => {
+      const space = new Space(new Vec2(0, 100), type);
+      const bodies = makeBodies(space, 10);
+      for (let i = 0; i < 5; i++) space.step(1 / 60, 3, 3);
+
+      // Remove half the bodies
+      for (let i = 0; i < 5; i++) {
+        bodies[i].space = null;
+      }
+      for (let i = 0; i < 5; i++) space.step(1 / 60, 3, 3);
+      expect(space.bodies.length).toBe(5);
+    });
+
+    it("should detect collisions between overlapping circles", () => {
+      const space = new Space(new Vec2(0, 0), type);
+      const b1 = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      b1.shapes.add(new Circle(20));
+      b1.space = space;
+
+      const b2 = new Body(BodyType.DYNAMIC, new Vec2(10, 0));
+      b2.shapes.add(new Circle(20));
+      b2.space = space;
+
+      space.step(1 / 60, 5, 5);
+
+      // They overlap, so there should be collision arbiters
+      const arb = space.arbiters.at(0);
+      expect(arb).toBeDefined();
+    });
+
+    it("should handle kinematic bodies", () => {
+      const space = new Space(new Vec2(0, 0), type);
+      const floor = new Body(BodyType.STATIC, new Vec2(0, 100));
+      floor.shapes.add(new Polygon(Polygon.box(200, 10)));
+      floor.space = space;
+
+      const kin = new Body(BodyType.KINEMATIC, new Vec2(0, 0));
+      kin.shapes.add(new Circle(10));
+      kin.velocity = new Vec2(50, 0);
+      kin.space = space;
+
+      for (let i = 0; i < 20; i++) space.step(1 / 60, 3, 3);
+      expect(kin.position.x).toBeGreaterThan(10);
+    });
+
+    it("should handle sensor shapes (no collision response)", () => {
+      const space = new Space(new Vec2(0, 0), type);
+      const b1 = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+      const s1 = new Circle(20);
+      s1.sensorEnabled = true;
+      b1.shapes.add(s1);
+      b1.space = space;
+
+      const b2 = new Body(BodyType.DYNAMIC, new Vec2(10, 0));
+      b2.shapes.add(new Circle(20));
+      b2.space = space;
+
+      space.step(1 / 60, 5, 5);
+      // Sensor should not push bodies apart
+    });
+
+    it("should add bodies between steps", () => {
+      const space = new Space(new Vec2(0, 100), type);
+      makeBodies(space, 5);
+      space.step(1 / 60, 3, 3);
+
+      // Add more bodies
+      makeBodies(space, 5, 300);
+      space.step(1 / 60, 3, 3);
+      expect(space.bodies.length).toBe(10);
+    });
+  });
+
+  describe("cross-broadphase parity", () => {
+    it("should produce collisions with all three broadphase types", () => {
+      for (const bp of broadphaseTypes) {
+        const space = new Space(new Vec2(0, 500), bp.type);
+
+        const floor = new Body(BodyType.STATIC, new Vec2(0, 100));
+        floor.shapes.add(new Polygon(Polygon.box(500, 10)));
+        floor.space = space;
+
+        const ball = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+        ball.shapes.add(new Circle(10));
+        ball.space = space;
+
+        for (let i = 0; i < 60; i++) space.step(1 / 60, 5, 5);
+
+        // Ball should have fallen onto floor
+        expect(ball.position.y).toBeGreaterThan(50);
+        expect(ball.position.y).toBeLessThan(110);
+      }
+    });
+  });
+
+  describe("bodiesInAABB / shapesInAABB", () => {
+    it("should find bodies within an AABB region", () => {
+      const space = new Space(new Vec2(0, 0), Broadphase.DYNAMIC_AABB_TREE);
+
+      const b1 = new Body(BodyType.DYNAMIC, new Vec2(50, 50));
+      b1.shapes.add(new Circle(5));
+      b1.space = space;
+
+      const b2 = new Body(BodyType.DYNAMIC, new Vec2(200, 200));
+      b2.shapes.add(new Circle(5));
+      b2.space = space;
+
+      space.step(1 / 60, 1, 1);
+
+      const queryAABB = new AABB(0, 0, 100, 100);
+      const found = space.bodiesInAABB(queryAABB);
+      expect(found.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should find shapes within an AABB region", () => {
+      const space = new Space(new Vec2(0, 0), Broadphase.DYNAMIC_AABB_TREE);
+
+      const b1 = new Body(BodyType.DYNAMIC, new Vec2(50, 50));
+      b1.shapes.add(new Circle(5));
+      b1.space = space;
+
+      space.step(1 / 60, 1, 1);
+
+      const queryAABB = new AABB(0, 0, 100, 100);
+      const found = space.shapesInAABB(queryAABB);
+      expect(found.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
New test files targeting low-coverage areas:
- EnumTypes: ArbiterType, BodyType, ShapeType, ListenerType toString fallback
- AABB: fromPoints, equals, clone, constructor edge cases
- InteractionGroup: interactors, groups, ignore flag, _wrap
- FluidProperties: gravity setter, copy with gravity, pool reuse
- Broadphase: all 3 types (AABB tree, SAP, spatial hash) scenarios
- Constraint: copy/toString for all joint types, breakUnderForce
- Shape: Circle, Polygon, Capsule, Edge properties and copy