### PR TITLE
docs: clean up roadmap — remove completed items, add new priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Fully typed, tree-shakeable 2D physics engine — a modern TypeScript rewrite of
 
 **[Homepage & Interactive Demos](https://newkrok.github.io/nape-js/)** | **[API Reference](https://newkrok.github.io/nape-js/api/)** | **[Examples](https://newkrok.github.io/nape-js/examples.html)** | **[Multiplayer Demo](https://newkrok.github.io/nape-js/multiplayer.html)**
 
+**[Cookbook](docs/guides/cookbook.md)** | **[Troubleshooting](docs/guides/troubleshooting.md)** | **[Anti-Patterns](docs/guides/anti-patterns.md)**
+
 - Originally created in Haxe by Luca Deltodesco
 - Ported to TypeScript by Istvan Krisztian Somoracz
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,34 +68,68 @@ Cancelled: P34 (tree shaking — architectural limit), P36 (server demos — sup
 
 ## New Priorities
 
+### Ecosystem & Integrations
+
 | # | Priority | Effort | Impact | Why |
 |---|----------|--------|--------|-----|
 | P58 | **Phaser plugin/adapter** | M | :fire: adoption | Phaser is the #1 JS game framework — direct integration = massive reach. Phaser Box2D exists but lacks fluid sim, character controller, serialization |
 | P59 | **React/R3F integration** | M | :fire: adoption | `@react-three/rapier`-style package for the React gamedev community. Growing market segment |
 | P60 | **Tilemap collision helper** | S | DX | Tiled/LDtk map -> physics body conversion. Common gamedev need, low effort, high utility |
-| P61 | **Bundle size reduction** | S-M | competitiveness | Close the gap with Phaser Box2D (65 KB). Audit for dead code, optimize hot paths |
-| P62 | **Particle system** | S-M | features | Simple physics-aware particle emitter — commonly requested by gamedevs |
+
+### Developer Experience & Onboarding
+
+| # | Priority | Effort | Impact | Why |
+|---|----------|--------|--------|-----|
+| P63 | **AI/LLM-friendly docs + Cookbook** | S | :fire: adoption | AI-korszakban a legjobb marketing ha az AI jo kodot general. Strukturalt prompt-peldak, 20-30 copy-paste recipe (platformer, ragdoll, fluid pool, pinball stb.), troubleshooting guide az API gotchakkal. A meglevo `llms.txt` jo alap |
+| P65 | **One-click game templates** | M | :fire: adoption | `npm create nape-game@latest` vagy StackBlitz template-ek: platformer starter (CharacterController + tilemap + camera), top-down car, ragdoll fighter, pinball. 5 perc alatt futo elso jatek = legfontosabb onboarding elem |
+| P66 | **Trigger zone API** | S | DX | Magas szintu Unity-stílusu `onEnter/onStay/onExit` wrapper a callback rendszer folott. A jelenlegi CbType-alapu API mukodik de nem intuitiv. Egyszerusitett API csökkenti a belépési küszöböt |
+
+### Physics Features
+
+| # | Priority | Effort | Impact | Why |
+|---|----------|--------|--------|-----|
+| P62 | **Particle system** | S-M | features | Fizika-tudatos particle emitter — gamedevek altal gyakran kert feature |
+| P64 | **Spring/Damper joint** | S | features | Hianyzó alap constraint. Soft-body, vehicle suspension, ragdoll hair, UI animaciok mind rugot akarnak. Most csak UserConstraint-tel oldhato meg |
+| P67 | **Destruction/Fracture system** | M | :fire: wow-factor | Voronoi-alapu toredezes — `Body.fracture(impactPoint, energy)` API. Egyetlen mas JS engine sem csinalja. Mar van `createConcaveBody` es `destructible-terrain` demo mint alap. Vizualisan latvanjos, marketing gold |
+
+### Tooling & Infrastructure
+
+| # | Priority | Effort | Impact | Why |
+|---|----------|--------|--------|-----|
+| P61 | **Bundle size reduction** | S-M | competitiveness | 87 KB vs Phaser Box2D 65 KB gap csökkentese. Dead code audit, hot path optimalizalas |
+| P68 | **Performance profiler / debug overlay** | S | DX | Runtime profiler: broadphase/narrowphase/solver ido, body/contact/constraint szam, sleep statisztikak, bottleneck highlight. Rapier-nek van, nekünk nincs. Bizalomépiítés profi fejlesztoknel |
+| P69 | **Deterministic replay system** | M | features | Input-rogzites + visszajátszas a meglevo serializacio + determinisztikus mod felett. Debug bug-reprodukcio, multiplayer rollback alap, megosztható replay, determinisztikus regression teszt — egy feature ami osszekot tobbet |
 
 ---
 
 ## Recommended Execution Order
 
-### Phase 1 — Finish what's started (next)
+### Phase 1 — Finish what's started + onboarding (next)
 
 1. **P44 Phase 2** — Ship `@newkrok/nape-pixi` npm package (auto-sync transforms, typed API, TSDoc)
-2. **P56** — Interactive playground (StackBlitz/CodeSandbox template, editable examples)
+2. **P63** — AI/LLM docs + Cookbook (legkisebb effort, legnagyobb hatás az AI-korszakban)
+3. **P56** — Interactive playground (StackBlitz/CodeSandbox template, editable examples)
 
-### Phase 2 — Ecosystem growth
+### Phase 2 — Wow-factor + ecosystem
 
-3. **P58** — Phaser plugin/adapter (biggest community reach opportunity)
-4. **P60** — Tilemap collision helper (low effort, high gamedev utility)
-5. **P59** — React/R3F integration (growing market)
+4. **P67** — Destruction/Fracture system (egyedülálló feature, marketing érték)
+5. **P58** — Phaser plugin/adapter (biggest community reach opportunity)
+6. **P65** — One-click game templates (5 perc elso jatekk)
+7. **P66** — Trigger zone API (kicsi effort, nagy DX javulas)
 
-### Phase 3 — Polish & features
+### Phase 3 — Ecosystem expand
 
-6. **P61** — Bundle size reduction
-7. **P62** — Particle system
-8. **P29** — Continue test coverage push toward 80%
+8. **P60** — Tilemap collision helper (low effort, high gamedev utility)
+9. **P59** — React/R3F integration (growing market)
+10. **P64** — Spring/Damper joint (alapveto fizika feature)
+
+### Phase 4 — Polish & tooling
+
+11. **P62** — Particle system
+12. **P68** — Performance profiler
+13. **P69** — Deterministic replay system
+14. **P61** — Bundle size reduction
+15. **P29** — Continue test coverage push toward 80%
 
 ### Ongoing — Marketing & Visibility
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# nape-js — Roadmap & Priority History
+# nape-js — Roadmap
 
 ## Competitive Advantages
 
@@ -11,384 +11,114 @@ nape-js already leads in several areas vs Matter.js, Planck.js, and other pure-J
 - **Full TypeScript** with `strict: true` — Matter.js relies on DefinitelyTyped
 - **Serialization API** — save/load/replay/multiplayer sync
 - **Debug draw API** — abstract interface, no renderer dependency in core
+- **Character controller** — geometric collide-and-slide with slope/step/one-way/moving platform support
+- **Sub-stepping solver** — configurable `space.subSteps` for improved stability
 
 Key competitors to watch:
 - **Phaser Box2D** (Dec 2024) — Box2D v3 port, 65KB, improved solver+CCD, speculative collision
-- **Rapier** — WASM+SIMD, cross-platform determinism, binary snapshots, 2–5x faster for large scenes, but large bundle + async init
-- **Matter.js** — largest community (14–16k stars) but no CCD, no TypeScript, 2+ years inactive
+- **Rapier** — WASM+SIMD, cross-platform determinism, binary snapshots, 2-5x faster for large scenes, but large bundle + async init
+- **Matter.js** — largest community (14-16k stars) but no CCD, no TypeScript, 2+ years inactive
 - **Planck.js** — Box2D v2 port, 4.8k stars, 577 npm/week, no CCD, no fluid sim
 - **p2-es** — modernized p2.js fork (poimandres), ESM+TS, small community (440 npm/week)
 
-### Detailed Competitor Feature Matrix
+### Competitor Feature Matrix
 
 | Feature | nape-js | Matter.js | Planck.js | p2-es | Rapier | Phaser Box2D |
 |---------|---------|-----------|-----------|-------|--------|--------------|
-| **CCD** | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| **Fluid Sim** | ✅ Unique | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Full TypeScript** | ✅ strict | ⚠️ DT | ❌ JS | ✅ fork | ⚠️ WASM | ✅ |
-| **Serialization** | ✅ JSON+Binary | ❌ | ❌ | ❌ | ✅ Binary | ❌ |
-| **Web Worker Helper** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Deterministic** | 🔶 Soft (P48) | ❌ | ✅ Fixed dt | ✅ | ✅ Cross-platform | ❌ |
+| **CCD** | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :white_check_mark: |
+| **Fluid Sim** | :white_check_mark: Unique | :x: | :x: | :x: | :x: | :x: |
+| **Full TypeScript** | :white_check_mark: strict | :warning: DT | :x: JS | :white_check_mark: fork | :warning: WASM | :white_check_mark: |
+| **Serialization** | :white_check_mark: JSON+Binary | :x: | :x: | :x: | :white_check_mark: Binary | :x: |
+| **Character Controller** | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :x: |
+| **Sub-stepping** | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :x: |
+| **Web Worker Helper** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+| **Deterministic** | :diamonds: Soft | :x: | :white_check_mark: Fixed dt | :white_check_mark: | :white_check_mark: Cross-platform | :x: |
 | **Bundle Size** | 87 KB / 16 KB gz | Large | Medium | Medium | 78 KB WASM | 65 KB |
-| **Debug Draw API** | ✅ Abstract | ❌ Built-in | ❌ | ❌ | ❌ | ❌ |
-| **Capsule Shape** | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| **Concave Helper** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Community** | Growing | 14–16k ⭐ | 4.8k ⭐ | Small | Medium | Growing |
-| **Active Dev** | ✅ | ❌ 2+ yrs | ✅ | ✅ fork | ✅ | ✅ |
+| **Debug Draw API** | :white_check_mark: Abstract | :x: Built-in | :x: | :x: | :x: | :x: |
+| **Capsule Shape** | :white_check_mark: | :x: | :x: | :white_check_mark: | :white_check_mark: | :x: |
+| **Concave Helper** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+| **Community** | Growing | 14-16k :star: | 4.8k :star: | Small | Medium | Growing |
+| **Active Dev** | :white_check_mark: | :x: 2+ yrs | :white_check_mark: | :white_check_mark: fork | :white_check_mark: | :white_check_mark: |
 
-### Competitive Gaps to Address
+### Competitive Gaps
 
-1. **Cross-platform determinism** — Rapier has bit-level IEEE 754 determinism; our P48 targets "soft" only (same-platform). True cross-platform is impractical in pure JS.
-2. **Raw performance** — Rapier WASM+SIMD is 2–5x faster for large scenes (1000+ bodies). Our P46 hot-path optimization helps but cannot match WASM.
-3. **CCD no longer exclusive** — Phaser Box2D (Dec 2024) now has CCD+speculative collision. Still an advantage vs Matter.js/Planck.js/p2.
-4. **Bundle size gap** — Phaser Box2D is 65 KB vs our 87 KB (small gap, but notable).
-5. **Community size** — Matter.js has 14–16k stars despite being stale. We need marketing/visibility.
+1. **Cross-platform determinism** — Rapier has bit-level IEEE 754 determinism; ours is "soft" (same-platform). True cross-platform is impractical in pure JS.
+2. **Raw performance** — Rapier WASM+SIMD is 2-5x faster for large scenes (1000+ bodies). Hot-path optimization helps but cannot match WASM.
+3. **Bundle size gap** — Phaser Box2D is 65 KB vs our 87 KB (small gap, but notable).
+4. **Community size** — Matter.js has 14-16k stars despite being stale. We need marketing/visibility.
 
 ---
 
-## Ideas Not Yet on Roadmap
+## Completed Items
 
-Potential future priorities identified via competitive analysis and market gaps:
+Done: P21-P28, P30-P33, P35, P37-P43, P45-P48, P50-P55, P57.
+Cancelled: P34 (tree shaking — architectural limit), P36 (server demos — superseded by P52), P49 (ECS adapter — trivial pattern).
 
-| Idea | Why | Effort | Impact |
-|------|-----|--------|--------|
-| **Phaser plugin/adapter** | Phaser is the #1 JS game framework; direct integration = massive reach | M | 🔥 Very high |
-| **React/R3F integration** | `@react-three/rapier`-style package for React gamedev community | M | 🔥 High |
-| **Particle system** | Simple physics-aware particle emitter — commonly requested by gamedevs | S-M | Medium |
-| **Tilemap collision helper** | Tiled/LDtk map → physics body conversion — common gamedev need | S | Medium |
+---
 
-### Marketing & Visibility Opportunities
+## Active Priorities
+
+| # | Priority | Effort | Impact | Status |
+|---|----------|--------|--------|--------|
+| P29 | Test coverage >= 80% | L | safety | :diamonds: ~57% (4873 tests) |
+| P44 | PixiJS integration — npm package | M | adoption | :diamonds: Phase 1 done (demos), Phase 2 pending (npm package) |
+| P56 | Interactive playground | S-M | adoption | :white_square_button: Not started |
+
+---
+
+## New Priorities
+
+| # | Priority | Effort | Impact | Why |
+|---|----------|--------|--------|-----|
+| P58 | **Phaser plugin/adapter** | M | :fire: adoption | Phaser is the #1 JS game framework — direct integration = massive reach. Phaser Box2D exists but lacks fluid sim, character controller, serialization |
+| P59 | **React/R3F integration** | M | :fire: adoption | `@react-three/rapier`-style package for the React gamedev community. Growing market segment |
+| P60 | **Tilemap collision helper** | S | DX | Tiled/LDtk map -> physics body conversion. Common gamedev need, low effort, high utility |
+| P61 | **Bundle size reduction** | S-M | competitiveness | Close the gap with Phaser Box2D (65 KB). Audit for dead code, optimize hot paths |
+| P62 | **Particle system** | S-M | features | Simple physics-aware particle emitter — commonly requested by gamedevs |
+
+---
+
+## Recommended Execution Order
+
+### Phase 1 — Finish what's started (next)
+
+1. **P44 Phase 2** — Ship `@newkrok/nape-pixi` npm package (auto-sync transforms, typed API, TSDoc)
+2. **P56** — Interactive playground (StackBlitz/CodeSandbox template, editable examples)
+
+### Phase 2 — Ecosystem growth
+
+3. **P58** — Phaser plugin/adapter (biggest community reach opportunity)
+4. **P60** — Tilemap collision helper (low effort, high gamedev utility)
+5. **P59** — React/R3F integration (growing market)
+
+### Phase 3 — Polish & features
+
+6. **P61** — Bundle size reduction
+7. **P62** — Particle system
+8. **P29** — Continue test coverage push toward 80%
+
+### Ongoing — Marketing & Visibility
 
 | Platform | Strategy | Priority |
 |----------|----------|----------|
-| **Hacker News** (Show HN) | Benchmark post: "nape-js vs Matter.js — CCD + Fluid sim in 87KB" | 🔥 Very high |
-| **Reddit** r/gamedev + r/javascript | Fluid simulation demo GIF/video — visually impressive | 🔥 Very high |
-| **dev.to / Medium** | "Why I rewrote a Haxe physics engine in TypeScript" — story post | High |
-| **Twitter/X #gamedev** | Short videos: fluid sim, CCD demo, multiplayer demo | High |
-| **Phaser community forum** | Announce Phaser plugin once ready | High |
-| **PixiJS Discord** | Announce P44 PixiJS integration once shipped | Medium |
-| **awesome-\* GitHub lists** | PRs to awesome-gamedev, awesome-typescript, awesome-javascript | ⭐ Easy win |
-| **Gamedev jams** (Ludum Dare, js13k) | Recommend engine to jam participants | Medium |
+| **Hacker News** (Show HN) | Benchmark post: "nape-js vs Matter.js — CCD + Fluid sim in 87KB" | :fire: Very high |
+| **Reddit** r/gamedev + r/javascript | Fluid simulation demo GIF/video | :fire: Very high |
+| **dev.to / Medium** | "Why I rewrote a Haxe physics engine in TypeScript" | High |
+| **Twitter/X #gamedev** | Short videos: fluid sim, CCD demo, multiplayer | High |
+| **Phaser community forum** | Announce Phaser plugin once P58 ships | High |
+| **awesome-* GitHub lists** | PRs to awesome-gamedev, awesome-typescript | :star: Easy win |
 | **YouTube tutorial** | "Build a platformer with nape-js in 10 minutes" | Medium-high |
+| **Gamedev jams** (Ludum Dare, js13k) | Recommend to jam participants | Medium |
 
 ---
 
-## Priority Table
-
-### Completed & Cancelled
-
-Done: P21–P28, P30–P33, P35, P37–P43, P46, P48, P50, P52, P53, P57.
-Cancelled: P34 (tree shaking — architectural limit), P36 (server demos — superseded by P52), P49 (ECS adapter — trivial pattern).
-
-### Active & Planned
-
-| Priority                                  | Effort | Impact    | Risk   | Status         |
-| ----------------------------------------- | ------ | --------- | ------ | -------------- |
-| P29 — Test coverage ≥80%                  | L      | safety    | none   | 🔶 ~57% (4873 tests) |
-| P44 — PixiJS integration package          | M      | adoption  | low    | 🔶 Phase 1 done |
-| P45 — Character controller                | M      | DX        | medium | ✅ Done |
-| P47 — CJS bundle dedup (serialization)    | S      | bundle    | low    | ✅ Done |
-| P51 — Sub-stepping solver                 | M      | stability | low    | ✅ Done |
-| P54 — Performance benchmark page          | S      | adoption  | low    | ✅ Done |
-| P55 — npm/SEO optimization                | XS     | adoption  | low    | ✅ Done |
-| P56 — Interactive playground              | S-M    | adoption  | low    | ⬜ Not started |
-| P57 — Polygon + Material tunneling bug    | M      | stability | medium | ✅ Done |
-
----
-
-## In Progress: P29 — Test Coverage
-
-**Effort: L | Impact: safety | Risk: none | Status: 🔶 ~57% (4873 tests)**
-
-### Integration Test Batch 1 (100 tests) — 2026-03-30
-
-Added 7 integration test files in `tests/integration/`:
-
-| File | Tests | Coverage Area |
-|------|-------|---------------|
-| `BodyLifecycle.integration.test.ts` | 24 | Add/remove bodies, type transitions (DYNAMIC↔STATIC↔KINEMATIC), compound lifecycle, mass/material, impulse, angular velocity, isBullet |
-| `FluidBuoyancy.integration.test.ts` | 10 | Buoyancy, viscosity effects, multiple fluid regions, fluid callbacks, constraints in fluid |
-| `CCD.integration.test.ts` | 12 | isBullet property, tunneling prevention, different shape types, multiple bullets, disableCCD |
-| `CallbackSystem.integration.test.ts` | 13 | BEGIN/END/ONGOING interaction lifecycle, BodyListener (WAKE/SLEEP), PreListener (IGNORE/ACCEPT), ConstraintListener (BREAK/SLEEP) |
-| `ShapeInteractions.integration.test.ts` | 16 | Circle/box/capsule collisions, friction/elasticity materials, InteractionFilter groups, multi-shape bodies |
-| `Serialization.integration.test.ts` | 17 | JSON & binary round-trip, simulation continuity after deserialize, constraints/gravity/velocity preservation, fluid properties |
-| `Raycasting.integration.test.ts` | 8 | Multi-body raycast, direction filtering, maxDistance, different shape types, post-simulation raycast |
-
-#### API Findings & Gotchas Discovered
-
-These findings should be documented in user-facing guides to prevent common mistakes:
-
-1. **No `applyForce()` on Body** — only `applyImpulse()` and `applyAngularImpulse()` exist. Force-based API is a common expectation from other engines (Matter.js, Box2D).
-2. **Compound body lifecycle** — bodies in a compound cannot have their `space` set individually; only the root `compound.space` can be assigned. Setting `body.space` on a compound member throws.
-3. **ConstraintListener requires custom CbType** — using `CbType.ANY_CONSTRAINT` does not work for BREAK/SLEEP events. A dedicated `CbType` must be created and added to the joint's `cbTypes`.
-4. **CCD is per-body, not per-space** — there is no `space.disableCCD`; use `body.isBullet` and `body.disableCCD` instead.
-5. **Material constructor order** — `Material(elasticity, dynamicFriction, staticFriction, density, rollingFriction)` — elasticity is first, not friction (differs from some engines).
-6. **Raycasting requires a step** — `space.rayCast()` on static bodies may require at least one `space.step()` call first for the broadphase to register shapes.
-
-#### Remaining Coverage Gaps (for future batches)
-
-- Character controller integration (platformer scenarios, slopes, one-way platforms)
-- Convex sweep / convexCast advanced scenarios
-- Debug draw integration with full simulation
-- Concave body creation + simulation
-- InteractionGroup hierarchy testing
-- Large-scene stress tests (100+ bodies)
-
----
-
-## In Progress: P44 — PixiJS Integration Package
-
-**Effort: M | Impact: adoption | Risk: low | Status: 🔶 Phase 1 done**
-
-### Phase 1 — Demo & CodePen support (✅ Done)
-
-- PixiJS adapter with Sprite + `generateTexture` pattern
-- `RENDERER_PIXI` CodePen helper, 28 demos with native `codePixi` snippets
-
-### Phase 2 — Public npm package (⬜ Pending)
-
-Target: `@newkrok/nape-pixi` or `@newkrok/nape-js/pixi` subpath export
-
-- Auto-sync body transforms → PixiJS Sprite/Container transforms
-- Create/destroy hooks, texture atlas support, typed API with TSDoc
-
----
-
-## Done: P45 — Character Controller
-
-**Effort: M | Impact: DX | Risk: medium**
-
-### Overview
-
-Two-layer geometric character controller inspired by Rapier's `KinematicCharacterController`
-and Box2D v3.1's character mover toolkit. Unlike dynamic-body approaches (force/impulse driven),
-a geometric controller uses shape-casting ("collide-and-slide") for pixel-perfect, single-frame
-movement resolution — the same approach used by Celeste, Hollow Knight, and most acclaimed
-2D platformers.
-
-**What sets nape-js apart from competitors:**
-
-| Feature | Rapier 2D | Box2D v3.1 | Matter/Planck | nape-js P45 |
-|---------|-----------|------------|---------------|-------------|
-| Abstraction level | High-level only | Low-level only | None | Both layers |
-| Moving platforms | Broken (open issue) | Manual | N/A | Built-in via surfaceVel |
-| One-way platforms | Manual filter | Manual filter | N/A | Built-in PreListener |
-| Fluid/swim mode | No | No | No | Built-in (buoyancy) |
-| TypeScript native | WASM bindings | C bindings | JS | Pure strict TS |
-| Serializable | No | No | No | Yes (JSON + binary) |
-
-### Architecture: Two-Layer API
-
-**High-level — `CharacterController` class** (batteries-included):
-
-```typescript
-const cc = new CharacterController(space, body, {
-  maxSlopeAngle: Math.PI / 4,  // 45° climbable
-  stepHeight: 8,                // auto-step small ledges
-  skinWidth: 0.5,               // numerical stability margin
-  snapToGround: 4,              // stick to ground on slopes
-  oneWayPlatformTag: platformCbType, // auto-setup PreListener
-  trackMovingPlatforms: true,   // inherit kinematic velocity
-});
-
-// Game loop:
-const result = cc.move(desiredDelta); // Vec2
-result.grounded;          // boolean
-result.groundNormal;      // Vec2 | null
-result.groundBody;        // Body | null
-result.onMovingPlatform;  // boolean
-result.slopeAngle;        // radians
-result.wallLeft;          // boolean
-result.wallRight;         // boolean
-result.numCollisions;     // number
-result.getCollision(i);   // { normal, point, body, shape }
-```
-
-**Low-level — exported utilities** (advanced / custom controllers):
-
-```typescript
-import { castShape, solvePlanes, clipVelocity } from 'nape-js';
-
-const hit = space.castShape(shape, translation, filter);
-const planes = space.collideMover(capsule, filter);
-const solved = solvePlanes(position, planes);
-const clipped = clipVelocity(velocity, planes);
-```
-
-### Features
-
-| Feature | Description |
-|---------|-------------|
-| Ground detection | Downward shape cast + normal angle check → `grounded`, `groundNormal`, `groundBody` |
-| Slope handling | `maxSlopeAngle` threshold — steeper slopes block movement; gentle slopes walk normally |
-| Step climbing | Up → forward → down cast sequence, bounded by `stepHeight` |
-| One-way platforms | Auto-configured PreListener — accept collision only when normal points up |
-| Moving platforms | Track kinematic body velocity; character inherits platform motion when grounded on it |
-| Snap to ground | Pre-step downward cast — prevents bouncing on slopes and stair edges |
-| Wall detection | Lateral shape casts → `wallLeft` / `wallRight` booleans + `wallNormal` |
-| Fluid/swim mode | Detect buoyancy shapes — reduce gravity, apply drag, enable swim movement |
-| Coyote time helper | `timeSinceGrounded` counter — game layer decides the window |
-| Collide-and-slide | Core algorithm: shape cast → slide along surface → repeat (max 3 iterations) |
-
-### Demo: Interactive Platformer Showcase
-
-Wide scrolling level (~3000×600 px) demonstrating every feature, with keyboard controls
-(WASD/arrows + Space). Requires a **camera system** in the demo framework (see below).
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│  ★ Coins                Moving Platform →                                       │
-│                          ═══════                    ┌──┐                        │
-│         ┌──┐                                  steps │  │                        │
-│  ───    │  │ step                              ─────┘  └───                     │
-│  ─────  └──┘        /                                        ≈≈≈≈≈≈≈≈          │
-│                    / slope        ═══════                    ≈ water ≈          │
-│  ─ ─ ─ ─ ─       /                                          ≈≈≈≈≈≈≈≈          │
-│  one-way      ═══════                                                           │
-│                                                                                 │
-│  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ │
-└─────────────────────────────────────────────────────────────────────────────────┘
-```
-
-### Demo Framework: Camera System
-
-New opt-in camera for demos whose physics world exceeds the 900×500 canvas viewport:
-
-- **`demo.camera`** config — `{ follow: bodyRef, offset, bounds, lerp, deadzone }`
-- Camera state stored per-demo, managed by DemoRunner
-- `Canvas2DAdapter` applies `ctx.translate(-camX, -camY)` before rendering
-- `drawGrid()` extended to tile infinitely within viewport
-- Pointer events inverse-transformed from screen → world coords
-- Other demos unaffected (no camera = identity transform)
-- Reusable by future demos (e.g. large constraint scenes, vehicle levels)
-
-### Implementation Order
-
-1. Camera system in demo framework (DemoRunner + Canvas2DAdapter + renderer)
-2. `CharacterController` core — collide-and-slide, `move()`, ground detection
-3. Slope handling + step climbing
-4. One-way platforms (PreListener auto-setup)
-5. Moving platform tracking
-6. Snap to ground + wall detection
-7. Fluid/swim mode integration
-8. Coyote time / helper properties
-9. Interactive platformer demo (wide level, keyboard controls)
-10. Unit + integration tests
-11. Docs update (API reference, guide, `CLAUDE.md`, README)
-
-### Competitive Analysis
-
-- **Rapier 2D**: High-level `KinematicCharacterController` with config. Known issues: moving
-  platforms broken (GitHub #488), slope angle settings were non-functional for months. Generic
-  design disclaimer: "may not work perfectly out-of-the-box for all game types."
-- **Box2D v3.1**: Low-level toolkit (`b2World_CastMover` + `b2SolvePlanes`). Capsule only.
-  Labeled "experimental." No built-in ground/slope/step helpers.
-- **Matter.js / Planck.js**: No character controller at all — developers build from scratch.
-- **Celeste / Hollow Knight**: Custom pixel-by-pixel systems with no physics engine for character
-  movement. Validates the geometric approach over dynamic bodies.
-
----
-
-## Done: P47 — CJS Bundle Dedup
-
-**Effort: S | Impact: bundle size | Risk: low**
-
-The serialization CJS bundle duplicated the entire engine (920 KB). Fixed by adding
-`splitting`, `treeshake`, and `target: "es2020"` to tsup config. CJS now code-splits
-into shared chunks — `serialization/index.cjs` dropped from 920 KB to 22 KB,
-`index.cjs` from 1006 KB to 103 KB.
-
----
-
-## Done: P51 — Sub-stepping Solver
-
-**Effort: M | Impact: stability | Risk: low**
-
-Added `space.subSteps` property (default: 1). When set to N > 1, each `step(dt)` call
-internally runs N sub-steps with `dt/N`, improving simulation stability for fast objects,
-stacking, and stiff constraints at the cost of proportionally more CPU time.
-
-**API:** `space.subSteps = 4` — good balance for most games. `1` = zero overhead (default).
-
-**Implementation:** The core physics pipeline (broadphase → narrowphase → prestep →
-velocity solve → position update → CCD → position solve → sleep management) runs N times
-per `step()` call, while outer bookkeeping (midstep flag, stamp, callbacks) runs once.
-
-**Tests:** 17 tests covering property validation, backward compatibility, tunneling
-prevention, stacking stability, joint stiffness, energy conservation, deterministic mode
-combo, and runtime changes.
-
-**Demo:** `docs/demos/sub-stepping.js` — fires bullets at a thin wall, left side
-(`subSteps=1`) shows tunneling, right side (`subSteps=4`) catches all bullets.
-
----
-
-## Done: P54 — Performance Benchmark Page
-
-**Effort: S | Impact: adoption | Risk: low | Status: ✅ Done**
-
-Public comparison page at `docs/benchmark.html` — nape-js vs Matter.js vs Planck.js vs Rapier (WASM):
-
-- **6 scenarios:** Falling Bodies (250/500/1000), Pyramid Stack, Constraint Chain, Mixed Shapes
-- **Visual preview:** live Canvas2D rendering during benchmark for each engine
-- **Fair methodology:** deterministic seeded layouts, warmup phase, median-based timing
-- **Feature matrix:** CCD, fluid sim, TypeScript, serialization, bundle size comparison
-- **Engine toggles:** enable/disable individual engines, run single or all scenarios
-- Links from index.html hero, demo tabs, and examples.html banner
-- Rapier (WASM) included with explicit note about JS vs WASM performance difference
-
----
-
-## Completed: P55 — npm/SEO Optimization
-
-**Effort: XS | Impact: adoption | Risk: low | Status: ✅ Done**
-
-Improved discoverability on npm and search engines:
-
-- ✅ Expanded package.json `keywords` from 7 to 20 (game-physics, fluid-simulation, multiplayer, etc.)
-- ✅ Optimized package.json `description` with high-value search terms
-- ✅ Set `homepage` to docs site (newkrok.github.io/nape-js)
-- ✅ README badges (npm version, downloads, CI, bundle size, license, docs)
-- ✅ Prominent docs/demos/API links in README header
-- ✅ JSON-LD structured data (SoftwareSourceCode schema) on landing page
-- ✅ Open Graph / Twitter Card with `summary_large_image` and social card
-- ✅ `theme-color` meta tag on all pages
-- ✅ Consistent meta descriptions across npm, GitHub, and docs site
-- ✅ Sitemap `lastmod` dates added
-- ✅ Version cache-buster strings synced to 3.16.1 across all HTML pages
-
----
-
-## Planned: P56 — Interactive Playground
-
-**Effort: S-M | Impact: adoption | Risk: low**
-
-Browser-based sandbox for instant try-out without local setup:
-
-- StackBlitz or CodeSandbox template with pre-configured nape-js
-- Editable examples: falling shapes, constraints, fluid sim, CCD
-- Link from README and docs landing page
-
----
-
-## Done: P57 — Polygon + Material Tunneling
-
-**Effort: M | Impact: stability | Risk: medium | Status: ✅ Done**
-
-Dynamic `Polygon` shapes with an explicit `Material` parameter tunneled through static `Polygon` floors (fall through without collision). Discovered 2026-03-28 during multiplayer platformer development. Fixed 2026-03-30.
-
-**Root cause:** The `Polygon` constructor signature was `(localVerts, material?, filter?)` while `Circle` was `(radius, localCOM?, material?, filter?)` and `Capsule` was `(width, height, localCOM?, material?, filter?)`. Users naturally wrote `new Polygon(verts, undefined, material)` following the Circle/Capsule pattern, but this silently passed `Material` into the `filter` parameter slot, breaking collision detection.
-
-**Fix:** Added `localCOM` parameter to `Polygon` constructor with smart overload detection. The 2nd parameter now accepts `Vec2 | Material` — if `Material` is detected, parameters shift automatically. `InteractionFilter` in the 3rd position is also detected for full backward compatibility.
-
-**Supported call patterns (all work correctly):**
-```js
-new Polygon(verts)                              // no material
-new Polygon(verts, material)                    // legacy — still works
-new Polygon(verts, undefined, material)         // P57 pattern — now works
-new Polygon(verts, localCOM, material, filter)  // new consistent API
-new Polygon(verts, undefined, filter)           // legacy — still works
-new Polygon(verts, material, filter)            // legacy — still works
-```
-
-**Tests:** 107 new tests covering: P57 regression (23), Shape × Material collision matrix (52), Material assignment timing (13), ZPP_Polygon native layer (19).
+## API Gotchas (from P29 testing)
+
+Discovered during integration testing — should be documented in user-facing guides:
+
+1. **No `applyForce()` on Body** — only `applyImpulse()` and `applyAngularImpulse()` exist
+2. **Compound body lifecycle** — only root `compound.space` can be assigned, not individual body `space`
+3. **ConstraintListener requires custom CbType** — `CbType.ANY_CONSTRAINT` does not work for BREAK/SLEEP events
+4. **CCD is per-body, not per-space** — use `body.isBullet` and `body.disableCCD`
+5. **Material constructor order** — `Material(elasticity, dynamicFriction, staticFriction, density, rollingFriction)`
+6. **Raycasting requires a step** — `space.rayCast()` on static bodies may need at least one `space.step()` first

--- a/docs/guides/anti-patterns.md
+++ b/docs/guides/anti-patterns.md
@@ -1,0 +1,301 @@
+# Anti-Patterns
+
+<!-- Last verified: v3.21.4 -->
+
+Common mistakes that cause bugs, poor performance, or confusion in nape-js.
+Each section shows the wrong approach, explains why it's a problem, and gives
+the correct alternative.
+
+---
+
+## Memory & Performance
+
+### Creating Vec2 every frame
+
+Allocating `new Vec2()` inside the game loop creates garbage every frame,
+triggering GC pauses that cause visible stuttering.
+
+```typescript
+// BAD — 60 allocations/sec, GC pressure
+function update() {
+  body.applyImpulse(new Vec2(10, 0));
+}
+
+// GOOD — reuse a pre-allocated vector
+const impulse = new Vec2(10, 0);
+function update() {
+  body.applyImpulse(impulse);
+}
+
+// ALSO GOOD — use the object pool
+function update() {
+  const v = Vec2.get(10, 0);
+  body.applyImpulse(v);
+  v.dispose(); // returns to pool
+}
+```
+
+### Using `Vec2.weak()` and keeping a reference
+
+Weak vectors are automatically disposed after their first use as a method
+argument. Holding a reference to them leads to "disposed Vec2" errors.
+
+```typescript
+// BAD — weak is auto-disposed after applyImpulse reads it
+const v = Vec2.weak(10, 0);
+body.applyImpulse(v);
+console.log(v.x); // ERROR: disposed
+
+// GOOD — use Vec2.get() when you need the value after
+const v = Vec2.get(10, 0);
+body.applyImpulse(v);
+console.log(v.x); // OK
+v.dispose();
+```
+
+### Iterating `space.bodies` to find one body
+
+Looping through all bodies every frame to find a specific one is O(n).
+
+```typescript
+// BAD — linear search every frame
+function update() {
+  for (const body of space.bodies) {
+    if (body.userData.id === "player") {
+      // do something
+    }
+  }
+}
+
+// GOOD — keep a direct reference
+const player = new Body(BodyType.DYNAMIC);
+// ... later:
+function update() {
+  player.position; // direct access, O(1)
+}
+```
+
+---
+
+## Body & Shape Setup
+
+### Using DYNAMIC bodies for character movement
+
+Force/impulse-based character movement on dynamic bodies is inherently
+imprecise — the character slides on slopes, bounces off walls, and can't
+do pixel-perfect movement.
+
+```typescript
+// BAD — sloppy, slides, hard to control
+function update() {
+  player.applyImpulse(new Vec2(moveX * 100, 0));
+  if (jump) player.applyImpulse(new Vec2(0, -5000));
+}
+
+// GOOD — geometric controller for precise platformer movement
+const cc = new CharacterController(space, player, {
+  maxSlopeAngle: Math.PI / 4,
+});
+cc.setVelocity(moveX * 200, player.velocity.y);
+```
+
+### Setting `body.space` on compound members
+
+Bodies inside a Compound share the compound's space assignment.
+Setting `.space` on a member throws an error.
+
+```typescript
+// BAD — throws
+const child = compound.bodies.at(0);
+child.space = space;
+
+// GOOD — assign space on the root compound
+compound.space = space;
+```
+
+### Setting position directly on kinematic bodies
+
+Setting `position` directly on a kinematic body teleports it — the physics
+solver doesn't know it moved, so it won't push dynamic bodies out of the way.
+
+```typescript
+// BAD — teleports, dynamic bodies clip through
+platform.position.x = targetX;
+
+// GOOD — set velocity so the solver handles contacts
+platform.velocity.x = (targetX - platform.position.x) / dt;
+```
+
+### Forgetting `body.allowRotation = false` on characters
+
+Characters without rotation locking will tumble and spin when they hit walls
+or land on slopes.
+
+```typescript
+// BAD — character rotates randomly
+const player = new Body(BodyType.DYNAMIC);
+player.shapes.add(new Circle(14));
+
+// GOOD — lock rotation for character controllers
+const player = new Body(BodyType.DYNAMIC);
+player.shapes.add(new Circle(14));
+player.allowRotation = false;
+```
+
+---
+
+## Constraints
+
+### Using `CbType.ANY_CONSTRAINT` for BREAK events
+
+This is a known gotcha — `ANY_CONSTRAINT` only works for generic
+constraint queries, not for BREAK or SLEEP event listeners.
+
+```typescript
+// BAD — listener never fires
+space.listeners.add(
+  new ConstraintListener(CbEvent.BREAK, CbType.ANY_CONSTRAINT, handler),
+);
+
+// GOOD — create a dedicated CbType
+const breakableTag = new CbType();
+joint.cbTypes.add(breakableTag);
+space.listeners.add(
+  new ConstraintListener(CbEvent.BREAK, breakableTag, handler),
+);
+```
+
+### Making every constraint stiff
+
+Stiff constraints (the default) create rigid connections. For natural-looking
+physics (ragdolls, ropes, vehicles), soft constraints are almost always better.
+
+```typescript
+// BAD — rigid, robotic ragdoll joints
+const neck = new AngleJoint(torso, head, -0.4, 0.4);
+neck.space = space;
+
+// GOOD — soft joint with natural give
+const neck = new AngleJoint(torso, head, -0.4, 0.4);
+neck.stiff = false;
+neck.frequency = 8;
+neck.damping = 0.6;
+neck.space = space;
+```
+
+---
+
+## Collision & Filtering
+
+### Enabling CCD on every body
+
+CCD (continuous collision detection) adds significant CPU cost. Only use it
+on bodies that actually move fast enough to tunnel.
+
+```typescript
+// BAD — unnecessary CCD on slow objects
+for (const body of space.bodies) {
+  body.isBullet = true;
+}
+
+// GOOD — only on fast-moving bodies
+bullet.isBullet = true;
+// Leave slow boxes, platforms, etc. with isBullet = false (default)
+```
+
+### Not calling `space.step()` before raycasting
+
+The broadphase only registers shapes after at least one simulation step.
+Raycasting against static bodies before any step returns null.
+
+```typescript
+// BAD — raycast on freshly created space
+const space = new Space(new Vec2(0, 600));
+floor.space = space;
+space.rayCast(ray); // null — broadphase hasn't indexed yet
+
+// GOOD — step first
+space.step(1 / 60);
+space.rayCast(ray); // works
+```
+
+---
+
+## Serialization
+
+### Assuming binary preserves userData
+
+Binary serialization (`spaceToBinary`) is compact but does **not** preserve
+`userData` on bodies. Use JSON if you need custom data.
+
+```typescript
+// BAD — userData lost
+body.userData.type = "player";
+const bin = spaceToBinary(space);
+const restored = spaceFromBinary(bin);
+restored.bodies.at(0).userData.type; // undefined!
+
+// GOOD — use JSON for userData preservation
+const json = spaceToJSON(space);
+const restored = spaceFromJSON(json);
+restored.bodies.at(0).userData.type; // "player"
+```
+
+### Serializing every frame in multiplayer
+
+Full space serialization is expensive. For real-time multiplayer, send
+only position/velocity deltas or use binary snapshots at a low rate
+(e.g., 10 Hz) with client-side interpolation.
+
+---
+
+## Simulation
+
+### Using huge gravity values
+
+Gravity is in pixels/s² (not meters/s²). Earth gravity in a 600px-tall
+world is around 600, not 9.8 or 9800.
+
+```typescript
+// BAD — objects move at light speed
+const space = new Space(new Vec2(0, 9800));
+
+// GOOD — typical for a 600px viewport
+const space = new Space(new Vec2(0, 600));
+```
+
+### Spawning overlapping bodies
+
+Bodies created inside each other generate extreme separation forces,
+causing them to "explode" apart on the first step.
+
+```typescript
+// BAD — instant physics explosion
+for (let i = 0; i < 10; i++) {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(400, 300)); // all same position!
+  b.shapes.add(new Circle(20));
+  b.space = space;
+}
+
+// GOOD — space them out
+for (let i = 0; i < 10; i++) {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(400, 100 + i * 45));
+  b.shapes.add(new Circle(20));
+  b.space = space;
+}
+```
+
+### Not disposing removed bodies
+
+Bodies removed from the space should be properly cleaned up to avoid
+memory leaks in long-running games.
+
+```typescript
+// BAD — body lingers in memory
+body.space = null;
+
+// GOOD — also clear references
+body.space = null;
+body.shapes.clear();
+// Drop your reference to the body so GC can collect it
+```

--- a/docs/guides/cookbook.md
+++ b/docs/guides/cookbook.md
@@ -1,0 +1,683 @@
+# nape-js Cookbook
+
+<!-- Last verified: v3.21.4 -->
+
+Practical, copy-paste-ready recipes for common game physics tasks.
+Each recipe shows the minimal working code and explains the "why" behind key decisions.
+
+---
+
+## Table of Contents
+
+- [Basic Setup](#basic-setup)
+- [Platformer Character](#platformer-character)
+- [One-Way Platforms](#one-way-platforms)
+- [Ragdoll](#ragdoll)
+- [Rope / Chain](#rope--chain)
+- [Vehicle (Top-Down)](#vehicle-top-down)
+- [Fluid / Water Pool](#fluid--water-pool)
+- [Raycasting](#raycasting)
+- [Sensor / Trigger Zone](#sensor--trigger-zone)
+- [Collision Filtering](#collision-filtering)
+- [Explosion Impulse](#explosion-impulse)
+- [Conveyor Belt](#conveyor-belt)
+- [Breakable Constraint](#breakable-constraint)
+- [Soft Constraint (Spring-Like)](#soft-constraint-spring-like)
+- [Serialization (Save / Load)](#serialization-save--load)
+- [Binary Snapshot (Multiplayer)](#binary-snapshot-multiplayer)
+- [Web Worker Off-Thread Physics](#web-worker-off-thread-physics)
+- [CCD (Bullet Bodies)](#ccd-bullet-bodies)
+- [Sub-Stepping for Stability](#sub-stepping-for-stability)
+- [Kinematic Moving Platform](#kinematic-moving-platform)
+- [Custom Material Presets](#custom-material-presets)
+
+---
+
+## Basic Setup
+
+Create a world, a floor, and a falling ball — the "Hello World" of nape-js.
+
+```typescript
+import { Space, Body, BodyType, Vec2, Circle, Polygon } from "@newkrok/nape-js";
+
+const space = new Space(new Vec2(0, 600)); // gravity: 600 px/s² downward
+
+// Static floor
+const floor = new Body(BodyType.STATIC, new Vec2(400, 550));
+floor.shapes.add(new Polygon(Polygon.box(800, 20)));
+floor.space = space;
+
+// Dynamic ball
+const ball = new Body(BodyType.DYNAMIC, new Vec2(400, 100));
+ball.shapes.add(new Circle(20));
+ball.space = space;
+
+// Game loop
+function update() {
+  space.step(1 / 60);
+  // Read ball.position.x, ball.position.y, ball.rotation for rendering
+}
+```
+
+**Key points:**
+- `space.step(1/60)` advances the simulation by one frame at 60 fps
+- Assign `body.space = space` to add a body — don't call a separate `addBody()` method
+- Gravity is in **pixels/s²** (not meters) — no conversion needed
+
+---
+
+## Platformer Character
+
+Use `CharacterController` for pixel-perfect movement with slope handling, step climbing, and wall detection.
+
+```typescript
+import {
+  Space, Body, BodyType, Vec2, Circle, CbType,
+  CharacterController,
+} from "@newkrok/nape-js";
+
+const space = new Space(new Vec2(0, 600));
+
+// Player body — DYNAMIC with rotation disabled
+const player = new Body(BodyType.DYNAMIC, new Vec2(100, 100));
+player.shapes.add(new Circle(14));
+player.allowRotation = false;
+player.isBullet = true; // enable CCD to prevent tunneling
+player.space = space;
+
+// Optional: tag for one-way platform filtering
+const platformTag = new CbType();
+
+const cc = new CharacterController(space, player, {
+  maxSlopeAngle: Math.PI / 4, // 45° climbable
+  oneWayPlatformTag: platformTag,
+});
+
+// Each frame:
+function update(dt: number, keys: { left: boolean; right: boolean; jump: boolean }) {
+  const speed = 200;
+  const dx = (keys.right ? 1 : 0) - (keys.left ? 1 : 0);
+
+  cc.setVelocity(dx * speed, player.velocity.y);
+  space.step(dt);
+
+  const result = cc.moveResult;
+  if (keys.jump && result.grounded) {
+    player.velocity.y = -400; // jump impulse
+  }
+}
+```
+
+**Key points:**
+- Use `allowRotation = false` so the character doesn't tumble
+- `isBullet = true` enables CCD — prevents falling through thin platforms
+- `CharacterController` handles slopes, steps, and wall detection automatically
+
+---
+
+## One-Way Platforms
+
+Platforms the player can jump through from below but stand on from above.
+
+```typescript
+import {
+  Space, Body, BodyType, Vec2, Polygon, Material,
+  CbType, PreListener, PreFlag,
+} from "@newkrok/nape-js";
+
+const platformTag = new CbType();
+const playerTag = new CbType();
+
+// Create platform
+const platform = new Body(BodyType.STATIC, new Vec2(300, 400));
+platform.shapes.add(new Polygon(Polygon.box(120, 12)));
+platform.cbTypes.add(platformTag);
+platform.space = space;
+
+// Add player's CbType
+playerBody.cbTypes.add(playerTag);
+
+// PreListener: ignore collision when player moves upward
+space.listeners.add(
+  new PreListener(
+    InteractionType.COLLISION,
+    playerTag,
+    platformTag,
+    (cb) => {
+      const arbiter = cb.arbiter.collisionArbiter;
+      // Normal points from shape1 to shape2; ignore if pointing down
+      return arbiter && arbiter.normal.y > 0 ? PreFlag.IGNORE : PreFlag.ACCEPT;
+    },
+  ),
+);
+```
+
+**Key point:** The `PreListener` fires *before* collision resolution — returning `PreFlag.IGNORE` lets the body pass through.
+
+---
+
+## Ragdoll
+
+A multi-body character held together by `PivotJoint` (position) and `AngleJoint` (rotation limits).
+
+```typescript
+import {
+  Space, Body, BodyType, Vec2, Circle, Polygon,
+  PivotJoint, AngleJoint,
+} from "@newkrok/nape-js";
+
+function createRagdoll(space: Space, x: number, y: number) {
+  const torso = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  torso.shapes.add(new Polygon(Polygon.box(24, 48)));
+  torso.space = space;
+
+  const head = new Body(BodyType.DYNAMIC, new Vec2(x, y - 38));
+  head.shapes.add(new Circle(12));
+  head.space = space;
+
+  // Pin head to torso
+  const neck = new PivotJoint(torso, head, new Vec2(0, -24), new Vec2(0, 12));
+  neck.space = space;
+
+  // Limit head rotation to ±23°
+  const neckAngle = new AngleJoint(torso, head, -0.4, 0.4);
+  neckAngle.stiff = false;
+  neckAngle.frequency = 8;
+  neckAngle.damping = 0.6;
+  neckAngle.space = space;
+
+  // Upper arm
+  const arm = new Body(BodyType.DYNAMIC, new Vec2(x - 26, y - 14));
+  arm.shapes.add(new Polygon(Polygon.box(28, 8)));
+  arm.space = space;
+
+  new PivotJoint(torso, arm, new Vec2(-12, -20), new Vec2(14, 0)).space = space;
+  new AngleJoint(torso, arm, -Math.PI * 0.75, Math.PI * 0.75).space = space;
+
+  // Add more limbs following the same pattern...
+  return { torso, head, arm };
+}
+```
+
+**Key points:**
+- `PivotJoint` pins two bodies at a shared point — use for all joint connections
+- `AngleJoint` with `stiff = false` creates soft rotation limits (more natural)
+- `frequency` and `damping` control the "springiness" of the joint
+
+---
+
+## Rope / Chain
+
+A chain of bodies connected by distance-constrained joints.
+
+```typescript
+const LINKS = 12;
+const LINK_LEN = 20;
+let prev: Body | null = space.world; // anchor to static world body
+
+for (let i = 0; i < LINKS; i++) {
+  const link = new Body(BodyType.DYNAMIC, new Vec2(300, 100 + i * LINK_LEN));
+  link.shapes.add(new Circle(4));
+  link.space = space;
+
+  const joint = new PivotJoint(
+    prev,
+    link,
+    prev === space.world ? new Vec2(300, 100) : new Vec2(0, LINK_LEN / 2),
+    new Vec2(0, -LINK_LEN / 2),
+  );
+  joint.space = space;
+  prev = link;
+}
+```
+
+**Key point:** Use `space.world` as the first body to anchor the chain to a fixed point in the world.
+
+---
+
+## Vehicle (Top-Down)
+
+Kinematic body with velocity-based steering.
+
+```typescript
+const car = new Body(BodyType.DYNAMIC, new Vec2(400, 300));
+car.shapes.add(new Polygon(Polygon.box(20, 40)));
+car.allowRotation = true;
+car.space = space;
+
+function updateCar(steer: number, throttle: number) {
+  const angle = car.rotation;
+  const forward = new Vec2(Math.sin(angle), -Math.cos(angle));
+
+  // Apply forward thrust
+  car.applyImpulse(Vec2.get(forward.x * throttle, forward.y * throttle));
+
+  // Steering: apply angular impulse
+  car.applyAngularImpulse(steer * 0.5);
+
+  // Kill lateral velocity for tighter handling
+  const lateral = new Vec2(-forward.y, forward.x);
+  const latSpeed = car.velocity.x * lateral.x + car.velocity.y * lateral.y;
+  car.velocity.x -= lateral.x * latSpeed * 0.9;
+  car.velocity.y -= lateral.y * latSpeed * 0.9;
+}
+```
+
+---
+
+## Fluid / Water Pool
+
+Create a body with `fluidEnabled = true` shapes for buoyancy and drag.
+
+```typescript
+import { Body, BodyType, Vec2, Polygon, FluidProperties } from "@newkrok/nape-js";
+
+// Water zone (static body, sensor-like)
+const water = new Body(BodyType.STATIC, new Vec2(400, 450));
+const waterShape = new Polygon(Polygon.box(300, 100));
+waterShape.fluidEnabled = true;
+waterShape.fluidProperties = new FluidProperties(1.5, 3.0); // density, viscosity
+water.shapes.add(waterShape);
+water.space = space;
+
+// Light object — floats
+const buoy = new Body(BodyType.DYNAMIC, new Vec2(400, 200));
+const buoyShape = new Circle(15);
+buoy.shapes.add(buoyShape);
+for (const s of buoy.shapes) {
+  s.material.density = 0.3; // lighter than water (1.5) → floats
+}
+buoy.space = space;
+
+// Heavy object — sinks slowly
+const anchor = new Body(BodyType.DYNAMIC, new Vec2(420, 200));
+anchor.shapes.add(new Polygon(Polygon.box(20, 20)));
+for (const s of anchor.shapes) {
+  s.material.density = 5.0; // heavier than water → sinks
+}
+anchor.space = space;
+```
+
+**Key points:**
+- `FluidProperties(density, viscosity)` — higher density = stronger buoyancy, higher viscosity = more drag
+- The body's `material.density` relative to the fluid's density determines floating vs sinking
+- Fluid simulation is **unique to nape-js** — no other pure-JS engine has this
+
+---
+
+## Raycasting
+
+Cast a ray and find the first body it hits.
+
+```typescript
+import { Space, Ray, Vec2 } from "@newkrok/nape-js";
+
+// Important: call space.step() at least once before raycasting
+// so the broadphase registers all shapes
+space.step(1 / 60);
+
+const ray = new Ray(
+  new Vec2(100, 300), // origin
+  new Vec2(1, 0),     // direction (rightward)
+);
+
+const result = space.rayCast(ray, false); // false = outer surfaces only
+
+if (result) {
+  console.log("Hit body:", result.shape.body);
+  console.log("Hit point:", result.point);
+  console.log("Distance:", result.distance);
+  console.log("Normal:", result.normal);
+}
+```
+
+**Gotcha:** `space.rayCast()` on static bodies may return null if you haven't called `space.step()` at least once — the broadphase needs a step to index the shapes.
+
+---
+
+## Sensor / Trigger Zone
+
+Detect bodies entering/exiting an area without physical collision.
+
+```typescript
+import {
+  Body, BodyType, Vec2, Polygon,
+  CbType, CbEvent, InteractionType, InteractionListener,
+} from "@newkrok/nape-js";
+
+const sensorTag = new CbType();
+const enemyTag = new CbType();
+
+// Sensor zone — no physical collision, only detection
+const zone = new Body(BodyType.STATIC, new Vec2(500, 400));
+const zoneShape = new Polygon(Polygon.box(100, 100));
+zoneShape.sensorEnabled = true;
+zone.shapes.add(zoneShape);
+zone.cbTypes.add(sensorTag);
+zone.space = space;
+
+// Enemy body
+enemy.cbTypes.add(enemyTag);
+
+// Detect entry
+space.listeners.add(
+  new InteractionListener(CbEvent.BEGIN, InteractionType.SENSOR, sensorTag, enemyTag, (cb) => {
+    console.log("Enemy entered zone!", cb.int2);
+  }),
+);
+
+// Detect exit
+space.listeners.add(
+  new InteractionListener(CbEvent.END, InteractionType.SENSOR, sensorTag, enemyTag, (cb) => {
+    console.log("Enemy left zone!", cb.int2);
+  }),
+);
+```
+
+---
+
+## Collision Filtering
+
+Control which bodies collide using `InteractionFilter` bit masks.
+
+```typescript
+import { Body, Circle, InteractionFilter } from "@newkrok/nape-js";
+
+// Define layers as bit flags
+const PLAYER = 1;
+const ENEMY = 2;
+const BULLET = 4;
+const WALL = 8;
+
+// Player collides with enemies and walls, not own bullets
+for (const s of playerBody.shapes) {
+  s.filter.collisionGroup = PLAYER;
+  s.filter.collisionMask = ENEMY | WALL;
+}
+
+// Enemy collides with player, bullets, and walls
+for (const s of enemyBody.shapes) {
+  s.filter.collisionGroup = ENEMY;
+  s.filter.collisionMask = PLAYER | BULLET | WALL;
+}
+
+// Bullet collides with enemies and walls only
+for (const s of bulletBody.shapes) {
+  s.filter.collisionGroup = BULLET;
+  s.filter.collisionMask = ENEMY | WALL;
+}
+```
+
+**Key point:** Two shapes collide when `(A.collisionGroup & B.collisionMask) !== 0 AND (B.collisionGroup & A.collisionMask) !== 0`. Both must agree.
+
+---
+
+## Explosion Impulse
+
+Apply radial impulse to all nearby bodies.
+
+```typescript
+function explode(space: Space, center: Vec2, radius: number, force: number) {
+  for (const body of space.bodies) {
+    if (body.type !== BodyType.DYNAMIC) continue;
+
+    const dx = body.position.x - center.x;
+    const dy = body.position.y - center.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+
+    if (dist < radius && dist > 0) {
+      const strength = force * (1 - dist / radius); // falloff
+      const impulse = Vec2.get((dx / dist) * strength, (dy / dist) * strength);
+      body.applyImpulse(impulse);
+      impulse.dispose();
+    }
+  }
+}
+
+// Usage:
+explode(space, new Vec2(400, 300), 200, 5000);
+```
+
+**Gotcha:** nape-js has `applyImpulse()`, not `applyForce()`. Impulse is instantaneous (velocity change), force is continuous (applied per step).
+
+---
+
+## Conveyor Belt
+
+Use `surfaceVel` on a shape's material to create a moving surface.
+
+```typescript
+const belt = new Body(BodyType.STATIC, new Vec2(400, 500));
+const beltShape = new Polygon(Polygon.box(200, 10));
+belt.shapes.add(beltShape);
+belt.space = space;
+
+// Set surface velocity — pushes objects rightward at 100 px/s
+for (const s of belt.shapes) {
+  s.material.dynamicFriction = 2;
+  s.material.staticFriction = 2;
+  s.surfaceVel.setXY(100, 0);
+}
+```
+
+---
+
+## Breakable Constraint
+
+A joint that snaps when force exceeds a threshold.
+
+```typescript
+import { PivotJoint, CbType, CbEvent, ConstraintListener } from "@newkrok/nape-js";
+
+const joint = new PivotJoint(bodyA, bodyB, new Vec2(0, 0), new Vec2(0, 0));
+joint.breakUnderForce = true;
+joint.maxForce = 5000;     // breaks above this force
+joint.removeOnBreak = true; // auto-remove from space
+
+// Listen for the break event
+const jointTag = new CbType();
+joint.cbTypes.add(jointTag); // IMPORTANT: must add a custom CbType
+
+space.listeners.add(
+  new ConstraintListener(CbEvent.BREAK, jointTag, (cb) => {
+    console.log("Joint broke!", cb.constraint);
+    // Spawn particles, play sound, etc.
+  }),
+);
+
+joint.space = space;
+```
+
+**Gotcha:** `CbType.ANY_CONSTRAINT` does **not** work for BREAK/SLEEP events. You must create and assign a dedicated `CbType` to the joint's `cbTypes`.
+
+---
+
+## Soft Constraint (Spring-Like)
+
+Any constraint can be made soft by setting `stiff = false` with frequency and damping.
+
+```typescript
+const joint = new DistanceJoint(bodyA, bodyB,
+  new Vec2(0, 0), new Vec2(0, 0),
+  50, 150, // min, max distance
+);
+joint.stiff = false;
+joint.frequency = 4;   // oscillation speed (Hz)
+joint.damping = 0.3;   // 0 = no damping, 1 = critical damping
+joint.space = space;
+```
+
+**Key point:** This works on **any** constraint type (PivotJoint, AngleJoint, WeldJoint, etc.) — not just DistanceJoint. Set `stiff = false`, then tune `frequency` and `damping`.
+
+---
+
+## Serialization (Save / Load)
+
+Save and restore the entire physics state as JSON.
+
+```typescript
+import { spaceToJSON, spaceFromJSON } from "@newkrok/nape-js/serialization";
+
+// Save
+const snapshot = spaceToJSON(space);
+const json = JSON.stringify(snapshot);
+localStorage.setItem("physics-save", json);
+
+// Load
+const saved = localStorage.getItem("physics-save");
+if (saved) {
+  const restoredSpace = spaceFromJSON(JSON.parse(saved));
+  // restoredSpace is a fully functional Space with all bodies, constraints, etc.
+}
+```
+
+**Key point:** JSON serialization preserves `userData` on bodies. Binary does not.
+
+---
+
+## Binary Snapshot (Multiplayer)
+
+Compact binary format for network sync.
+
+```typescript
+import { spaceToBinary, spaceFromBinary } from "@newkrok/nape-js/serialization";
+
+// Server: serialize
+const binary = spaceToBinary(space); // Uint8Array
+
+// Send binary over WebSocket
+ws.send(binary);
+
+// Client: deserialize
+ws.onmessage = (event) => {
+  const restored = spaceFromBinary(new Uint8Array(event.data));
+  // Use restored space for prediction/rendering
+};
+```
+
+---
+
+## Web Worker Off-Thread Physics
+
+Run physics simulation on a background thread to keep the UI at 60 fps.
+
+```typescript
+import {
+  PhysicsWorkerManager,
+  buildWorkerScript,
+} from "@newkrok/nape-js/worker";
+
+const manager = new PhysicsWorkerManager();
+
+// Initialize worker with engine URL
+await manager.init(buildWorkerScript("/node_modules/@newkrok/nape-js/dist/index.js"));
+
+// Add bodies (mirrored in the worker)
+manager.addBody({ id: "ball", type: "dynamic", x: 400, y: 100, shape: "circle", radius: 20 });
+manager.addBody({ id: "floor", type: "static", x: 400, y: 550, shape: "box", width: 800, height: 20 });
+
+// Start simulation
+manager.start();
+
+// Read transforms for rendering (zero-copy with SharedArrayBuffer)
+function render() {
+  const transforms = manager.getTransforms();
+  for (const [id, { x, y, rotation }] of transforms) {
+    // Update your rendering objects
+  }
+  requestAnimationFrame(render);
+}
+```
+
+---
+
+## CCD (Bullet Bodies)
+
+Prevent fast-moving objects from tunneling through thin walls.
+
+```typescript
+// Enable CCD on fast-moving bodies
+bullet.isBullet = true;
+
+// Optional: fine-tune per body
+bullet.disableCCD = false; // default, CCD active when isBullet = true
+```
+
+**Key points:**
+- CCD is **per-body**, not per-space — there is no `space.disableCCD`
+- Only set `isBullet = true` on bodies that actually move fast (bullets, projectiles)
+- CCD adds CPU cost — don't enable it on every body
+
+---
+
+## Sub-Stepping for Stability
+
+Improve simulation quality for stacking, fast objects, and stiff constraints.
+
+```typescript
+// Run 4 sub-steps per frame (each at dt/4)
+space.subSteps = 4;
+
+// Then step normally — it internally runs 4 smaller steps
+space.step(1 / 60);
+```
+
+**Key points:**
+- `subSteps = 1` is the default (zero overhead)
+- `subSteps = 4` is a good balance for most games
+- Cost scales linearly — `subSteps = 4` costs ~4x more CPU
+- Particularly useful for: stacking stability, thin wall collisions, stiff constraints
+
+---
+
+## Kinematic Moving Platform
+
+A platform that moves on a fixed path and pushes dynamic bodies.
+
+```typescript
+const platform = new Body(BodyType.KINEMATIC, new Vec2(300, 400));
+platform.shapes.add(new Polygon(Polygon.box(100, 12)));
+platform.space = space;
+
+// Move back and forth
+let time = 0;
+function updatePlatform(dt: number) {
+  time += dt;
+  const targetX = 300 + Math.sin(time) * 150;
+  // Set velocity so the solver pushes bodies correctly
+  platform.velocity.x = (targetX - platform.position.x) / dt;
+  platform.velocity.y = 0;
+}
+```
+
+**Key point:** Set `velocity` on kinematic bodies — don't set `position` directly. The solver uses velocity to push dynamic bodies that are standing on the platform.
+
+---
+
+## Custom Material Presets
+
+nape-js includes built-in presets, or create your own.
+
+```typescript
+import { Material } from "@newkrok/nape-js";
+
+// Built-in presets
+const wood = Material.wood();
+const steel = Material.steel();
+const ice = Material.ice();
+const rubber = Material.rubber();
+const glass = Material.glass();
+const sand = Material.sand();
+
+// Custom material
+// Constructor order: elasticity, dynamicFriction, staticFriction, density, rollingFriction
+const bouncy = new Material(0.9, 0.1, 0.1, 1.0, 0.01);
+const heavy = new Material(0.2, 0.8, 0.9, 10.0, 0.5);
+
+// Apply to a shape
+for (const s of body.shapes) {
+  s.material = bouncy;
+}
+```
+
+**Gotcha:** The constructor order is `(elasticity, dynamicFriction, staticFriction, density, rollingFriction)` — elasticity comes **first**, not friction. This differs from some other engines.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,277 @@
+# Troubleshooting Guide
+
+<!-- Last verified: v3.21.4 -->
+
+Common problems, their causes, and solutions. If your issue isn't listed here,
+check the [API Reference](https://newkrok.github.io/nape-js/api/) or
+[open an issue on GitHub](https://github.com/NewKrok/nape-js/issues).
+
+---
+
+## Bodies fall through walls / floors
+
+**Symptoms:** Dynamic bodies pass through static bodies without colliding.
+
+### Cause 1: Fast body, no CCD
+
+Small or fast bodies can skip past thin walls between simulation steps.
+
+```typescript
+// Fix: enable CCD on fast-moving bodies
+bullet.isBullet = true;
+```
+
+### Cause 2: Sub-stepping too low
+
+Even with CCD, extreme speeds or thin walls can cause tunneling.
+
+```typescript
+// Fix: increase sub-steps
+space.subSteps = 4; // each step(dt) runs 4 internal passes at dt/4
+```
+
+### Cause 3: Material in wrong constructor parameter (P57 bug)
+
+If you created a Polygon with a Material in the wrong position, the Material
+object was silently treated as an InteractionFilter, breaking collision.
+
+```typescript
+// WRONG — Material ends up in the filter slot
+new Polygon(verts, undefined, material);
+
+// CORRECT — all of these work
+new Polygon(verts, material);                    // 2-arg shorthand
+new Polygon(verts, localCOM, material, filter);  // full signature
+new Polygon(verts, undefined, material);         // also works after P57 fix
+```
+
+If you're on a version **before** 3.19, update to the latest.
+
+### Cause 4: Zero friction tunneling
+
+Bodies with `friction = 0` and horizontal velocity can tunnel through floors.
+
+```typescript
+// Fix: use a small minimum friction
+for (const s of body.shapes) {
+  s.material.dynamicFriction = Math.max(s.material.dynamicFriction, 0.01);
+  s.material.staticFriction = Math.max(s.material.staticFriction, 0.01);
+}
+```
+
+---
+
+## Raycast returns null even though bodies exist
+
+**Cause:** The broadphase hasn't indexed the shapes yet. Static bodies are
+only registered after the first simulation step.
+
+```typescript
+// Fix: call step() at least once before raycasting
+space.step(1 / 60);
+
+const result = space.rayCast(ray);
+// Now result will include static bodies
+```
+
+---
+
+## `applyForce()` is not a function
+
+**Cause:** nape-js uses `applyImpulse()` instead of `applyForce()`.
+
+- **Impulse** = instantaneous velocity change (used once)
+- **Force** = continuous acceleration (you'd apply it every frame)
+
+```typescript
+// For a one-time push (e.g., explosion, jump):
+body.applyImpulse(new Vec2(0, -5000));
+
+// For continuous acceleration (e.g., thrust), apply impulse every frame:
+function update(dt: number) {
+  body.applyImpulse(new Vec2(thrustX * dt, thrustY * dt));
+  space.step(dt);
+}
+```
+
+---
+
+## Cannot set `space` on a compound member body
+
+**Cause:** Bodies inside a `Compound` share the compound's space. You can only
+set `.space` on the root compound, not on individual member bodies.
+
+```typescript
+// WRONG — throws an error
+compound.bodies.at(0).space = space;
+
+// CORRECT — set space on the compound
+compound.space = space;
+```
+
+---
+
+## ConstraintListener doesn't fire for BREAK events
+
+**Cause:** `CbType.ANY_CONSTRAINT` does **not** work for BREAK or SLEEP events.
+You must create a dedicated `CbType` and assign it to the constraint.
+
+```typescript
+// WRONG — listener never fires
+space.listeners.add(
+  new ConstraintListener(CbEvent.BREAK, CbType.ANY_CONSTRAINT, handler),
+);
+
+// CORRECT — create and assign a custom tag
+const breakableTag = new CbType();
+joint.cbTypes.add(breakableTag);
+
+space.listeners.add(
+  new ConstraintListener(CbEvent.BREAK, breakableTag, handler),
+);
+```
+
+---
+
+## Material constructor order is confusing
+
+The parameter order is:
+```
+Material(elasticity, dynamicFriction, staticFriction, density, rollingFriction)
+```
+
+Elasticity comes **first**. This differs from some engines where friction is first.
+
+```typescript
+// Bouncy rubber ball
+const rubber = new Material(
+  0.9,  // elasticity (high = bouncy)
+  0.8,  // dynamicFriction
+  0.9,  // staticFriction
+  1.2,  // density
+  0.01, // rollingFriction
+);
+
+// Or use a built-in preset:
+const preset = Material.rubber(); // pre-configured values
+```
+
+---
+
+## Bodies jitter or explode on startup
+
+**Cause:** Bodies spawned overlapping each other. The solver pushes them apart
+aggressively, causing a "physics explosion."
+
+**Fix:** Ensure bodies don't overlap at spawn. Leave at least 1-2 px gap, or
+use `space.subSteps = 4` to improve solver stability.
+
+---
+
+## Stacked objects are unstable / wobble
+
+**Fix 1:** Increase sub-steps:
+```typescript
+space.subSteps = 4;
+```
+
+**Fix 2:** Increase solver iterations:
+```typescript
+// Default is step(dt, 10, 10)
+space.step(1 / 60, 20, 20); // more velocity + position iterations
+```
+
+**Fix 3:** Increase friction on the shapes:
+```typescript
+for (const s of body.shapes) {
+  s.material.staticFriction = 2.0;
+  s.material.dynamicFriction = 1.5;
+}
+```
+
+---
+
+## Character slides on slopes / doesn't stop
+
+**Cause:** Using force/impulse-based movement instead of `CharacterController`.
+
+Dynamic body movement with forces inherently slides on slopes due to gravity
+decomposition. Use the geometric `CharacterController` for precise platformer
+movement.
+
+```typescript
+import { CharacterController } from "@newkrok/nape-js";
+
+const cc = new CharacterController(space, body, {
+  maxSlopeAngle: Math.PI / 4, // 45° walkable
+});
+```
+
+---
+
+## Web Worker physics is slower than main thread
+
+**Possible causes:**
+
+1. **`postMessage` fallback** — If `SharedArrayBuffer` is not available (missing
+   COOP/COEP headers), transforms are copied via postMessage each frame.
+   Ensure your server sends:
+   ```
+   Cross-Origin-Opener-Policy: same-origin
+   Cross-Origin-Embedder-Policy: require-corp
+   ```
+
+2. **Too many bodies** — Worker communication overhead per body is fixed.
+   For < 50 bodies, main-thread physics is often faster.
+
+---
+
+## Fluid buoyancy doesn't work
+
+**Checklist:**
+
+1. Is `fluidEnabled = true` on the fluid shape?
+2. Did you set `fluidProperties`?
+3. Is the fluid body's type `STATIC` (or `KINEMATIC`)?
+4. Is the dynamic body's shape density different from the fluid density?
+
+```typescript
+// Correct fluid setup
+const waterShape = new Polygon(Polygon.box(300, 100));
+waterShape.fluidEnabled = true; // <-- often forgotten
+waterShape.fluidProperties = new FluidProperties(1.5, 3.0);
+waterBody.shapes.add(waterShape);
+```
+
+---
+
+## "Cannot read property of disposed Vec2"
+
+**Cause:** Using a `Vec2.weak()` or manually disposed vector after it's been
+returned to the object pool.
+
+```typescript
+// WRONG — weak vectors are auto-disposed after one use
+const v = Vec2.weak(10, 0);
+body.applyImpulse(v);
+console.log(v.x); // ERROR: disposed
+
+// CORRECT — use Vec2.get() and dispose manually
+const v = Vec2.get(10, 0);
+body.applyImpulse(v);
+console.log(v.x); // OK
+v.dispose(); // return to pool when done
+```
+
+---
+
+## Deterministic mode doesn't produce identical results across browsers
+
+**This is expected.** nape-js provides "soft" determinism — identical results
+on the **same platform** (same browser + OS + architecture). Cross-platform
+bit-exact IEEE 754 determinism is not possible in pure JavaScript because
+different JS engines handle floating-point edge cases differently.
+
+For multiplayer, use server-authoritative architecture with periodic state
+sync rather than relying on cross-platform determinism. See the
+[Multiplayer Guide](./multiplayer-guide.md).

--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -165,9 +165,12 @@ When a PR changes features, APIs, priorities, or versions:
 | `ROADMAP.md` | Priority table, status, competitive analysis | Priority changes |
 | `docs/guides/architecture.md` | Internal patterns, registration flow | Architecture changes |
 | `docs/guides/multiplayer-guide.md` | Server setup, protocol, prediction | Multiplayer changes |
+| `docs/guides/cookbook.md` | Add recipe for new feature, update existing recipes | New features, API changes |
+| `docs/guides/troubleshooting.md` | Add entry for new gotchas, update fixes | Bug fixes, API gotchas |
+| `docs/guides/anti-patterns.md` | Add entry for new pitfalls | Bug fixes, performance changes |
 | `README.md` | Quick start, API tables, badge versions | Public API changes, releases |
 | `llms.txt` | Class list, links, quick start | Public API additions/removals |
-| `llms-full.txt` | Complete API reference, version (line 1) | Any public API change |
+| `llms-full.txt` | Complete API reference, gotchas, version (line 1) | Any public API change |
 | `package.json` | `version` field | Releases |
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -92,6 +92,8 @@
         <a href="examples.html" class="tab tab-more" onclick="gtag('event','navigation',{event_category:'demo_tab',event_label:'more_examples'})">More &rarr;</a>
         <a href="multiplayer.html" class="tab tab-mp" onclick="gtag('event','navigation',{event_category:'demo_tab',event_label:'multiplayer'})">&#9654; Multiplayer</a>
         <a href="benchmark.html" class="tab tab-bench" onclick="gtag('event','navigation',{event_category:'demo_tab',event_label:'benchmarks'})">&#9889; Benchmarks</a>
+        <a href="guides/cookbook.md" class="tab" onclick="gtag('event','navigation',{event_category:'demo_tab',event_label:'cookbook'})">&#128214; Cookbook</a>
+        <a href="guides/troubleshooting.md" class="tab" onclick="gtag('event','navigation',{event_category:'demo_tab',event_label:'troubleshooting'})">&#128295; Troubleshooting</a>
       </nav>
 
       <div class="canvas-wrap" id="canvasWrap">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,6 +8,24 @@
 - **Demos**: https://newkrok.github.io/nape-js/examples.html
 - **License**: MIT
 - **Version**: 3.8.1
+- **Cookbook**: https://github.com/NewKrok/nape-js/blob/master/docs/guides/cookbook.md
+- **Troubleshooting**: https://github.com/NewKrok/nape-js/blob/master/docs/guides/troubleshooting.md
+- **Anti-Patterns**: https://github.com/NewKrok/nape-js/blob/master/docs/guides/anti-patterns.md
+
+---
+
+## Common Gotchas (Quick Reference)
+
+1. **No `applyForce()`** — use `applyImpulse()` (instantaneous) or apply impulse every frame scaled by dt
+2. **Material constructor order** — `Material(elasticity, dynamicFriction, staticFriction, density, rollingFriction)` — elasticity is first
+3. **Raycast needs a step first** — call `space.step(1/60)` before `space.rayCast()` so broadphase indexes shapes
+4. **CCD is per-body** — `body.isBullet = true`, no global space setting
+5. **ConstraintListener BREAK events** — must use custom `CbType`, not `CbType.ANY_CONSTRAINT`
+6. **Compound members** — set `compound.space = space`, not `memberBody.space = space`
+7. **Vec2.weak()** — auto-disposed after first use; use `Vec2.get()` if you need the value later
+8. **Gravity is in pixels/s²** — typical value is 600, not 9.8
+9. **Kinematic bodies** — set `velocity`, don't set `position` directly (solver needs velocity to push contacts)
+10. **Binary serialization** — does not preserve `userData`; use JSON serialization if you need it
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,9 @@ Install: `npm install @newkrok/nape-js`
 - [API Reference](https://newkrok.github.io/nape-js/api/index.html): Full TypeDoc-generated API docs
 - [Interactive Demos](https://newkrok.github.io/nape-js/examples.html): Live physics demos with source code
 - [Full LLM Documentation](https://raw.githubusercontent.com/NewKrok/nape-js/master/llms-full.txt): Complete API reference in a single file
+- [Cookbook](https://github.com/NewKrok/nape-js/blob/master/docs/guides/cookbook.md): Task-oriented recipes (platformer, ragdoll, fluid, serialization, etc.)
+- [Troubleshooting](https://github.com/NewKrok/nape-js/blob/master/docs/guides/troubleshooting.md): Common problems and solutions
+- [Anti-Patterns](https://github.com/NewKrok/nape-js/blob/master/docs/guides/anti-patterns.md): Common mistakes to avoid
 
 ## Quick Start
 


### PR DESCRIPTION
- Removed detailed descriptions of completed items (P45, P47, P51, P54, P55, P57)
- Consolidated done list into single line
- Updated competitive advantages with new features (character controller, sub-stepping)
- Added 5 new priorities: P58 Phaser plugin, P59 React/R3F, P60 Tilemap helper, P61 Bundle size, P62 Particle system
- Added recommended execution order in 3 phases
- Kept API gotchas section as reference for documentation work

https://claude.ai/code/session_01EcNRQeDg8688n4fncRbu6z