### PR TITLE
test(nape-js): add 133 tests across 7 high-impact coverage areas

### DIFF
--- a/packages/nape-js/tests/constraint/SpringJoint.solver.test.ts
+++ b/packages/nape-js/tests/constraint/SpringJoint.solver.test.ts
@@ -1,0 +1,386 @@
+/**
+ * SpringJoint — solver branch coverage.
+ *
+ * Targets uncovered branches in:
+ * - ZPP_SpringJoint.preStep / applyImpulseVel (warm-start, mass matrix invert,
+ *   degenerate alignment, body→body angular path)
+ * - SpringJoint accessors (anchor1/anchor2 mutation, body re-assign)
+ * - Energy decay under different damping ratios (0, 0.5, 1, oscillatory)
+ * - Long-rope chains (N springs in series)
+ * - World-anchor (one body null) path
+ */
+
+import { describe, it, expect } from "vitest";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Circle } from "../../src/shape/Circle";
+import { Polygon } from "../../src/shape/Polygon";
+import { SpringJoint } from "../../src/constraint/SpringJoint";
+
+function dyn(space: Space, x = 0, y = 0): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(8));
+  b.space = space;
+  return b;
+}
+
+function staticBody(space: Space, x = 0, y = 0): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(x, y));
+  b.shapes.add(new Circle(8));
+  b.space = space;
+  return b;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Warm-start across many steps
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — warm-start persistence", () => {
+  it("hanging spring under gravity converges to a stable extension", () => {
+    const space = new Space(new Vec2(0, 200));
+    const anchor = staticBody(space, 0, 0);
+    const bob = dyn(space, 0, 100);
+
+    const joint = new SpringJoint(anchor, bob, Vec2.weak(0, 0), Vec2.weak(0, 0), 50);
+    joint.frequency = 4;
+    joint.damping = 0.7;
+    joint.space = space;
+
+    for (let i = 0; i < 600; i++) space.step(1 / 60);
+
+    // Expected length L = 50 + (m*g/k). With frequency f, k = (2*pi*f)^2 * m_eff.
+    // At rest: extension stable, dx finite.
+    const dy = bob.position.y;
+    expect(Number.isFinite(dy)).toBe(true);
+    expect(dy).toBeGreaterThan(50);
+    expect(dy).toBeLessThan(200);
+  });
+
+  it("survives a sudden dt jump without divergence", () => {
+    const space = new Space(new Vec2(0, 200));
+    const anchor = staticBody(space, 0, 0);
+    const bob = dyn(space, 0, 100);
+    const j = new SpringJoint(anchor, bob, Vec2.weak(0, 0), Vec2.weak(0, 0), 50);
+    j.frequency = 5;
+    j.damping = 1;
+    j.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60);
+    for (let i = 0; i < 10; i++) space.step(1 / 30);
+    for (let i = 0; i < 10; i++) space.step(1 / 120);
+
+    expect(Number.isFinite(bob.position.x)).toBe(true);
+    expect(Number.isFinite(bob.position.y)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Damping ratio extremes
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — damping ratio", () => {
+  it("damping=0 (no damping) preserves energy over time", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = staticBody(space, 0, 0);
+    const b = dyn(space, 200, 0);
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 100);
+    j.frequency = 2;
+    j.damping = 0;
+    j.space = space;
+
+    let maxDistance = 0;
+    let minDistance = 1e9;
+    for (let i = 0; i < 600; i++) {
+      space.step(1 / 60);
+      const d = Math.abs(b.position.x - a.position.x);
+      if (d > maxDistance) maxDistance = d;
+      if (d < minDistance) minDistance = d;
+    }
+
+    // With zero damping, the oscillation should not decay much
+    // — keep both peaks and troughs significantly different
+    expect(maxDistance - minDistance).toBeGreaterThan(50);
+  });
+
+  it("damping=2 (overdamped) converges monotonically without overshoot", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = staticBody(space, 0, 0);
+    const b = dyn(space, 200, 0);
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 100);
+    j.frequency = 3;
+    j.damping = 2;
+    j.space = space;
+
+    let prevDx = b.position.x;
+    let overshoots = 0;
+    for (let i = 0; i < 300; i++) {
+      space.step(1 / 60);
+      const dx = b.position.x;
+      // Overshoot: position passed below 100 (rest) coming from 200
+      if (dx < 95) overshoots++;
+      prevDx = dx;
+    }
+    // Overdamped: should not significantly overshoot
+    expect(overshoots).toBeLessThan(5);
+    expect(prevDx).toBeCloseTo(100, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Frequency boundaries
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — frequency boundaries", () => {
+  it("very high frequency (50 Hz) still produces stable simulation", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = staticBody(space, 0, 0);
+    const b = dyn(space, 200, 0);
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 100);
+    j.frequency = 50;
+    j.damping = 1;
+    j.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60);
+    expect(Number.isFinite(b.position.x)).toBe(true);
+    expect(b.position.x).toBeCloseTo(100, 0);
+  });
+
+  it("very low frequency (0.5 Hz) is very compliant", () => {
+    const space = new Space(new Vec2(0, 200));
+    const a = staticBody(space, 0, 0);
+    const b = dyn(space, 0, 50);
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 50);
+    j.frequency = 0.5; // very soft
+    j.damping = 1;
+    j.space = space;
+
+    for (let i = 0; i < 120; i++) space.step(1 / 60);
+    // Soft spring under gravity: bob hangs much lower than rest
+    expect(b.position.y).toBeGreaterThan(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Anchor offsets — torque path
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — off-centre anchors", () => {
+  it("offset anchor with perpendicular force produces angular response", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = staticBody(space, 0, 0);
+    const b = new Body(BodyType.DYNAMIC, new Vec2(0, 150));
+    b.shapes.add(new Polygon(Polygon.box(40, 10)));
+    b.space = space;
+
+    // Spring is vertical (along y), anchor on b is offset along x → torque
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(20, 0), 80);
+    j.frequency = 4;
+    j.damping = 0.5;
+    j.space = space;
+
+    for (let i = 0; i < 120; i++) space.step(1 / 60);
+
+    // Should have rotated (offset anchor with perpendicular force)
+    expect(Math.abs(b.rotation)).toBeGreaterThan(0.005);
+  });
+
+  it("symmetric centre anchors do not produce rotation", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = staticBody(space, 0, 0);
+    const b = new Body(BodyType.DYNAMIC, new Vec2(150, 0));
+    b.shapes.add(new Polygon(Polygon.box(40, 10)));
+    b.space = space;
+
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 80);
+    j.frequency = 4;
+    j.damping = 1;
+    j.space = space;
+
+    for (let i = 0; i < 240; i++) space.step(1 / 60);
+
+    expect(Math.abs(b.rotation)).toBeLessThan(0.05);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Constraint requires both bodies (validation)
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — body validation", () => {
+  it("throws on step if body1 is null", () => {
+    const space = new Space(new Vec2(0, 0));
+    const b = dyn(space, 100, 0);
+    const j = new SpringJoint(null, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 50);
+    j.space = space;
+
+    expect(() => space.step(1 / 60)).toThrow(/null bod/);
+  });
+
+  it("throws on step if body2 is null", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const j = new SpringJoint(a, null, Vec2.weak(0, 0), Vec2.weak(0, 0), 50);
+    j.space = space;
+
+    expect(() => space.step(1 / 60)).toThrow(/null bod/);
+  });
+
+  it("throws on step if body1 == body2", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const j = new SpringJoint(a, a, Vec2.weak(0, 0), Vec2.weak(10, 0), 50);
+    j.space = space;
+
+    expect(() => space.step(1 / 60)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Long chain (N springs in series)
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — chain", () => {
+  it("a chain of 5 springs hangs under gravity without divergence", () => {
+    const space = new Space(new Vec2(0, 200));
+
+    const anchor = staticBody(space, 0, 0);
+    const segs: Body[] = [];
+    let prev = anchor;
+    for (let i = 0; i < 5; i++) {
+      const b = dyn(space, 0, 30 * (i + 1));
+      const j = new SpringJoint(prev, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 30);
+      j.frequency = 8;
+      j.damping = 1;
+      j.space = space;
+      segs.push(b);
+      prev = b;
+    }
+
+    for (let i = 0; i < 600; i++) space.step(1 / 60);
+
+    // Last segment should be hanging below the anchor
+    expect(segs[segs.length - 1].position.y).toBeGreaterThan(80);
+    for (const b of segs) {
+      expect(Number.isFinite(b.position.x)).toBe(true);
+      expect(Number.isFinite(b.position.y)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Body re-assignment mid-simulation
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — body reassignment", () => {
+  it("changing body2 mid-simulation transfers the spring force", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = staticBody(space, 0, 0);
+    const b1 = dyn(space, 200, 0);
+    const b2 = dyn(space, 200, 100);
+    const j = new SpringJoint(a, b1, Vec2.weak(0, 0), Vec2.weak(0, 0), 50);
+    j.frequency = 4;
+    j.damping = 1;
+    j.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60);
+    const b1Pos = b1.position.x;
+
+    // Reassign to b2
+    j.body2 = b2;
+    for (let i = 0; i < 60; i++) space.step(1 / 60);
+
+    // b1 no longer pulled — b2 now pulled
+    expect(Math.abs(b1.position.x - b1Pos)).toBeLessThan(50);
+    // b2 has been pulled toward a
+    const b2Dist = Math.sqrt(b2.position.x ** 2 + b2.position.y ** 2);
+    expect(b2Dist).toBeLessThan(220);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Anchor mutation invalidation
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — anchor mutation", () => {
+  it("changing anchor1 component (x, y) invalidates and reapplies", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = staticBody(space, 0, 0);
+    const b = dyn(space, 100, 0);
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 50);
+    j.frequency = 4;
+    j.damping = 1;
+    j.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60);
+
+    // Move world anchor on a (via wrap)
+    j.anchor1.x = 30;
+    j.anchor1.y = 30;
+    for (let i = 0; i < 60; i++) space.step(1 / 60);
+
+    expect(Number.isFinite(b.position.x)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. restLength=0 (anchors should converge)
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — restLength=0", () => {
+  it("anchors converge towards the same point", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = staticBody(space, 0, 0);
+    const b = dyn(space, 100, 0);
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 0);
+    j.frequency = 8;
+    j.damping = 1;
+    j.space = space;
+
+    const initial = Math.abs(b.position.x);
+    for (let i = 0; i < 600; i++) space.step(1 / 60);
+
+    // Should be much closer than the starting distance
+    expect(Math.abs(b.position.x)).toBeLessThan(initial / 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. impulse and bodyImpulse non-zero under load
+// ---------------------------------------------------------------------------
+
+describe("SpringJoint — impulse accessors under load", () => {
+  it("impulse() returns non-zero for a stretched spring", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = staticBody(space, 0, 0);
+    const b = dyn(space, 200, 0);
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 50);
+    j.frequency = 4;
+    j.damping = 1;
+    j.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60);
+
+    const imp = j.impulse();
+    // MatMN(1, 1)
+    expect(imp.zpp_inner.x[0]).not.toBe(0);
+  });
+
+  it("bodyImpulse on b1 and b2 are equal-and-opposite (Newton's 3rd)", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 200, 0);
+    const j = new SpringJoint(a, b, Vec2.weak(0, 0), Vec2.weak(0, 0), 50);
+    j.frequency = 4;
+    j.damping = 1;
+    j.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60);
+
+    const imp1 = j.bodyImpulse(a);
+    const imp2 = j.bodyImpulse(b);
+    expect(imp1.x + imp2.x).toBeCloseTo(0, 5);
+    expect(imp1.y + imp2.y).toBeCloseTo(0, 5);
+  });
+});

--- a/packages/nape-js/tests/constraint/UserConstraint.solver.test.ts
+++ b/packages/nape-js/tests/constraint/UserConstraint.solver.test.ts
@@ -1,0 +1,492 @@
+/**
+ * UserConstraint — solver branch coverage.
+ *
+ * Targets uncovered branches in:
+ * - ZPP_UserConstraint.preStep / applyImpulseVel / applyImpulsePos
+ *   (multi-DOF constraints, velocity-only mode, clamp paths, multiple bodies)
+ * - UserConstraint base methods (__bindVec2, __broken hook, __draw forwarding)
+ * - Body re-registration with _registerBody (oldBody==newBody, oldBody not registered)
+ * - bodyImpulse with deactivated constraint
+ * - visitBodies with duplicate body entries (dedup path)
+ */
+
+import { describe, it, expect } from "vitest";
+import { Space } from "../../src/space/Space";
+import { Body } from "../../src/phys/Body";
+import { BodyType } from "../../src/phys/BodyType";
+import { Vec2 } from "../../src/geom/Vec2";
+import { Circle } from "../../src/shape/Circle";
+import { UserConstraint } from "../../src/constraint/UserConstraint";
+
+type Any = any;
+
+// ---------------------------------------------------------------------------
+// Test constraints
+// ---------------------------------------------------------------------------
+
+/** Two-body distance constraint (1-DOF positional). */
+class DistanceConstraint extends UserConstraint {
+  private _b1: Body | null = null;
+  private _b2: Body | null = null;
+  target: number;
+  brokenCalled = false;
+  drawCalled = false;
+  clampCalled = false;
+
+  constructor(b1: Body | null, b2: Body | null, target: number, velOnly = false) {
+    super(1, velOnly);
+    this.target = target;
+    this._b1 = this.__registerBody(this._b1, b1);
+    this._b2 = this.__registerBody(this._b2, b2);
+  }
+
+  set body1(value: Body | null) {
+    this._b1 = this.__registerBody(this._b1, value);
+  }
+  set body2(value: Body | null) {
+    this._b2 = this.__registerBody(this._b2, value);
+  }
+  get body1() {
+    return this._b1;
+  }
+  get body2() {
+    return this._b2;
+  }
+
+  __copy() {
+    return new DistanceConstraint(this._b1, this._b2, this.target);
+  }
+  __broken() {
+    this.brokenCalled = true;
+  }
+  __draw(_g: Any) {
+    this.drawCalled = true;
+  }
+  __position(err: number[]) {
+    const a = (this._b1 as Any).zpp_inner;
+    const b = (this._b2 as Any).zpp_inner;
+    const dx = b.posx - a.posx;
+    const dy = b.posy - a.posy;
+    err[0] = Math.sqrt(dx * dx + dy * dy) - this.target;
+  }
+  __velocity(err: number[]) {
+    const a = (this._b1 as Any).zpp_inner;
+    const b = (this._b2 as Any).zpp_inner;
+    const dx = b.posx - a.posx;
+    const dy = b.posy - a.posy;
+    const d = Math.sqrt(dx * dx + dy * dy);
+    if (d === 0) {
+      err[0] = 0;
+      return;
+    }
+    const nx = dx / d;
+    const ny = dy / d;
+    err[0] = (b.velx - a.velx) * nx + (b.vely - a.vely) * ny;
+  }
+  __eff_mass(eff: number[]) {
+    const a = (this._b1 as Any).zpp_inner;
+    const b = (this._b2 as Any).zpp_inner;
+    eff[0] = a.imass + b.imass;
+  }
+  __clamp(jAcc: number[]) {
+    this.clampCalled = true;
+    // No actual clamping
+    return jAcc;
+  }
+  __impulse(imp: number[], body: Body, out: Any) {
+    const a = (this._b1 as Any).zpp_inner;
+    const b = (this._b2 as Any).zpp_inner;
+    const dx = b.posx - a.posx;
+    const dy = b.posy - a.posy;
+    const d = Math.sqrt(dx * dx + dy * dy);
+    if (d === 0) {
+      out.zpp_inner.x = 0;
+      out.zpp_inner.y = 0;
+      out.zpp_inner.z = 0;
+      return;
+    }
+    const nx = dx / d;
+    const ny = dy / d;
+    const sign = body === this._b1 ? -1 : 1;
+    out.zpp_inner.x = sign * imp[0] * nx;
+    out.zpp_inner.y = sign * imp[0] * ny;
+    out.zpp_inner.z = 0;
+  }
+}
+
+/** 2-DOF Cartesian constraint — locks both x and y of body relative to anchor. */
+class XYLockConstraint extends UserConstraint {
+  private _body: Body | null = null;
+  ax: number;
+  ay: number;
+
+  constructor(body: Body | null, ax: number, ay: number) {
+    super(2);
+    this.ax = ax;
+    this.ay = ay;
+    this._body = this.__registerBody(this._body, body);
+  }
+
+  __copy() {
+    return new XYLockConstraint(this._body, this.ax, this.ay);
+  }
+  __position(err: number[]) {
+    const b = (this._body as Any).zpp_inner;
+    err[0] = b.posx - this.ax;
+    err[1] = b.posy - this.ay;
+  }
+  __velocity(err: number[]) {
+    const b = (this._body as Any).zpp_inner;
+    err[0] = b.velx;
+    err[1] = b.vely;
+  }
+  __eff_mass(eff: number[]) {
+    const b = (this._body as Any).zpp_inner;
+    // Upper triangle of 2x2 effective mass = mass * I
+    eff[0] = b.imass; // [0][0]
+    eff[1] = 0; // [0][1]
+    eff[2] = b.imass; // [1][1]
+  }
+  __impulse(imp: number[], _body: Body, out: Any) {
+    out.zpp_inner.x = imp[0];
+    out.zpp_inner.y = imp[1];
+    out.zpp_inner.z = 0;
+  }
+}
+
+/** Velocity-only constraint — limits body x velocity. */
+class XVelocityCap extends UserConstraint {
+  private _body: Body | null = null;
+  cap: number;
+
+  constructor(body: Body | null, cap: number) {
+    super(1, true); // velocity-only
+    this.cap = cap;
+    this._body = this.__registerBody(this._body, body);
+  }
+
+  __copy() {
+    return new XVelocityCap(this._body, this.cap);
+  }
+  __velocity(err: number[]) {
+    const b = (this._body as Any).zpp_inner;
+    // Push toward zero only when above cap
+    err[0] = b.velx > this.cap ? b.velx - this.cap : 0;
+  }
+  __eff_mass(eff: number[]) {
+    eff[0] = (this._body as Any).zpp_inner.imass;
+  }
+  __clamp(j: number[]) {
+    // Clamp impulse so it can only push leftward (not pull body forward)
+    if (j[0] < 0) j[0] = 0;
+  }
+  __impulse(imp: number[], _body: Body, out: Any) {
+    out.zpp_inner.x = imp[0];
+    out.zpp_inner.y = 0;
+    out.zpp_inner.z = 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function dyn(space: Space, x = 0, y = 0): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(8));
+  b.space = space;
+  return b;
+}
+
+// ---------------------------------------------------------------------------
+// 1. 2-DOF constraint (XY lock)
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — 2-DOF XY lock", () => {
+  it("soft 2-DOF lock pulls a body toward an anchor point", () => {
+    const space = new Space(new Vec2(0, 0));
+    const body = dyn(space, 100, 50);
+
+    const lock = new XYLockConstraint(body, 50, 100);
+    lock.stiff = false;
+    lock.frequency = 5;
+    lock.damping = 1;
+    lock.space = space;
+
+    for (let i = 0; i < 240; i++) space.step(1 / 60, 10, 10);
+
+    // Should converge near the anchor
+    expect(Math.abs(body.position.x - 50)).toBeLessThan(5);
+    expect(Math.abs(body.position.y - 100)).toBeLessThan(5);
+  });
+
+  it("2-DOF Keff factorisation runs over many steps without NaN", () => {
+    const space = new Space(new Vec2(0, 0));
+    const body = dyn(space, 50, 50);
+
+    const lock = new XYLockConstraint(body, 100, 100);
+    lock.stiff = false;
+    lock.frequency = 3;
+    lock.damping = 0.9;
+    lock.space = space;
+
+    for (let i = 0; i < 600; i++) space.step(1 / 60);
+
+    expect(Number.isFinite(body.position.x)).toBe(true);
+    expect(Number.isFinite(body.position.y)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Velocity-only constraint with clamp
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — velocity-only mode", () => {
+  it("clamps x velocity downward via __clamp", () => {
+    const space = new Space(new Vec2(0, 0));
+    const body = dyn(space, 0, 0);
+    body.velocity = new Vec2(500, 0);
+
+    const cap = new XVelocityCap(body, 100);
+    cap.space = space;
+
+    const v0 = body.velocity.x;
+    for (let i = 0; i < 60; i++) space.step(1 / 60);
+
+    // Velocity should be reduced — constraint pushes down toward cap
+    expect(body.velocity.x).toBeLessThan(v0);
+  });
+
+  it("clamp prevents reverse impulse — does not pull body forward", () => {
+    const space = new Space(new Vec2(0, 0));
+    const body = dyn(space, 0, 0);
+    body.velocity = new Vec2(10, 0); // already below cap
+
+    const cap = new XVelocityCap(body, 100);
+    cap.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60);
+
+    // Body's velocity should remain at 10 (cap shouldn't accelerate it up to 100)
+    expect(body.velocity.x).toBeCloseTo(10, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Distance constraint with breakUnderForce
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — break under force", () => {
+  it("__broken is invoked when constraint breaks under high load", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 50, 0);
+
+    const c = new DistanceConstraint(a, b, 50);
+    c.maxForce = 1; // very low
+    c.breakUnderForce = true;
+    c.removeOnBreak = true;
+    c.space = space;
+
+    // Kick body away — should exceed maxForce and break
+    b.velocity = new Vec2(2000, 0);
+    for (let i = 0; i < 60; i++) space.step(1 / 60);
+
+    expect(c.brokenCalled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Re-register body cases
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — body registration", () => {
+  it("setting body to itself is a no-op", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 100, 0);
+
+    const c = new DistanceConstraint(a, b, 100);
+    expect(c.body1).toBe(a);
+
+    // Set to same body — no-op
+    c.body1 = a;
+    expect(c.body1).toBe(a);
+    expect(c.zpp_inner.bodies.length).toBe(2);
+  });
+
+  it("setting body to null unregisters it", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 100, 0);
+    const c = new DistanceConstraint(a, b, 100);
+
+    c.body1 = null;
+    expect(c.body1).toBe(null);
+    expect(c.zpp_inner.bodies.length).toBe(1);
+  });
+
+  it("setting body to a brand-new body works", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 100, 0);
+    const c = new DistanceConstraint(a, b, 100);
+
+    const d = dyn(space, 200, 0);
+    c.body1 = d;
+    expect(c.body1).toBe(d);
+    expect(c.zpp_inner.bodies.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. bodyImpulse with deactivated constraint
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — bodyImpulse(active=false)", () => {
+  it("returns zero impulse when constraint is inactive", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 100, 0);
+    const c = new DistanceConstraint(a, b, 100);
+    c.space = space;
+
+    space.step(1 / 60);
+    c.active = false;
+
+    const imp = c.bodyImpulse(a);
+    expect(imp.x).toBe(0);
+    expect(imp.y).toBe(0);
+    expect(imp.z).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. impulse() returns MatMN with each DOF
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — impulse() multi-DOF", () => {
+  it("returns 2-row matrix for 2-DOF constraint", () => {
+    const space = new Space(new Vec2(0, 200));
+    const body = dyn(space, 100, 0);
+
+    const lock = new XYLockConstraint(body, 50, 100);
+    lock.space = space;
+
+    space.step(1 / 60);
+
+    const imp = lock.impulse();
+    expect(imp.zpp_inner.m).toBe(2);
+    expect(imp.zpp_inner.n).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. visitBodies dedup path (same body listed twice)
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — visitBodies dedup", () => {
+  it("does not call lambda twice if a body appears in multiple slots", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+
+    // Register the same body twice via DistanceConstraint
+    // Workaround: a real two-slot constraint registering the same body
+    const c = new DistanceConstraint(a, a, 0);
+
+    const visited: Body[] = [];
+    c.visitBodies((b) => visited.push(b));
+    expect(visited.length).toBe(1);
+    expect(visited[0]).toBe(a);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. __bindVec2 invalidation
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — __bindVec2", () => {
+  it("modifying a bound Vec2 invalidates the constraint", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 100, 0);
+    const c = new DistanceConstraint(a, b, 100);
+    c.space = space;
+
+    const bound = c.__bindVec2();
+    expect((bound as Any).zpp_inner._inuse).toBe(true);
+
+    // Mutate — should call invalidate (not throw)
+    bound.x = 5;
+    bound.y = 10;
+    expect(bound.x).toBe(5);
+    expect(bound.y).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. __copy creates an independent constraint
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — __copy", () => {
+  it("DistanceConstraint __copy returns a new instance with same anchors", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 100, 0);
+    const c = new DistanceConstraint(a, b, 100);
+
+    const copy = c.__copy();
+    expect(copy).not.toBe(c);
+    expect(copy.body1).toBe(a);
+    expect(copy.body2).toBe(b);
+    expect((copy as DistanceConstraint).target).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Inactive constraint does not affect the simulation
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — active=false", () => {
+  it("inactive distance constraint does not pull bodies together", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 200, 0);
+    const c = new DistanceConstraint(a, b, 50);
+    c.active = false;
+    c.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60);
+    // Without the constraint pulling, bodies stay where they were
+    expect(b.position.x).toBeCloseTo(200, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. Soft mode (frequency/damping)
+// ---------------------------------------------------------------------------
+
+describe("UserConstraint — soft mode", () => {
+  it("soft distance constraint allows oscillation", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dyn(space, 0, 0);
+    const b = dyn(space, 200, 0);
+    const c = new DistanceConstraint(a, b, 100);
+    c.stiff = false;
+    c.frequency = 2;
+    c.damping = 0.1;
+    c.space = space;
+
+    let minDx = Infinity;
+    let maxDx = -Infinity;
+    for (let i = 0; i < 600; i++) {
+      space.step(1 / 60);
+      const dx = b.position.x - a.position.x;
+      if (dx < minDx) minDx = dx;
+      if (dx > maxDx) maxDx = dx;
+    }
+
+    // Should oscillate around 100
+    expect(maxDx - minDx).toBeGreaterThan(20);
+  });
+});

--- a/packages/nape-js/tests/geom/GeomPoly.cuts-decomp.test.ts
+++ b/packages/nape-js/tests/geom/GeomPoly.cuts-decomp.test.ts
@@ -1,0 +1,429 @@
+/**
+ * GeomPoly cut + decomposition algorithm coverage.
+ *
+ * Targets uncovered branches in:
+ * - ZPP_Cutter (51% → boost): unbounded/bounded cuts, vertex hits, near-parallel,
+ *   tangential cuts, multi-segment outputs, cuts that fully separate the polygon
+ *   into N pieces.
+ * - ZPP_Monotone (58% → boost): convex inputs, concave with single reflex vertex,
+ *   multiple reflex vertices, triangulation through monotone partitions, etc.
+ * - ZPP_Simple (57% → boost): self-intersection detection on various polygons.
+ * - ZPP_Convex (97% → preserve), ZPP_Triangular (89%): convex decomposition checks.
+ */
+
+import { describe, it, expect } from "vitest";
+import "../../src/core/engine";
+import { GeomPoly } from "../../src/geom/GeomPoly";
+import { Vec2 } from "../../src/geom/Vec2";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSquare(s = 20): GeomPoly {
+  return new GeomPoly([Vec2.get(-s, -s), Vec2.get(s, -s), Vec2.get(s, s), Vec2.get(-s, s)]);
+}
+
+function makePentagon(r = 20): GeomPoly {
+  const verts: Vec2[] = [];
+  for (let i = 0; i < 5; i++) {
+    const a = (i / 5) * Math.PI * 2 - Math.PI / 2;
+    verts.push(Vec2.get(Math.cos(a) * r, Math.sin(a) * r));
+  }
+  return new GeomPoly(verts);
+}
+
+/** Concave L-shape with one reflex vertex. */
+function makeLShape(): GeomPoly {
+  return new GeomPoly([
+    Vec2.get(0, 0),
+    Vec2.get(40, 0),
+    Vec2.get(40, 20),
+    Vec2.get(20, 20),
+    Vec2.get(20, 40),
+    Vec2.get(0, 40),
+  ]);
+}
+
+/** Cross/plus-sign with 4 reflex vertices. */
+function makePlus(): GeomPoly {
+  return new GeomPoly([
+    Vec2.get(-10, -30),
+    Vec2.get(10, -30),
+    Vec2.get(10, -10),
+    Vec2.get(30, -10),
+    Vec2.get(30, 10),
+    Vec2.get(10, 10),
+    Vec2.get(10, 30),
+    Vec2.get(-10, 30),
+    Vec2.get(-10, 10),
+    Vec2.get(-30, 10),
+    Vec2.get(-30, -10),
+    Vec2.get(-10, -10),
+  ]);
+}
+
+/** Star with concave reflex vertices between every spike. */
+function makeStar(spikes = 5, outerR = 30, innerR = 12): GeomPoly {
+  const verts: Vec2[] = [];
+  const total = spikes * 2;
+  for (let i = 0; i < total; i++) {
+    const a = (i / total) * Math.PI * 2 - Math.PI / 2;
+    const r = i % 2 === 0 ? outerR : innerR;
+    verts.push(Vec2.get(Math.cos(a) * r, Math.sin(a) * r));
+  }
+  return new GeomPoly(verts);
+}
+
+// ---------------------------------------------------------------------------
+// 1. ZPP_Cutter — unbounded vs bounded cuts
+// ---------------------------------------------------------------------------
+
+describe("GeomPoly.cut — unbounded line", () => {
+  it("horizontal unbounded cut splits a square into 2 pieces", () => {
+    const sq = makeSquare(20);
+    const result = sq.cut(Vec2.get(-50, 0), Vec2.get(50, 0));
+    expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("vertical unbounded cut splits a square into 2 pieces", () => {
+    const sq = makeSquare(20);
+    const result = sq.cut(Vec2.get(0, -50), Vec2.get(0, 50));
+    expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("diagonal cut on a square produces 2 pieces of equal area", () => {
+    const sq = makeSquare(20);
+    const result = sq.cut(Vec2.get(-50, -50), Vec2.get(50, 50));
+    expect(result.length).toBeGreaterThanOrEqual(2);
+
+    const a1 = result.at(0).area();
+    const a2 = result.at(1).area();
+    expect(Math.abs(a1 - a2)).toBeLessThan(1);
+  });
+
+  it("cut passing through a vertex still produces valid pieces", () => {
+    const sq = makeSquare(20);
+    // Cut through the (-20, -20) corner
+    const result = sq.cut(Vec2.get(-30, -30), Vec2.get(30, 30));
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("cut tangent to one edge does not multiply pieces unexpectedly", () => {
+    const sq = makeSquare(20);
+    // Run cut along the top edge
+    const result = sq.cut(Vec2.get(-30, 20), Vec2.get(30, 20));
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("GeomPoly.cut — bounded line (segment)", () => {
+  it("bounded cut entirely outside the polygon returns the original", () => {
+    const sq = makeSquare(20);
+    const result = sq.cut(Vec2.get(50, 0), Vec2.get(60, 10), true, true);
+    expect(result.length).toBe(1);
+  });
+
+  it("bounded cut starting inside but ending outside leaves the polygon whole", () => {
+    const sq = makeSquare(20);
+    const result = sq.cut(Vec2.get(0, 0), Vec2.get(50, 0), true, true);
+    expect(result.length).toBe(1);
+  });
+
+  it("bounded cut spanning the polygon splits it into 2 pieces", () => {
+    const sq = makeSquare(20);
+    const result = sq.cut(Vec2.get(-30, 0), Vec2.get(30, 0), true, true);
+    expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("boundedStart=true alone (end is unbounded ray) cuts when start is in", () => {
+    const sq = makeSquare(20);
+    const result = sq.cut(Vec2.get(0, 0), Vec2.get(30, 0), true, false);
+    // End is an unbounded ray from (30, 0) onward — should cut
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("boundedEnd=true alone (start is unbounded ray) cuts symmetrically", () => {
+    const sq = makeSquare(20);
+    const result = sq.cut(Vec2.get(-30, 0), Vec2.get(0, 0), false, true);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. ZPP_Cutter — multi-piece outputs (concave shapes)
+// ---------------------------------------------------------------------------
+
+describe("GeomPoly.cut — concave shapes produce >=2 pieces", () => {
+  it("horizontal cut through a plus produces multiple pieces", () => {
+    const plus = makePlus();
+    const result = plus.cut(Vec2.get(-50, 0), Vec2.get(50, 0));
+    // A horizontal cut through the centre of a plus produces 2 pieces
+    expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("cut through L-shape returns valid pieces", () => {
+    const lshape = makeLShape();
+    // Diagonal cut through the L
+    const result = lshape.cut(Vec2.get(0, 50), Vec2.get(50, 0));
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("vertical cut through star produces several pieces", () => {
+    const star = makeStar(5, 30, 12);
+    const result = star.cut(Vec2.get(0, -50), Vec2.get(0, 50));
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Sequential cuts (cuts on cuts)
+// ---------------------------------------------------------------------------
+
+describe("GeomPoly.cut — sequential cuts", () => {
+  it("two perpendicular cuts produce 4 pieces from a square", () => {
+    const sq = makeSquare(20);
+    const horiz = sq.cut(Vec2.get(-30, 0), Vec2.get(30, 0));
+    let total = 0;
+    for (let i = 0; i < horiz.length; i++) {
+      const piece = horiz.at(i);
+      const sub = piece.cut(Vec2.get(0, -30), Vec2.get(0, 30));
+      total += sub.length;
+    }
+    expect(total).toBeGreaterThanOrEqual(4);
+  });
+
+  it("three radial cuts produce a pinwheel of pieces", () => {
+    let pieces = [makePentagon(30)];
+    for (let i = 0; i < 3; i++) {
+      const a = (i / 3) * Math.PI;
+      const x = Math.cos(a) * 100;
+      const y = Math.sin(a) * 100;
+      const next: GeomPoly[] = [];
+      for (const p of pieces) {
+        const r = p.cut(Vec2.get(-x, -y), Vec2.get(x, y));
+        for (let j = 0; j < r.length; j++) next.push(r.at(j));
+      }
+      pieces = next;
+    }
+    expect(pieces.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Cut error paths
+// ---------------------------------------------------------------------------
+
+describe("GeomPoly.cut — error handling", () => {
+  it("throws on null start", () => {
+    const sq = makeSquare(20);
+    expect(() => sq.cut(null as unknown as Vec2, Vec2.get(0, 0))).toThrow();
+  });
+
+  it("throws on null end", () => {
+    const sq = makeSquare(20);
+    expect(() => sq.cut(Vec2.get(0, 0), null as unknown as Vec2)).toThrow();
+  });
+
+  it("throws on disposed Vec2", () => {
+    const sq = makeSquare(20);
+    const v = Vec2.get(0, 0);
+    v.dispose();
+    expect(() => sq.cut(v, Vec2.get(10, 10))).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. ZPP_Monotone — decomposition correctness
+// ---------------------------------------------------------------------------
+
+describe("GeomPoly.monotoneDecomposition", () => {
+  it("convex polygon decomposes to itself (1 piece)", () => {
+    const sq = makeSquare(20);
+    const result = sq.monotoneDecomposition();
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("L-shape decomposes into >= 1 monotone piece", () => {
+    const result = makeLShape().monotoneDecomposition();
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    // Each piece must itself be a monotone polygon
+    for (let i = 0; i < result.length; i++) {
+      expect(result.at(i).isMonotone()).toBe(true);
+    }
+  });
+
+  it("plus shape decomposes into multiple monotone pieces", () => {
+    const result = makePlus().monotoneDecomposition();
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    for (let i = 0; i < result.length; i++) {
+      expect(result.at(i).isMonotone()).toBe(true);
+    }
+  });
+
+  it("star decomposes into multiple monotone pieces", () => {
+    const result = makeStar(5, 30, 12).monotoneDecomposition();
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < result.length; i++) {
+      expect(result.at(i).isMonotone()).toBe(true);
+    }
+  });
+
+  it("preserves total area within rounding tolerance", () => {
+    const star = makeStar(6, 25, 10);
+    const original = Math.abs(star.area());
+    const result = star.monotoneDecomposition();
+    let sum = 0;
+    for (let i = 0; i < result.length; i++) sum += Math.abs(result.at(i).area());
+    expect(Math.abs(sum - original)).toBeLessThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. ZPP_Convex — convex decomposition
+// ---------------------------------------------------------------------------
+
+describe("GeomPoly.convexDecomposition", () => {
+  it("convex polygon decomposes to itself (1 convex piece)", () => {
+    const result = makePentagon(20).convexDecomposition();
+    expect(result.length).toBe(1);
+    expect(result.at(0).isConvex()).toBe(true);
+  });
+
+  it("L-shape decomposes into convex pieces", () => {
+    const result = makeLShape().convexDecomposition();
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < result.length; i++) {
+      expect(result.at(i).isConvex()).toBe(true);
+    }
+  });
+
+  it("plus shape decomposes into convex pieces", () => {
+    const result = makePlus().convexDecomposition();
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < result.length; i++) {
+      expect(result.at(i).isConvex()).toBe(true);
+    }
+  });
+
+  it("star decomposes into convex pieces", () => {
+    const result = makeStar(5, 30, 12).convexDecomposition();
+    expect(result.length).toBeGreaterThanOrEqual(3);
+    for (let i = 0; i < result.length; i++) {
+      expect(result.at(i).isConvex()).toBe(true);
+    }
+  });
+
+  it("delaunay flag produces valid output", () => {
+    const result = makeLShape().convexDecomposition(true);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. ZPP_Triangular — every output triangle has 3 vertices
+// ---------------------------------------------------------------------------
+
+describe("GeomPoly.triangularDecomposition", () => {
+  it("convex pentagon → 3 triangles", () => {
+    const result = makePentagon(20).triangularDecomposition();
+    expect(result.length).toBe(3);
+    for (let i = 0; i < result.length; i++) {
+      expect(result.at(i).area()).not.toBe(0);
+    }
+  });
+
+  it("L-shape produces a valid triangulation", () => {
+    const result = makeLShape().triangularDecomposition();
+    expect(result.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("plus shape triangulates into multiple triangles covering the original area", () => {
+    const plus = makePlus();
+    const original = Math.abs(plus.area());
+    const result = plus.triangularDecomposition();
+    expect(result.length).toBeGreaterThanOrEqual(4);
+    let sum = 0;
+    for (let i = 0; i < result.length; i++) sum += Math.abs(result.at(i).area());
+    expect(Math.abs(sum - original)).toBeLessThan(1);
+  });
+
+  it("delaunay-optimised triangulation still produces valid pieces", () => {
+    const result = makeLShape().triangularDecomposition(true);
+    expect(result.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. ZPP_Simple — self-intersection detection
+// ---------------------------------------------------------------------------
+
+describe("GeomPoly.isSimple", () => {
+  it("true for a square", () => {
+    expect(makeSquare(20).isSimple()).toBe(true);
+  });
+
+  it("true for a star shape (no self-intersections in this construction)", () => {
+    expect(makeStar(5, 30, 12).isSimple()).toBe(true);
+  });
+
+  it("false for a self-intersecting bowtie", () => {
+    const bowtie = new GeomPoly([
+      Vec2.get(-10, -10),
+      Vec2.get(10, 10),
+      Vec2.get(10, -10),
+      Vec2.get(-10, 10),
+    ]);
+    expect(bowtie.isSimple()).toBe(false);
+  });
+
+  it("false for figure-8", () => {
+    const fig8 = new GeomPoly([Vec2.get(0, 0), Vec2.get(20, 20), Vec2.get(0, 20), Vec2.get(20, 0)]);
+    expect(fig8.isSimple()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. ZPP_Simplify — Douglas-Peucker correctness
+// ---------------------------------------------------------------------------
+
+describe("GeomPoly.simplify", () => {
+  it("removes nearly collinear points within epsilon", () => {
+    const verts: Vec2[] = [];
+    // Square with extra points on one edge
+    verts.push(Vec2.get(0, 0));
+    for (let i = 1; i <= 10; i++) verts.push(Vec2.get(i * 2, 0));
+    verts.push(Vec2.get(20, 20));
+    verts.push(Vec2.get(0, 20));
+    const noisy = new GeomPoly(verts);
+
+    const simplified = noisy.simplify(0.5);
+
+    // Vertex count should be reduced
+    let count = 0;
+    const it = simplified.iterator();
+    while (it.hasNext()) {
+      it.next();
+      count++;
+    }
+    expect(count).toBeLessThan(13);
+  });
+
+  it("throws on epsilon <= 0", () => {
+    const sq = makeSquare(20);
+    expect(() => sq.simplify(0)).toThrow();
+    expect(() => sq.simplify(-1)).toThrow();
+  });
+
+  it("very small epsilon preserves all vertices of a clean shape", () => {
+    const sq = makeSquare(20);
+    const simplified = sq.simplify(0.0001);
+    let count = 0;
+    const it = simplified.iterator();
+    while (it.hasNext()) {
+      it.next();
+      count++;
+    }
+    expect(count).toBe(4);
+  });
+});

--- a/packages/nape-js/tests/native/dynamics/ZPP_ColArbiter.warmstart.test.ts
+++ b/packages/nape-js/tests/native/dynamics/ZPP_ColArbiter.warmstart.test.ts
@@ -1,0 +1,496 @@
+/**
+ * ZPP_ColArbiter — warm-start, multi-step persistence and 2-contact solver.
+ *
+ * Targets uncovered branches:
+ * - preStep dt-ratio scaling (changing dt across steps re-scales jnAcc/jtAcc)
+ * - Warm-start impulse persistence across N steps for resting contact
+ * - 2-contact block solver path (poly-poly with 2 contact points)
+ * - Position correction (Baumgarte) on deep penetration
+ * - Static friction → dynamic friction transition
+ * - Restitution velocity threshold (low velocity → no bounce)
+ * - Contact persistence across many steps without loss
+ * - Sleeping → wake → re-collide cycle
+ */
+
+import { describe, it, expect } from "vitest";
+import { Space } from "../../../src/space/Space";
+import { Body } from "../../../src/phys/Body";
+import { BodyType } from "../../../src/phys/BodyType";
+import { Vec2 } from "../../../src/geom/Vec2";
+import { Circle } from "../../../src/shape/Circle";
+import { Polygon } from "../../../src/shape/Polygon";
+import { Material } from "../../../src/phys/Material";
+import { InteractionListener } from "../../../src/callbacks/InteractionListener";
+import { CbType } from "../../../src/callbacks/CbType";
+import { CbEvent } from "../../../src/callbacks/CbEvent";
+import { InteractionType } from "../../../src/callbacks/InteractionType";
+import "../../../src/dynamics/Contact";
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+function dynamicBox(x: number, y: number, w = 30, h = 30, mat?: Material): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  const s = new Polygon(Polygon.box(w, h));
+  if (mat) s.material = mat;
+  b.shapes.add(s);
+  return b;
+}
+
+function dynamicCircle(x: number, y: number, r = 15, mat?: Material): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  const s = new Circle(r);
+  if (mat) s.material = mat;
+  b.shapes.add(s);
+  return b;
+}
+
+function staticFloor(y = 300, w = 600, h = 20, mat?: Material): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(0, y));
+  const s = new Polygon(Polygon.box(w, h));
+  if (mat) s.material = mat;
+  b.shapes.add(s);
+  return b;
+}
+
+function arbiterCount(space: Space): number {
+  return (space.arbiters as any).zpp_gl();
+}
+
+// -------------------------------------------------------------------------
+// 1. dt-ratio scaling across variable timesteps
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — dt-ratio warm start", () => {
+  it("survives a step-size change without losing contact", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.space = space;
+
+    const box = dynamicBox(0, 200, 30, 30);
+    box.space = space;
+
+    // Settle with dt=1/60
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+    expect(arbiterCount(space)).toBeGreaterThan(0);
+
+    // Switch to dt=1/30 — preStep dtratio path
+    for (let i = 0; i < 30; i++) space.step(1 / 30, 10, 10);
+    expect(box.position.y).toBeLessThan(310);
+
+    // Switch back to small dt=1/120 — box must remain above the floor and finite
+    for (let i = 0; i < 60; i++) space.step(1 / 120, 10, 10);
+    expect(box.position.y).toBeLessThan(310);
+    expect(Number.isFinite(box.position.y)).toBe(true);
+  });
+
+  it("variable dt does not produce NaN positions", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.space = space;
+
+    const box = dynamicBox(0, 200, 40, 40);
+    box.space = space;
+
+    const dts = [1 / 60, 1 / 30, 1 / 120, 1 / 80, 1 / 50];
+    for (let cycle = 0; cycle < 5; cycle++) {
+      const dt = dts[cycle % dts.length];
+      for (let i = 0; i < 20; i++) space.step(dt, 10, 10);
+      expect(Number.isFinite(box.position.x)).toBe(true);
+      expect(Number.isFinite(box.position.y)).toBe(true);
+    }
+  });
+});
+
+// -------------------------------------------------------------------------
+// 2. Warm-start impulse persistence (resting contact)
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — warm-start persistence", () => {
+  it("resting box settles to a stable y position", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(0, 1, 1, 1, 0);
+    floor.space = space;
+
+    const box = dynamicBox(0, 200, 40, 40);
+    box.shapes.at(0).material = new Material(0, 1, 1, 1, 0);
+    box.space = space;
+
+    // Settle
+    for (let i = 0; i < 120; i++) space.step(1 / 60, 10, 10);
+    const y1 = box.position.y;
+
+    // Run more — position should be virtually unchanged (warm-start = small drift)
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+    const y2 = box.position.y;
+
+    expect(Math.abs(y2 - y1)).toBeLessThan(2);
+  });
+
+  it("rapid micro-displacements stay near settled position", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(0, 1, 1, 1, 0);
+    floor.space = space;
+
+    const box = dynamicBox(0, 200, 40, 40);
+    box.shapes.at(0).material = new Material(0, 1, 1, 1, 0);
+    box.space = space;
+
+    // Settle
+    for (let i = 0; i < 300; i++) space.step(1 / 60, 10, 10);
+    const ySettled = box.position.y;
+
+    // Drift over the next 5 seconds should be tiny
+    for (let i = 0; i < 300; i++) space.step(1 / 60, 10, 10);
+    expect(Math.abs(box.position.y - ySettled)).toBeLessThan(2);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 3. 2-contact polygon-polygon solver paths
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — 2-contact polygon solver", () => {
+  it("box on floor produces 2 contact points and stays level", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.space = space;
+
+    const box = dynamicBox(0, 200, 60, 60);
+    box.space = space;
+
+    let twoPointSeen = false;
+    const listener = new InteractionListener(
+      CbEvent.ONGOING,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      (cb: any) => {
+        const arbiters = cb.arbiters;
+        for (let i = 0; i < arbiters.length; i++) {
+          const arb = arbiters.at(i);
+          if (arb.isCollisionArbiter()) {
+            const contacts = arb.collisionArbiter.contacts;
+            let count = 0;
+            for (const _c of contacts) count++;
+            if (count >= 2) twoPointSeen = true;
+          }
+        }
+      },
+    );
+    listener.space = space;
+
+    for (let i = 0; i < 90; i++) space.step(1 / 60, 10, 10);
+
+    expect(twoPointSeen).toBe(true);
+
+    // Box should not have rotated significantly when settled flat
+    expect(Math.abs(box.angularVel)).toBeLessThan(2);
+  });
+
+  it("box-on-box stack stabilises with 2-contact arbiters", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(0, 1, 1, 1, 0);
+    floor.space = space;
+
+    const lower = dynamicBox(0, 240, 50, 30);
+    lower.shapes.at(0).material = new Material(0, 1, 1, 1, 0);
+    lower.space = space;
+
+    const upper = dynamicBox(0, 180, 50, 30);
+    upper.shapes.at(0).material = new Material(0, 1, 1, 1, 0);
+    upper.space = space;
+
+    for (let i = 0; i < 240; i++) space.step(1 / 60, 10, 10);
+
+    // Both boxes should be stationary above the floor
+    expect(Math.abs(lower.velocity.y)).toBeLessThan(20);
+    expect(Math.abs(upper.velocity.y)).toBeLessThan(20);
+    // Upper should be on top of lower
+    expect(upper.position.y).toBeLessThan(lower.position.y);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 4. Position correction (Baumgarte) on deep penetration
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — position correction", () => {
+  it("pushes apart deeply overlapping boxes", () => {
+    const space = new Space(new Vec2(0, 0));
+    const a = dynamicBox(0, 0, 40, 40);
+    a.space = space;
+    const b = dynamicBox(10, 0, 40, 40); // huge overlap (30 units)
+    b.space = space;
+
+    for (let i = 0; i < 120; i++) space.step(1 / 60, 10, 10);
+
+    const dx = Math.abs(b.position.x - a.position.x);
+    // Should have separated to at least the box width
+    expect(dx).toBeGreaterThanOrEqual(30);
+  });
+
+  it("circle-circle deep overlap separates", () => {
+    const space = new Space(new Vec2(0, 0));
+    const c1 = dynamicCircle(0, 0, 25);
+    c1.space = space;
+    const c2 = dynamicCircle(15, 0, 25); // 35 of 50 overlap
+    c2.space = space;
+
+    for (let i = 0; i < 120; i++) space.step(1 / 60, 10, 10);
+
+    const dx = c2.position.x - c1.position.x;
+    const dy = c2.position.y - c1.position.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    expect(dist).toBeGreaterThanOrEqual(48);
+  });
+
+  it("box pushed into static wall stays outside the wall", () => {
+    const space = new Space(new Vec2(0, 0));
+    const wall = new Body(BodyType.STATIC, new Vec2(100, 0));
+    wall.shapes.add(new Polygon(Polygon.box(20, 400)));
+    wall.space = space;
+
+    const box = dynamicBox(50, 0, 30, 30);
+    box.velocity = new Vec2(500, 0);
+    box.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+
+    // Box's right edge should be at most at wall's left edge (90)
+    expect(box.position.x).toBeLessThanOrEqual(76);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 5. Friction transition (static → dynamic)
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — friction transition", () => {
+  it("dynamic friction slows a sliding box on rough floor", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(0, 0.8, 0.8, 1, 0);
+    floor.space = space;
+
+    const box = dynamicBox(0, 200, 30, 30);
+    box.shapes.at(0).material = new Material(0, 0.8, 0.8, 1, 0);
+    box.velocity = new Vec2(300, 0);
+    box.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+    const v1 = Math.abs(box.velocity.x);
+
+    for (let i = 0; i < 120; i++) space.step(1 / 60, 10, 10);
+    const v2 = Math.abs(box.velocity.x);
+
+    expect(v2).toBeLessThan(v1);
+  });
+
+  it("zero friction allows perpetual sliding (no horizontal slowdown beyond air)", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(0, 0, 0, 1, 0);
+    floor.space = space;
+
+    const box = dynamicBox(0, 200, 30, 30);
+    box.shapes.at(0).material = new Material(0, 0, 0, 1, 0);
+    box.velocity = new Vec2(200, 0);
+    box.space = space;
+
+    // Settle
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+    const v1 = box.velocity.x;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+    const v2 = box.velocity.x;
+
+    // No friction → x velocity preserved (small numerical drift OK)
+    expect(Math.abs(v2 - v1)).toBeLessThan(10);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 6. Restitution velocity threshold
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — restitution threshold", () => {
+  it("low approach velocity does not bounce (below threshold)", () => {
+    const space = new Space(new Vec2(0, 50)); // weak gravity
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(1, 0, 0, 1, 0);
+    floor.space = space;
+
+    const ball = dynamicCircle(0, 285, 10);
+    ball.shapes.at(0).material = new Material(1, 0, 0, 1, 0);
+    // Slow approach
+    ball.velocity = new Vec2(0, 1);
+    ball.space = space;
+
+    for (let i = 0; i < 240; i++) space.step(1 / 60, 10, 10);
+
+    // Should be at rest, not bouncing
+    expect(Math.abs(ball.velocity.y)).toBeLessThan(10);
+  });
+
+  it("high approach velocity bounces with elasticity 1", () => {
+    const space = new Space(new Vec2(0, 0));
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(1, 0, 0, 1, 0);
+    floor.space = space;
+
+    const ball = dynamicCircle(0, 100, 10);
+    ball.shapes.at(0).material = new Material(1, 0, 0, 1, 0);
+    ball.velocity = new Vec2(0, 800);
+    ball.space = space;
+
+    let maxUpwardSpeed = 0;
+    for (let i = 0; i < 60; i++) {
+      space.step(1 / 60, 10, 10);
+      if (ball.velocity.y < 0 && Math.abs(ball.velocity.y) > maxUpwardSpeed) {
+        maxUpwardSpeed = Math.abs(ball.velocity.y);
+      }
+    }
+
+    // Should have rebounded upward
+    expect(maxUpwardSpeed).toBeGreaterThan(400);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 7. Long-run contact persistence (no contact loss across 600 steps)
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — long-run persistence", () => {
+  it("stack of 3 boxes stays together for 10 seconds", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(0.1, 1, 1, 1, 0);
+    floor.space = space;
+
+    const stack: Body[] = [];
+    for (let i = 0; i < 3; i++) {
+      const b = dynamicBox(0, 280 - i * 32, 40, 30);
+      b.shapes.at(0).material = new Material(0.1, 1, 1, 1, 0);
+      b.space = space;
+      stack.push(b);
+    }
+
+    for (let i = 0; i < 600; i++) space.step(1 / 60, 10, 10);
+
+    // None should have fallen below the floor; positions remain finite
+    for (const b of stack) {
+      expect(b.position.y).toBeLessThan(310);
+      expect(Number.isFinite(b.position.x)).toBe(true);
+      expect(Number.isFinite(b.position.y)).toBe(true);
+    }
+    // Stack still ordered (bottom > middle > top in y)
+    expect(stack[0].position.y).toBeGreaterThan(stack[1].position.y);
+    expect(stack[1].position.y).toBeGreaterThan(stack[2].position.y);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 8. Sleeping → wake → re-collide cycle
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — sleep/wake cycle", () => {
+  it("body sleeps when settled, wakes when nudged", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(0.1, 1, 1, 1, 0);
+    floor.space = space;
+
+    const box = dynamicBox(0, 200, 30, 30);
+    box.shapes.at(0).material = new Material(0.1, 1, 1, 1, 0);
+    box.space = space;
+
+    // Settle and sleep
+    for (let i = 0; i < 600; i++) space.step(1 / 60, 10, 10);
+    expect(box.isSleeping).toBe(true);
+
+    // Wake by setting velocity
+    box.velocity = new Vec2(50, -100);
+    expect(box.isSleeping).toBe(false);
+
+    // Bounces, then re-settles
+    for (let i = 0; i < 600; i++) space.step(1 / 60, 10, 10);
+    expect(box.position.y).toBeLessThan(310);
+    expect(Number.isFinite(box.velocity.x)).toBe(true);
+  });
+
+  it("removing then re-adding body reuses arbiter pool", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.space = space;
+
+    for (let cycle = 0; cycle < 4; cycle++) {
+      const box = dynamicBox(0, 200, 30, 30);
+      box.space = space;
+
+      for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+      expect(arbiterCount(space)).toBeGreaterThan(0);
+
+      box.space = null;
+      for (let i = 0; i < 5; i++) space.step(1 / 60, 10, 10);
+      expect(arbiterCount(space)).toBe(0);
+    }
+  });
+});
+
+// -------------------------------------------------------------------------
+// 9. Asymmetric mass — heavy body on light body
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — mass asymmetry", () => {
+  it("heavy box on light box does not crush through it", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticFloor();
+    floor.shapes.at(0).material = new Material(0.1, 1, 1, 1, 0);
+    floor.space = space;
+
+    const light = dynamicBox(0, 250, 40, 30);
+    light.shapes.at(0).material = new Material(0.1, 1, 0.1, 1, 0);
+    light.space = space;
+
+    const heavy = dynamicBox(0, 180, 40, 30);
+    heavy.shapes.at(0).material = new Material(0.1, 1, 10, 1, 0);
+    heavy.space = space;
+
+    for (let i = 0; i < 240; i++) space.step(1 / 60, 10, 10);
+
+    // Heavy should still be above light
+    expect(heavy.position.y).toBeLessThan(light.position.y + 5);
+    // Light should not have shot through floor
+    expect(light.position.y).toBeLessThan(310);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 10. Continuous push from kinematic
+// -------------------------------------------------------------------------
+
+describe("ZPP_ColArbiter — kinematic push", () => {
+  it("kinematic platform sliding under dynamic transfers x velocity", () => {
+    const space = new Space(new Vec2(0, 500));
+
+    const platform = new Body(BodyType.KINEMATIC, new Vec2(0, 300));
+    platform.shapes.add(new Polygon(Polygon.box(400, 20)));
+    platform.shapes.at(0).material = new Material(0, 1, 1, 1, 0);
+    platform.velocity = new Vec2(80, 0);
+    platform.space = space;
+
+    const box = dynamicBox(0, 200, 30, 30);
+    box.shapes.at(0).material = new Material(0, 1, 1, 1, 0);
+    box.space = space;
+
+    for (let i = 0; i < 240; i++) space.step(1 / 60, 10, 10);
+
+    // Box should have acquired some x velocity from the conveyor
+    expect(Math.abs(box.velocity.x)).toBeGreaterThan(5);
+  });
+});

--- a/packages/nape-js/tests/native/dynamics/ZPP_FluidArbiter.preStep.test.ts
+++ b/packages/nape-js/tests/native/dynamics/ZPP_FluidArbiter.preStep.test.ts
@@ -1,0 +1,434 @@
+/**
+ * ZPP_FluidArbiter — preStep solver branches.
+ *
+ * Targets uncovered branches in the fluid solver:
+ * - Buoyancy: fluid-fluid (mass1 > mass2, mass1 < mass2, mass1 == mass2 paths)
+ * - Custom per-fluid gravity vs space gravity
+ * - Polygon edge iteration (drag accumulates over edges)
+ * - Circle drag path
+ * - Zero viscosity → nodrag flag
+ * - Mixed viscosity (one shape with viscosity, the other without)
+ * - Angular damping (polygon vs circle)
+ * - Buoyancy magnitude correlates with overlap (deeper → stronger lift)
+ */
+
+import { describe, it, expect } from "vitest";
+import { Space } from "../../../src/space/Space";
+import { Body } from "../../../src/phys/Body";
+import { BodyType } from "../../../src/phys/BodyType";
+import { Vec2 } from "../../../src/geom/Vec2";
+import { Circle } from "../../../src/shape/Circle";
+import { Polygon } from "../../../src/shape/Polygon";
+import { FluidProperties } from "../../../src/phys/FluidProperties";
+import "../../../src/dynamics/Contact";
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+function makeFluidPool(
+  density = 2.0,
+  viscosity = 0.5,
+  customGravity?: Vec2,
+  w = 4000,
+  h = 2000,
+): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(0, 0));
+  const s = new Polygon(Polygon.box(w, h));
+  s.fluidEnabled = true;
+  const fp = new FluidProperties(density, viscosity);
+  if (customGravity) {
+    fp.gravity = customGravity;
+  }
+  s.fluidProperties = fp;
+  b.shapes.add(s);
+  return b;
+}
+
+function dynamicCircle(x: number, y: number, r = 20): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(r));
+  return b;
+}
+
+function dynamicBox(x: number, y: number, w = 30, h = 30): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Polygon(Polygon.box(w, h)));
+  return b;
+}
+
+function makeFluidCircle(x: number, y: number, r: number, density: number, viscosity = 0): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  const s = new Circle(r);
+  s.fluidEnabled = true;
+  s.fluidProperties = new FluidProperties(density, viscosity);
+  b.shapes.add(s);
+  return b;
+}
+
+// -------------------------------------------------------------------------
+// 1. Buoyancy — light body floats up against gravity
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — buoyancy basic", () => {
+  it("low-density object rises against gravity in dense fluid", () => {
+    const space = new Space(new Vec2(0, 200));
+    const fluid = makeFluidPool(5.0, 0); // dense, no viscosity
+    fluid.space = space;
+
+    // Box of low density (default 1.0 < fluid density 5)
+    const buoyant = dynamicBox(0, 100, 30, 30);
+    buoyant.space = space;
+
+    // Track velocity for several steps
+    let movedUp = false;
+    for (let i = 0; i < 60; i++) {
+      space.step(1 / 60, 10, 10);
+      if (buoyant.velocity.y < 0) {
+        movedUp = true;
+        break;
+      }
+    }
+    expect(movedUp).toBe(true);
+  });
+
+  it("high-density object sinks in less-dense fluid", () => {
+    const space = new Space(new Vec2(0, 200));
+    const fluid = makeFluidPool(0.5, 0); // sparse fluid
+    fluid.space = space;
+
+    const sinker = dynamicBox(0, 100, 30, 30);
+    sinker.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+    expect(sinker.velocity.y).toBeGreaterThan(0);
+    expect(sinker.position.y).toBeGreaterThan(100);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 2. Fluid-fluid: density mismatch (mass1 > mass2 path)
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — fluid-fluid density mismatch", () => {
+  it("dense fluid object pushes light fluid object out", () => {
+    const space = new Space(new Vec2(0, 200));
+
+    // Heavy fluid blob
+    const heavy = makeFluidCircle(0, 50, 30, 10, 0.1);
+    heavy.space = space;
+
+    // Light fluid blob, overlapping heavy
+    const light = makeFluidCircle(20, 50, 30, 0.5, 0.1);
+    light.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60, 10, 10);
+
+    // The two should have different vertical velocities (one up, one down or apart)
+    expect(Number.isFinite(heavy.position.x)).toBe(true);
+    expect(Number.isFinite(light.position.x)).toBe(true);
+  });
+
+  it("equal-density fluid bodies use COM-based buoyancy decision", () => {
+    const space = new Space(new Vec2(0, 200));
+
+    // Two identical density fluid blobs
+    const a = makeFluidCircle(0, 50, 30, 2.0, 0.1);
+    a.space = space;
+    const b = makeFluidCircle(20, 100, 30, 2.0, 0.1);
+    b.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60, 10, 10);
+
+    // Whichever has the lower COM (relative to gravity direction) gets pushed up
+    expect(Number.isFinite(a.position.y)).toBe(true);
+    expect(Number.isFinite(b.position.y)).toBe(true);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 3. Custom per-fluid gravity overrides space gravity
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — custom fluid gravity", () => {
+  it("fluid with leftward gravity drags object left", () => {
+    const space = new Space(new Vec2(0, 0));
+
+    // Fluid with horizontal gravity (left)
+    const fluid = makeFluidPool(3.0, 0, new Vec2(-200, 0));
+    fluid.space = space;
+
+    const obj = dynamicBox(0, 0, 30, 30); // density 1 < fluid 3 → buoyant
+    obj.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+
+    // Custom gravity is leftward → buoyancy pushes object rightward
+    expect(obj.velocity.x).toBeGreaterThan(0);
+  });
+
+  it("custom gravity is independent of space gravity direction", () => {
+    const space = new Space(new Vec2(0, 500)); // strong downward space gravity
+    const fluid = makeFluidPool(3.0, 0, new Vec2(0, -100)); // upward fluid gravity
+    fluid.space = space;
+
+    const obj = dynamicBox(0, 0, 30, 30);
+    obj.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60, 10, 10);
+
+    // Both fluid buoyancy (downward, since fluid g is up so buoyancy is down)
+    // and space gravity push the object down — net downward
+    expect(obj.position.y).toBeGreaterThan(0);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 4. Polygon edge iteration — drag accumulates per edge
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — polygon drag", () => {
+  it("polygon submerged with viscosity slows down moving body", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluid = makeFluidPool(0.5, 5.0); // light but high viscosity
+    fluid.space = space;
+
+    const moving = dynamicBox(0, 0, 40, 40);
+    moving.velocity = new Vec2(200, 0);
+    moving.space = space;
+
+    const v0 = Math.abs(moving.velocity.x);
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+    const v1 = Math.abs(moving.velocity.x);
+
+    expect(v1).toBeLessThan(v0);
+  });
+
+  it("higher viscosity stops body faster than low viscosity", () => {
+    const space1 = new Space(new Vec2(0, 0));
+    const fluid1 = makeFluidPool(0.5, 1.0);
+    fluid1.space = space1;
+    const m1 = dynamicBox(0, 0, 40, 40);
+    m1.velocity = new Vec2(200, 0);
+    m1.space = space1;
+
+    const space2 = new Space(new Vec2(0, 0));
+    const fluid2 = makeFluidPool(0.5, 20.0);
+    fluid2.space = space2;
+    const m2 = dynamicBox(0, 0, 40, 40);
+    m2.velocity = new Vec2(200, 0);
+    m2.space = space2;
+
+    for (let i = 0; i < 60; i++) {
+      space1.step(1 / 60, 10, 10);
+      space2.step(1 / 60, 10, 10);
+    }
+
+    expect(Math.abs(m2.velocity.x)).toBeLessThan(Math.abs(m1.velocity.x));
+  });
+});
+
+// -------------------------------------------------------------------------
+// 5. Circle drag path
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — circle drag", () => {
+  it("circle submerged with viscosity slows down", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluid = makeFluidPool(0.5, 5.0);
+    fluid.space = space;
+
+    const ball = dynamicCircle(0, 0, 25);
+    ball.velocity = new Vec2(200, 0);
+    ball.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+    expect(Math.abs(ball.velocity.x)).toBeLessThan(200);
+  });
+
+  it("circle drag is symmetric (no net rotation from translation)", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluid = makeFluidPool(0.5, 3.0);
+    fluid.space = space;
+
+    const ball = dynamicCircle(0, 0, 25);
+    ball.velocity = new Vec2(150, 0);
+    ball.space = space;
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+
+    // Translating circle in fluid should not pick up significant angular velocity
+    expect(Math.abs(ball.angularVel)).toBeLessThan(0.5);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 6. Zero viscosity → nodrag path
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — nodrag", () => {
+  it("zero viscosity preserves x velocity (only buoyancy effect)", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluid = makeFluidPool(2.0, 0); // viscosity = 0
+    fluid.space = space;
+
+    const obj = dynamicBox(0, 0, 30, 30);
+    obj.velocity = new Vec2(150, 0);
+    obj.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60, 10, 10);
+
+    // No drag → x-velocity unchanged
+    expect(obj.velocity.x).toBeCloseTo(150, -1); // within ±10
+  });
+
+  it("zero viscosity does not produce angular damping", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluid = makeFluidPool(2.0, 0);
+    fluid.space = space;
+
+    const spinner = dynamicBox(0, 0, 30, 30);
+    spinner.angularVel = 5;
+    spinner.space = space;
+
+    const w0 = spinner.angularVel;
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+
+    // No viscosity → angular velocity preserved
+    expect(spinner.angularVel).toBeCloseTo(w0, -1);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 7. Angular damping (with viscosity)
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — angular damping", () => {
+  it("polygon spinning in viscous fluid slows angular velocity", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluid = makeFluidPool(0.5, 8.0);
+    fluid.space = space;
+
+    const spinner = dynamicBox(0, 0, 60, 30);
+    spinner.angularVel = 8;
+    spinner.space = space;
+
+    const w0 = Math.abs(spinner.angularVel);
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 10, 10);
+    const w1 = Math.abs(spinner.angularVel);
+
+    expect(w1).toBeLessThan(w0);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 8. Mixed viscosity (one shape viscous, the other not)
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — mixed viscosity", () => {
+  it("fluid with viscosity > 0 and a non-fluid body still produces drag", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluid = makeFluidPool(1.5, 4.0);
+    fluid.space = space;
+
+    const obj = dynamicCircle(0, 0, 20);
+    obj.velocity = new Vec2(200, 0);
+    obj.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60, 10, 10);
+    expect(Math.abs(obj.velocity.x)).toBeLessThan(200);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 9. Buoyancy magnitude — bigger overlap → stronger force
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — density ratio determines acceleration", () => {
+  it("higher fluid density → stronger upward acceleration on identical body", () => {
+    const space1 = new Space(new Vec2(0, 200));
+    const denseFluid = makeFluidPool(10.0, 0);
+    denseFluid.space = space1;
+    const inDense = dynamicBox(0, 0, 30, 30);
+    inDense.space = space1;
+
+    const space2 = new Space(new Vec2(0, 200));
+    const sparseFluid = makeFluidPool(2.0, 0);
+    sparseFluid.space = space2;
+    const inSparse = dynamicBox(0, 0, 30, 30);
+    inSparse.space = space2;
+
+    for (let i = 0; i < 30; i++) {
+      space1.step(1 / 60, 10, 10);
+      space2.step(1 / 60, 10, 10);
+    }
+
+    // Denser fluid → object accelerates upward more strongly (more negative velocity.y)
+    expect(inDense.velocity.y).toBeLessThan(inSparse.velocity.y);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 10. Variable dt across steps (warm-start in fluid)
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — variable dt", () => {
+  it("changing dt across steps produces finite results", () => {
+    const space = new Space(new Vec2(0, 200));
+    const fluid = makeFluidPool(2.0, 3.0);
+    fluid.space = space;
+
+    const obj = dynamicBox(0, 0, 30, 30);
+    obj.velocity = new Vec2(100, 0);
+    obj.space = space;
+
+    space.step(1 / 60, 10, 10);
+    space.step(1 / 30, 10, 10);
+    space.step(1 / 120, 10, 10);
+    space.step(1 / 90, 10, 10);
+
+    expect(Number.isFinite(obj.position.x)).toBe(true);
+    expect(Number.isFinite(obj.position.y)).toBe(true);
+    expect(Number.isFinite(obj.velocity.x)).toBe(true);
+    expect(Number.isFinite(obj.velocity.y)).toBe(true);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 11. Surface velocity in fluid
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — surface velocity / kinematic flow", () => {
+  it("fluid body with surface velocity does not crash", () => {
+    const space = new Space(new Vec2(0, 0));
+    const fluid = makeFluidPool(1.5, 2.0);
+    fluid.surfaceVel = new Vec2(50, 0);
+    fluid.space = space;
+
+    const obj = dynamicBox(0, 0, 30, 30);
+    obj.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60, 10, 10);
+    expect(Number.isFinite(obj.position.x)).toBe(true);
+  });
+});
+
+// -------------------------------------------------------------------------
+// 12. Sleeping body in fluid
+// -------------------------------------------------------------------------
+
+describe("ZPP_FluidArbiter — sleeping body", () => {
+  it("a body floating at neutral buoyancy may sleep without crash", () => {
+    const space = new Space(new Vec2(0, 100));
+    // Density matched to obj (default 1.0)
+    const fluid = makeFluidPool(1.0, 0.5);
+    fluid.space = space;
+
+    const obj = dynamicBox(0, 0, 30, 30);
+    obj.space = space;
+
+    for (let i = 0; i < 600; i++) space.step(1 / 60, 10, 10);
+
+    expect(Number.isFinite(obj.position.y)).toBe(true);
+  });
+});

--- a/packages/nape-js/tests/native/space/ZPP_AABBTree.balance.test.ts
+++ b/packages/nape-js/tests/native/space/ZPP_AABBTree.balance.test.ts
@@ -1,0 +1,409 @@
+/**
+ * ZPP_AABBTree — balance / restructure / removal-with-rebalance tests.
+ *
+ * Targets uncovered branches around lines 990–1186:
+ * - Both directions of `balance()` rotation (balance > 1 / balance < -1)
+ * - Both branches inside each rotation (f.height vs g.height comparisons)
+ * - Removing a node from the deeper child path (sibling promotion + rebalance)
+ * - Sequential operations that force ripple-up height recompute
+ * - Many-body integration that exercises the tree across moves
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import "../../../src/core/engine";
+import { Space } from "../../../src/space/Space";
+import { Body } from "../../../src/phys/Body";
+import { BodyType } from "../../../src/phys/BodyType";
+import { Vec2 } from "../../../src/geom/Vec2";
+import { AABB } from "../../../src/geom/AABB";
+import { Circle } from "../../../src/shape/Circle";
+import { Polygon } from "../../../src/shape/Polygon";
+import { Ray } from "../../../src/geom/Ray";
+import { Broadphase } from "../../../src/space/Broadphase";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function dynCircle(x: number, y: number, r = 5): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(r));
+  return b;
+}
+
+function statCircle(x: number, y: number, r = 5): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(x, y));
+  b.shapes.add(new Circle(r));
+  return b;
+}
+
+function step(space: Space, n = 1): void {
+  for (let i = 0; i < n; i++) space.step(1 / 60);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Right-leaning insertion forces balance > 1 (rotate left)
+// ---------------------------------------------------------------------------
+
+describe("ZPP_AABBTree — left rotation (balance > 1)", () => {
+  let space: Space;
+  beforeEach(() => {
+    space = new Space(new Vec2(0, 0), Broadphase.DYNAMIC_AABB_TREE);
+  });
+
+  it("inserting in increasing-x order produces a balanced tree", () => {
+    // Insert many bodies along x axis — naive insertion would be left-deep.
+    const bodies: Body[] = [];
+    for (let i = 0; i < 64; i++) {
+      const b = dynCircle(i * 50, 0, 5);
+      b.space = space;
+      bodies.push(b);
+    }
+    step(space, 1);
+
+    // Tree must still serve correct point queries
+    for (let i = 0; i < 64; i++) {
+      const shapes = space.shapesUnderPoint(new Vec2(i * 50, 0));
+      expect(shapes.length).toBe(1);
+    }
+  });
+
+  it("inserting in decreasing-x order also produces balanced queries", () => {
+    for (let i = 63; i >= 0; i--) {
+      dynCircle(i * 50, 0, 5).space = space;
+    }
+    step(space, 1);
+
+    for (let i = 0; i < 64; i++) {
+      const shapes = space.shapesUnderPoint(new Vec2(i * 50, 0));
+      expect(shapes.length).toBe(1);
+    }
+  });
+
+  it("alternating insertion patterns on a 2D grid stay queryable", () => {
+    const xs = [0, 200, 100, 300, 50, 250, 150, 350, 75, 275];
+    const ys = [0, 100, 50, 150, 25, 125, 75, 175, 200, 250];
+    for (const x of xs) {
+      for (const y of ys) {
+        dynCircle(x, y, 4).space = space;
+      }
+    }
+    step(space, 1);
+
+    for (const x of xs) {
+      for (const y of ys) {
+        const shapes = space.shapesUnderPoint(new Vec2(x, y));
+        expect(shapes.length).toBe(1);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Removal from various tree positions (deep, leaf, root sibling)
+// ---------------------------------------------------------------------------
+
+describe("ZPP_AABBTree — removal triggers rebalance", () => {
+  let space: Space;
+  beforeEach(() => {
+    space = new Space(new Vec2(0, 0), Broadphase.DYNAMIC_AABB_TREE);
+  });
+
+  it("removing nodes from the middle of a tree keeps queries correct", () => {
+    const bodies: Body[] = [];
+    for (let i = 0; i < 32; i++) {
+      const b = dynCircle(i * 30, 0, 4);
+      b.space = space;
+      bodies.push(b);
+    }
+    step(space, 1);
+
+    // Remove every other body in reverse — exercises various rebalance paths
+    for (let i = 30; i >= 0; i -= 2) {
+      bodies[i].space = null;
+    }
+    step(space, 1);
+
+    // Remaining odd-indexed bodies must still be queryable
+    for (let i = 1; i < 32; i += 2) {
+      const shapes = space.shapesUnderPoint(new Vec2(i * 30, 0));
+      expect(shapes.length).toBe(1);
+    }
+    // Removed even-indexed must NOT be found
+    for (let i = 0; i < 32; i += 2) {
+      const shapes = space.shapesUnderPoint(new Vec2(i * 30, 0));
+      expect(shapes.length).toBe(0);
+    }
+  });
+
+  it("repeated insertion+removal of one body amid many others stays consistent", () => {
+    for (let i = 0; i < 30; i++) dynCircle(i * 25, 0, 4).space = space;
+    step(space, 1);
+
+    const probe = dynCircle(500, 500, 4);
+    for (let cycle = 0; cycle < 20; cycle++) {
+      probe.space = space;
+      step(space, 1);
+      expect(space.shapesUnderPoint(new Vec2(500, 500)).length).toBe(1);
+      probe.space = null;
+      step(space, 1);
+      expect(space.shapesUnderPoint(new Vec2(500, 500)).length).toBe(0);
+    }
+  });
+
+  it("removing root child triggers sibling promotion path", () => {
+    const a = dynCircle(0, 0, 5);
+    a.space = space;
+    const b = dynCircle(100, 0, 5);
+    b.space = space;
+    step(space, 1);
+
+    // Remove `a` — sibling `b` becomes root
+    a.space = null;
+    step(space, 1);
+
+    expect(space.bodies.length).toBe(1);
+    expect(space.shapesUnderPoint(new Vec2(100, 0)).length).toBe(1);
+    expect(space.shapesUnderPoint(new Vec2(0, 0)).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Movement over time — each step refits AABBs and may trigger rebalance
+// ---------------------------------------------------------------------------
+
+describe("ZPP_AABBTree — movement-driven rebalance", () => {
+  let space: Space;
+  beforeEach(() => {
+    space = new Space(new Vec2(0, 0), Broadphase.DYNAMIC_AABB_TREE);
+  });
+
+  it("bodies streaming across the world keep correct broadphase", () => {
+    const bodies: Body[] = [];
+    for (let i = 0; i < 30; i++) {
+      const b = dynCircle(-1000 + i * 10, 0, 4);
+      b.velocity = new Vec2(50 + i * 2, 0);
+      b.space = space;
+      bodies.push(b);
+    }
+    // Many steps move bodies through the world — tree must keep up
+    step(space, 60);
+
+    // Each body should find itself by point query
+    for (const b of bodies) {
+      const shapes = space.shapesUnderPoint(new Vec2(b.position.x, b.position.y));
+      expect(shapes.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("teleporting many bodies simultaneously rebalances correctly", () => {
+    const bodies: Body[] = [];
+    for (let i = 0; i < 32; i++) {
+      const b = dynCircle(i * 20, 0, 4);
+      b.space = space;
+      bodies.push(b);
+    }
+    step(space, 1);
+
+    // Teleport all to a far line, well-spaced so radii don't overlap
+    for (let i = 0; i < bodies.length; i++) {
+      bodies[i].position = new Vec2(10000 + i * 50, 10000);
+    }
+    step(space, 1);
+
+    // Old positions: empty. Each new position: exactly one body found.
+    expect(space.shapesUnderPoint(new Vec2(0, 0)).length).toBe(0);
+    for (let i = 0; i < bodies.length; i++) {
+      const found = space.shapesUnderPoint(new Vec2(10000 + i * 50, 10000));
+      expect(found.length).toBe(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Mixed shapes and rotations — extreme AABB churn
+// ---------------------------------------------------------------------------
+
+describe("ZPP_AABBTree — heterogeneous + rotating churn", () => {
+  let space: Space;
+  beforeEach(() => {
+    space = new Space(new Vec2(0, 0), Broadphase.DYNAMIC_AABB_TREE);
+  });
+
+  it("rotating thin polygons triggers many AABB updates", () => {
+    const bodies: Body[] = [];
+    for (let i = 0; i < 16; i++) {
+      const b = new Body(BodyType.DYNAMIC, new Vec2(i * 50, 0));
+      b.shapes.add(new Polygon(Polygon.box(5, 100)));
+      b.angularVel = 1 + i * 0.3;
+      b.space = space;
+      bodies.push(b);
+    }
+
+    step(space, 60);
+
+    for (const b of bodies) {
+      // Rotation must not have torn the body off the tree
+      expect(Number.isFinite(b.position.x)).toBe(true);
+    }
+    // Total bodies preserved
+    expect(space.bodies.length).toBe(16);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Ray + AABB queries on a rebalanced tree
+// ---------------------------------------------------------------------------
+
+describe("ZPP_AABBTree — ray and AABB queries after rebalance", () => {
+  let space: Space;
+  beforeEach(() => {
+    space = new Space(new Vec2(0, 0), Broadphase.DYNAMIC_AABB_TREE);
+  });
+
+  it("rayMultiCast hits all collinear bodies after heavy churn", () => {
+    // Heavy churn first
+    const trash: Body[] = [];
+    for (let i = 0; i < 50; i++) {
+      const b = dynCircle(Math.random() * 1000, Math.random() * 1000, 4);
+      b.space = space;
+      trash.push(b);
+    }
+    step(space, 1);
+    for (const b of trash) b.space = null;
+    step(space, 1);
+
+    // Now place 5 collinear targets
+    const targets: Body[] = [];
+    for (let i = 0; i < 5; i++) {
+      const b = dynCircle(i * 40, 0, 8);
+      b.space = space;
+      targets.push(b);
+    }
+    step(space, 1);
+
+    const ray = new Ray(new Vec2(-50, 0), new Vec2(1, 0));
+    ray.maxDistance = 500;
+    const hits = space.rayMultiCast(ray);
+    expect(hits.length).toBe(5);
+  });
+
+  it("shapesInAABB returns correct subset after many removes", () => {
+    const grid: Body[] = [];
+    for (let x = 0; x <= 200; x += 50) {
+      for (let y = 0; y <= 200; y += 50) {
+        const b = dynCircle(x, y, 5);
+        b.space = space;
+        grid.push(b);
+      }
+    }
+    const initialCount = grid.length;
+    step(space, 1);
+
+    // Remove the lower-left quadrant (strictly < 75)
+    let removedCount = 0;
+    for (const b of grid) {
+      if (b.position.x < 75 && b.position.y < 75) {
+        b.space = null;
+        removedCount++;
+      }
+    }
+    step(space, 1);
+
+    // Tight query inside the removed area returns nothing
+    let shapes = space.shapesInAABB(new AABB(20, 20, 30, 30));
+    expect(shapes.length).toBe(0);
+
+    // Tight query inside a kept area returns the body there
+    shapes = space.shapesInAABB(new AABB(95, 95, 10, 10));
+    expect(shapes.length).toBeGreaterThan(0);
+
+    // Total live count consistent
+    expect(space.bodies.length).toBe(initialCount - removedCount);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Very deep tree (extreme adversarial pattern)
+// ---------------------------------------------------------------------------
+
+describe("ZPP_AABBTree — extreme insertion patterns", () => {
+  let space: Space;
+  beforeEach(() => {
+    space = new Space(new Vec2(0, 0), Broadphase.DYNAMIC_AABB_TREE);
+  });
+
+  it("100 separated bodies each return exactly one shape under their own point", () => {
+    const bodies: Body[] = [];
+    for (let i = 0; i < 100; i++) {
+      const b = dynCircle(i * 30, 0, 4);
+      b.space = space;
+      bodies.push(b);
+    }
+    step(space, 1);
+
+    for (let i = 0; i < 100; i++) {
+      const shapes = space.shapesUnderPoint(new Vec2(i * 30, 0));
+      expect(shapes.length).toBe(1);
+    }
+  });
+
+  it("insertion + half-removal + insertion sequence stays consistent", () => {
+    const first: Body[] = [];
+    for (let i = 0; i < 40; i++) {
+      const b = dynCircle(i * 30, 0, 5);
+      b.space = space;
+      first.push(b);
+    }
+    step(space, 1);
+
+    // Remove every 3rd (creates fragmented tree)
+    for (let i = 0; i < first.length; i += 3) first[i].space = null;
+    step(space, 1);
+
+    // Add new bodies in the gaps
+    for (let i = 0; i < first.length; i += 3) {
+      dynCircle(i * 30, 100, 5).space = space;
+    }
+    step(space, 1);
+
+    // Query the new bodies' positions
+    let found = 0;
+    for (let i = 0; i < first.length; i += 3) {
+      if (space.shapesUnderPoint(new Vec2(i * 30, 100)).length > 0) found++;
+    }
+    expect(found).toBe(Math.ceil(first.length / 3));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Static + dynamic mix — separate sub-trees may be in play
+// ---------------------------------------------------------------------------
+
+describe("ZPP_AABBTree — static + dynamic interplay", () => {
+  let space: Space;
+  beforeEach(() => {
+    space = new Space(new Vec2(0, 0), Broadphase.DYNAMIC_AABB_TREE);
+  });
+
+  it("static obstacle wall + many dynamics produces correct collisions", () => {
+    // Static wall (left side)
+    for (let y = 0; y < 200; y += 10) {
+      statCircle(0, y, 5).space = space;
+    }
+    // Many dynamics flying left-to-right
+    const dyns: Body[] = [];
+    for (let i = 0; i < 20; i++) {
+      const b = dynCircle(100 + i * 5, i * 10, 4);
+      b.velocity = new Vec2(-200, 0);
+      b.space = space;
+      dyns.push(b);
+    }
+    step(space, 60);
+
+    // None of the dynamics should have passed through (x < -10)
+    for (const b of dyns) {
+      expect(b.position.x).toBeGreaterThan(-10);
+    }
+  });
+});

--- a/packages/nape-js/tests/native/space/ZPP_CallbackSet.lifecycle.test.ts
+++ b/packages/nape-js/tests/native/space/ZPP_CallbackSet.lifecycle.test.ts
@@ -1,0 +1,439 @@
+/**
+ * ZPP_CallbackSet — lifecycle, sleeping aggregation, and arbiter-list edge cases.
+ *
+ * Targets uncovered branches in lines ~380–615:
+ * - Sleeping aggregation (sleeping/empty_arb/really_empty methods)
+ * - Multiple arbiters per pair (compound bodies)
+ * - Multi-shape, multi-event interactions
+ * - Lazy delete (lazydel) path
+ * - State transitions across many steps (COLLISIONstate, SENSORstate, FLUIDstate)
+ * - Filtered groups → SENSOR vs COLLISION classification
+ * - Arbiter add/remove cycles within a single CallbackSet
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import "../../../src/core/engine";
+import { Space } from "../../../src/space/Space";
+import { Body } from "../../../src/phys/Body";
+import { BodyType } from "../../../src/phys/BodyType";
+import { Vec2 } from "../../../src/geom/Vec2";
+import { Circle } from "../../../src/shape/Circle";
+import { Polygon } from "../../../src/shape/Polygon";
+import { CbType } from "../../../src/callbacks/CbType";
+import { CbEvent } from "../../../src/callbacks/CbEvent";
+import { InteractionType } from "../../../src/callbacks/InteractionType";
+import { InteractionListener } from "../../../src/callbacks/InteractionListener";
+import { Material } from "../../../src/phys/Material";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function step(space: Space, n: number, dt = 1 / 60): void {
+  for (let i = 0; i < n; i++) space.step(dt);
+}
+
+function dynCircle(x: number, y: number, r = 10): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(r));
+  return b;
+}
+
+function staticBox(x: number, y: number, w = 200, h = 10): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(x, y));
+  b.shapes.add(new Polygon(Polygon.box(w, h)));
+  return b;
+}
+
+function lowFrictionMaterial(): Material {
+  return new Material(0.1, 1, 1, 1, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Compound body — multiple shapes generate multiple arbiters per pair
+// ---------------------------------------------------------------------------
+
+describe("ZPP_CallbackSet — compound bodies / multi-arbiter", () => {
+  it("body with two shapes contacts a floor with two simultaneous arbiters", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticBox(0, 300, 800, 20);
+    floor.space = space;
+
+    // Body with two well-separated shapes — both touch the floor side-by-side
+    const car = new Body(BodyType.DYNAMIC, new Vec2(0, 200));
+    car.shapes.add(new Circle(15, new Vec2(-30, 15)));
+    car.shapes.add(new Circle(15, new Vec2(30, 15)));
+    car.space = space;
+
+    let beginCount = 0;
+    const beginListener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => beginCount++,
+    );
+    beginListener.space = space;
+
+    step(space, 60);
+    // BEGIN fires per-CallbackSet, so even with two arbiters it fires once per pair
+    expect(beginCount).toBeGreaterThanOrEqual(1);
+    expect(car.position.y).toBeLessThan(300);
+  });
+
+  it("compound car settles with both wheels touching the floor", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticBox(0, 300, 800, 20);
+    floor.shapes.at(0).material = lowFrictionMaterial();
+    floor.space = space;
+
+    const car = new Body(BodyType.DYNAMIC, new Vec2(0, 200));
+    const w1 = new Circle(15, new Vec2(-30, 0));
+    const w2 = new Circle(15, new Vec2(30, 0));
+    w1.material = lowFrictionMaterial();
+    w2.material = lowFrictionMaterial();
+    car.shapes.add(w1);
+    car.shapes.add(w2);
+    car.space = space;
+
+    step(space, 240);
+    // Should rest in roughly horizontal orientation
+    expect(Math.abs(car.rotation)).toBeLessThan(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Sleeping aggregation — a CallbackSet sleeps only when ALL arbiters sleep
+// ---------------------------------------------------------------------------
+
+describe("ZPP_CallbackSet — sleeping aggregation", () => {
+  it("a settled stack of bodies eventually goes to sleep", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticBox(0, 300, 800, 20);
+    floor.shapes.at(0).material = lowFrictionMaterial();
+    floor.space = space;
+
+    const stack: Body[] = [];
+    for (let i = 0; i < 3; i++) {
+      const b = dynCircle(0, 280 - i * 32, 14);
+      b.shapes.at(0).material = lowFrictionMaterial();
+      b.space = space;
+      stack.push(b);
+    }
+
+    step(space, 600);
+    // At least the bottom and middle should be asleep
+    let sleeping = 0;
+    for (const b of stack) if (b.isSleeping) sleeping++;
+    expect(sleeping).toBeGreaterThanOrEqual(2);
+  });
+
+  it("waking one body in a pair wakes its CallbackSet", () => {
+    const space = new Space(new Vec2(0, 500));
+    const floor = staticBox(0, 300, 800, 20);
+    floor.shapes.at(0).material = lowFrictionMaterial();
+    floor.space = space;
+
+    const ball = dynCircle(0, 200, 14);
+    ball.shapes.at(0).material = lowFrictionMaterial();
+    ball.space = space;
+
+    step(space, 600);
+    expect(ball.isSleeping).toBe(true);
+
+    ball.velocity = new Vec2(0, -200);
+    expect(ball.isSleeping).toBe(false);
+    step(space, 5);
+    // Ball should still be in the world / consistent
+    expect(Number.isFinite(ball.position.y)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. State transitions across many steps
+// ---------------------------------------------------------------------------
+
+describe("ZPP_CallbackSet — long-run state transitions", () => {
+  it("BEGIN → ONGOING → END for an oscillating ball", () => {
+    const space = new Space(new Vec2(0, 0));
+    const wall = staticBox(0, 100, 200, 10);
+    wall.space = space;
+
+    const ball = dynCircle(0, 0, 8);
+    ball.space = space;
+
+    const events: string[] = [];
+    new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => events.push("BEGIN"),
+    ).space = space;
+    new InteractionListener(
+      CbEvent.END,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => events.push("END"),
+    ).space = space;
+
+    // Drive ball into the wall, then pull it away
+    ball.velocity = new Vec2(0, 200);
+    step(space, 30);
+
+    // BEGIN should have fired
+    expect(events.includes("BEGIN")).toBe(true);
+
+    // Now pull it away
+    ball.velocity = new Vec2(0, -500);
+    ball.position = new Vec2(0, -1000);
+    step(space, 60);
+
+    // END should have fired by now
+    expect(events.includes("END")).toBe(true);
+  });
+
+  it("re-entering same pair triggers a fresh BEGIN", () => {
+    const space = new Space(new Vec2(0, 0));
+    const wall = staticBox(0, 100, 200, 10);
+    wall.space = space;
+
+    const ball = dynCircle(0, 0, 8);
+    ball.space = space;
+
+    let beginCount = 0;
+    new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => beginCount++,
+    ).space = space;
+
+    // Cycle 1
+    ball.velocity = new Vec2(0, 200);
+    step(space, 30);
+    const begin1 = beginCount;
+    expect(begin1).toBeGreaterThanOrEqual(1);
+
+    // Pull away → END
+    ball.position = new Vec2(0, -200);
+    ball.velocity = new Vec2(0, 0);
+    step(space, 5);
+
+    // Re-enter with strong velocity
+    ball.velocity = new Vec2(0, 800);
+    step(space, 60);
+
+    expect(beginCount).toBeGreaterThan(begin1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Many simultaneous pairs
+// ---------------------------------------------------------------------------
+
+describe("ZPP_CallbackSet — many simultaneous pairs", () => {
+  it("100 pairs of contacts all fire BEGIN exactly once each", () => {
+    const space = new Space(new Vec2(0, 0));
+
+    let beginCount = 0;
+    new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => beginCount++,
+    ).space = space;
+
+    // Place 100 pairs of overlapping circles, well-separated from each other
+    for (let i = 0; i < 100; i++) {
+      const a = dynCircle(i * 200, 0, 20);
+      a.space = space;
+      const b = dynCircle(i * 200 + 5, 0, 20); // overlapping
+      b.space = space;
+    }
+
+    step(space, 1);
+    expect(beginCount).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Body removal during an active CallbackSet
+// ---------------------------------------------------------------------------
+
+describe("ZPP_CallbackSet — removal mid-contact", () => {
+  it("removing one body during contact triggers END for the pair", () => {
+    const space = new Space(new Vec2(0, 0));
+
+    const a = dynCircle(0, 0, 20);
+    a.space = space;
+    const b = dynCircle(5, 0, 20);
+    b.space = space;
+
+    let endFired = false;
+    new InteractionListener(
+      CbEvent.END,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        endFired = true;
+      },
+    ).space = space;
+
+    step(space, 1);
+
+    // Remove a, expect END
+    a.space = null;
+    step(space, 2);
+    expect(endFired).toBe(true);
+  });
+
+  it("removing a body with multiple active pairs cleans up all CallbackSets", () => {
+    const space = new Space(new Vec2(0, 0));
+
+    const center = dynCircle(0, 0, 30);
+    center.space = space;
+
+    // Place 4 bodies overlapping the center one
+    const others: Body[] = [];
+    for (const [dx, dy] of [
+      [25, 0],
+      [-25, 0],
+      [0, 25],
+      [0, -25],
+    ]) {
+      const o = dynCircle(dx, dy, 20);
+      o.space = space;
+      others.push(o);
+    }
+
+    let endCount = 0;
+    new InteractionListener(
+      CbEvent.END,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => endCount++,
+    ).space = space;
+
+    step(space, 1);
+    center.space = null;
+    step(space, 2);
+
+    // 4 END events expected (one per remaining body)
+    expect(endCount).toBeGreaterThanOrEqual(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Listener add/remove during simulation
+// ---------------------------------------------------------------------------
+
+describe("ZPP_CallbackSet — listener lifecycle", () => {
+  let space: Space;
+  beforeEach(() => {
+    space = new Space(new Vec2(0, 0));
+  });
+
+  it("listener added mid-simulation receives subsequent events", () => {
+    const a = dynCircle(0, 0, 20);
+    a.space = space;
+    step(space, 1);
+
+    let receivedAfter = false;
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        receivedAfter = true;
+      },
+    );
+    listener.space = space;
+
+    // Add a second body that immediately overlaps
+    const b = dynCircle(5, 0, 20);
+    b.space = space;
+    step(space, 1);
+
+    expect(receivedAfter).toBe(true);
+  });
+
+  it("listener removed mid-simulation stops receiving events", () => {
+    let count = 0;
+    const listener = new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => count++,
+    );
+    listener.space = space;
+
+    const a = dynCircle(0, 0, 20);
+    a.space = space;
+    const b = dynCircle(5, 0, 20);
+    b.space = space;
+    step(space, 1);
+
+    const before = count;
+    listener.space = null;
+
+    // Re-pair: remove b, then re-add nearby
+    b.space = null;
+    step(space, 1);
+    const c = dynCircle(0, 100, 20);
+    c.space = space;
+    const d = dynCircle(5, 100, 20);
+    d.space = space;
+    step(space, 1);
+
+    expect(count).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Re-using a CallbackSet from the pool
+// ---------------------------------------------------------------------------
+
+describe("ZPP_CallbackSet — pool reuse", () => {
+  it("repeat add/remove cycles do not leak counts or fire phantom events", () => {
+    const space = new Space(new Vec2(0, 0));
+
+    let beginCount = 0;
+    let endCount = 0;
+    new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => beginCount++,
+    ).space = space;
+    new InteractionListener(
+      CbEvent.END,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => endCount++,
+    ).space = space;
+
+    for (let cycle = 0; cycle < 10; cycle++) {
+      const a = dynCircle(0, 0, 20);
+      a.space = space;
+      const b = dynCircle(5, 0, 20);
+      b.space = space;
+      step(space, 1);
+      a.space = null;
+      b.space = null;
+      step(space, 2);
+    }
+
+    expect(beginCount).toBe(10);
+    expect(endCount).toBe(10);
+  });
+});


### PR DESCRIPTION
Boost branch + statement coverage on previously thin areas:

- ZPP_ColArbiter (warm-start, 2-contact solver, position correction,
  friction transition, restitution threshold, sleep/wake cycles, mass
  asymmetry, kinematic push) — 18 tests
- ZPP_FluidArbiter preStep (buoyancy, fluid-fluid density mismatch,
  custom fluid gravity, polygon edge drag, circle drag, nodrag, angular
  damping, mixed viscosity, variable dt, surface velocity) — 18 tests
- ZPP_AABBTree (left/right rotations, removal-driven rebalance,
  movement churn, rotating-polygon AABB updates, ray + AABB queries
  after heavy churn, static+dynamic interplay) — 14 tests
- ZPP_CallbackSet lifecycle (compound multi-arbiter, sleeping
  aggregation, BEGIN/ONGOING/END transitions, 100 simultaneous pairs,
  removal mid-contact, listener add/remove, pool reuse) — 12 tests
- GeomPoly cut + decomposition (unbounded/bounded cuts, vertex hits,
  multi-piece concave outputs, sequential cuts, error paths,
  monotone/convex/triangular decomposition, isSimple, simplify) —
  39 tests
- SpringJoint solver (warm-start under load, damping ratio extremes,
  frequency boundaries, off-centre torque path, body validation,
  long chain, body reassign, anchor mutation, restLength=0,
  Newton's-3rd-law impulse balance) — 17 tests
- UserConstraint solver (2-DOF Cholesky factorisation, velocity-only
  with __clamp, breakUnderForce + __broken hook, body re-registration,
  bodyImpulse on inactive constraint, multi-DOF impulse(), visitBodies
  dedup, __bindVec2, __copy, soft-mode oscillation) — 15 tests

Test count: 5275 → 5408 (+133). Coverage:
  Stmts    70.58% → 71.17% (+0.59pp)
  Branch   61.52% → 62.24% (+0.72pp)
  Func     86.62% → 86.92% (+0.30pp)
  Lines    70.61% → 71.21% (+0.60pp)

Per-file highlights:
  ZPP_Monotone     57.89% → 72.36% stmts (+14.5pp)
  UserConstraint   61.72% → 70.37% stmts (+8.6pp)
  SpringJoint      58.57% → 64.49% stmts (+5.9pp)
  ZPP_AABBTree     42.02% → 44.44% stmts (+2.4pp)

https://claude.ai/code/session_019cUpGu7b5ih4RoVrs9hKre