### PR TITLE
Feat/convex cast demo

### DIFF
--- a/docs/demos/convex-cast.js
+++ b/docs/demos/convex-cast.js
@@ -8,6 +8,8 @@ const BLADE_THICK = 10;   // capsule diameter, px
 const SWING_SPEED = 1.8;  // rad/s  (one full revolution every ~3.5 s)
 const OBSTACLE_R  = 65;   // ring radius where the static obstacles sit
 const CAST_DT     = 0.35; // seconds ahead for convexMultiCast
+const GHOSTS      = 10;   // number of ghost outlines in the swept-arc visualisation
+const NORMAL_LEN  = 20;   // length of hit-normal arrows, px
 
 // ── Module-level state (reset in setup) ────────────────────────────────────
 let _sword     = null;  // kinematic Body
@@ -29,8 +31,8 @@ function spawnObstacle(space, x, y, colorIdx) {
   return body;
 }
 
-// Draw a capsule outline in the 2D overlay context (no fill, transform applied
-// externally via ctx.save/translate/rotate).
+// Draw a capsule outline in the 2D overlay context (no fill).
+// Applies its own save/translate/rotate/restore internally.
 function drawCapsuleOutline(ctx, cx, cy, angle, halfLen, radius) {
   ctx.save();
   ctx.translate(cx, cy);
@@ -158,15 +160,14 @@ export default {
   },
 
   render3dOverlay(ctx, space, W, H) {
-    const cx   = W / 2;
-    const cy   = H / 2;
-    const GHOSTS     = 10;            // number of ghost outlines in the sweep arc
-    const NORMAL_LEN = 20;            // pixels for hit-normal arrows
+    const cx = W / 2;
+    const cy = H / 2;
 
     // ── Swept-arc ghost outlines ───────────────────────────────────────────
     // Draw GHOSTS semi-transparent capsule outlines from the current angle
     // forward through the convexMultiCast window (CAST_DT * SWING_SPEED rad).
     const sweepSpan = SWING_SPEED * CAST_DT;
+    ctx.save();
     for (let i = 1; i <= GHOSTS; i++) {
       const t     = i / GHOSTS;
       const a     = _angle + t * sweepSpan;
@@ -175,6 +176,7 @@ export default {
       ctx.lineWidth   = 1;
       drawCapsuleOutline(ctx, cx, cy, a, BLADE_HALF, BLADE_THICK / 2);
     }
+    ctx.restore();
 
     // ── Multi-hit markers — yellow ─────────────────────────────────────────
     for (const h of _multiHits) {

--- a/docs/demos/convex-cast.js
+++ b/docs/demos/convex-cast.js
@@ -1,0 +1,235 @@
+import {
+  Body, BodyType, Vec2, Circle, Polygon, Capsule,
+} from "../nape-js.esm.js";
+
+// ── Constants ──────────────────────────────────────────────────────────────
+const BLADE_HALF  = 80;   // half-length of the capsule (center → tip), px
+const BLADE_THICK = 10;   // capsule diameter, px
+const SWING_SPEED = 1.8;  // rad/s  (one full revolution every ~3.5 s)
+const OBSTACLE_R  = 65;   // ring radius where the static obstacles sit
+const CAST_DT     = 0.35; // seconds ahead for convexMultiCast
+
+// ── Module-level state (reset in setup) ────────────────────────────────────
+let _sword     = null;  // kinematic Body
+let _blade     = null;  // Capsule shape attached to _sword
+let _angle     = 0;     // current rotation of the sword body (radians)
+let _firstHit  = null;  // { x, y, nx, ny, toi } | null  — from convexCast
+let _multiHits = [];    // [{ x, y, nx, ny, toi }]        — from convexMultiCast
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+function spawnObstacle(space, x, y, colorIdx) {
+  const body = new Body(BodyType.STATIC, new Vec2(x, y));
+  if (colorIdx % 2 === 0) {
+    body.shapes.add(new Polygon(Polygon.box(28, 28)));
+  } else {
+    body.shapes.add(new Circle(16));
+  }
+  try { body.userData._colorIdx = colorIdx % 6; } catch (_) {}
+  body.space = space;
+  return body;
+}
+
+// Draw a capsule outline in the 2D overlay context (no fill, transform applied
+// externally via ctx.save/translate/rotate).
+function drawCapsuleOutline(ctx, cx, cy, angle, halfLen, radius) {
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(angle);
+  // A capsule = rectangle + two semicircle end-caps.
+  // halfLen already accounts for the cap radius (see Capsule construction).
+  const hw = halfLen - radius; // half-distance between cap centres
+  ctx.beginPath();
+  ctx.moveTo(-hw, -radius);
+  ctx.lineTo( hw, -radius);
+  ctx.arc( hw, 0, radius, -Math.PI / 2,  Math.PI / 2);
+  ctx.lineTo(-hw, radius);
+  ctx.arc(-hw, 0, radius,  Math.PI / 2, -Math.PI / 2);
+  ctx.closePath();
+  ctx.stroke();
+  ctx.restore();
+}
+
+// ── Demo definition ────────────────────────────────────────────────────────
+export default {
+  id:    "convex-cast",
+  label: "Convex Cast",
+  tags:  ["ConvexCast", "ConvexMultiCast", "CCD", "Query", "Sweep", "Raycasting"],
+  featured: false,
+  desc:
+    "A spinning blade sweeps obstacles using <code>space.convexCast()</code> and " +
+    "<code>space.convexMultiCast()</code>. The <b>red</b> marker is the first hit " +
+    "in the next frame; <b>yellow</b> dots are all hits within the next 0.35 s. " +
+    "<b>Click</b> to spawn dynamic bodies into the sweep zone.",
+  walls: true,
+  workerCompatible: false,
+
+  moduleState:
+    `let _sword = null;\nlet _blade = null;\n` +
+    `let _angle = 0;\nlet _firstHit = null;\nlet _multiHits = [];`,
+
+  setup(space, W, H) {
+    space.gravity = new Vec2(0, 0); // zero-g top-down arena
+
+    const cx = W / 2;
+    const cy = H / 2;
+
+    // ── Sword ──────────────────────────────────────────────────────────────
+    // Kinematic body at the arena centre; the capsule is centred on the body
+    // and rotates like a clock hand (both tips sweep identical arcs).
+    _sword = new Body(BodyType.KINEMATIC, new Vec2(cx, cy));
+    _blade = new Capsule(BLADE_HALF * 2, BLADE_THICK);
+    _sword.shapes.add(_blade);
+    _sword.space = space;
+
+    // Initialise module state
+    _angle     = 0;
+    _firstHit  = null;
+    _multiHits = [];
+
+    // ── Static obstacle ring ───────────────────────────────────────────────
+    // 8 alternating boxes and circles sit just within the blade's reach.
+    const N = 8;
+    for (let i = 0; i < N; i++) {
+      const a = (i / N) * Math.PI * 2;
+      spawnObstacle(
+        space,
+        cx + Math.cos(a) * OBSTACLE_R,
+        cy + Math.sin(a) * OBSTACLE_R,
+        i,
+      );
+    }
+  },
+
+  step(space) {
+    if (!_sword || !_blade) return;
+
+    // ── Advance sword rotation manually ───────────────────────────────────
+    // The body is kinematic, so we drive it explicitly. We also temporarily
+    // set angularVel so convexCast knows the sweep direction.
+    _angle += SWING_SPEED * (1 / 60);
+    _sword.rotation      = _angle;
+    _sword.velocity      = new Vec2(0, 0);
+    _sword.angularVel    = SWING_SPEED;  // needed by convexCast internals
+
+    // ── convexCast — first hit in the very next frame ──────────────────────
+    const first = space.convexCast(_blade, 1 / 60, false);
+    if (first) {
+      _firstHit = {
+        x: first.position.x,
+        y: first.position.y,
+        nx: first.normal.x,
+        ny: first.normal.y,
+        toi: first.toi,
+      };
+      first.dispose(); // return pooled object
+    } else {
+      _firstHit = null;
+    }
+
+    // ── convexMultiCast — all hits over the next CAST_DT seconds ──────────
+    _multiHits = [];
+    const multi = space.convexMultiCast(_blade, CAST_DT, false);
+    for (const r of multi) {
+      _multiHits.push({
+        x: r.position.x,
+        y: r.position.y,
+        nx: r.normal.x,
+        ny: r.normal.y,
+        toi: r.toi,
+      });
+      r.dispose();
+    }
+
+    // Reset angularVel after the casts so space.step() does not also advance
+    // the rotation (the body is kinematic — we control its position manually).
+    _sword.angularVel = 0;
+  },
+
+  click(x, y, space) {
+    // Spawn a small dynamic body at the click point so it drifts into the blade.
+    const body = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+    if (Math.random() < 0.5) {
+      body.shapes.add(new Circle(14));
+    } else {
+      body.shapes.add(new Polygon(Polygon.box(24, 24)));
+    }
+    try { body.userData._colorIdx = Math.floor(Math.random() * 6); } catch (_) {}
+    body.space = space;
+  },
+
+  render3dOverlay(ctx, space, W, H) {
+    const cx   = W / 2;
+    const cy   = H / 2;
+    const GHOSTS     = 10;            // number of ghost outlines in the sweep arc
+    const NORMAL_LEN = 20;            // pixels for hit-normal arrows
+
+    // ── Swept-arc ghost outlines ───────────────────────────────────────────
+    // Draw GHOSTS semi-transparent capsule outlines from the current angle
+    // forward through the convexMultiCast window (CAST_DT * SWING_SPEED rad).
+    const sweepSpan = SWING_SPEED * CAST_DT;
+    for (let i = 1; i <= GHOSTS; i++) {
+      const t     = i / GHOSTS;
+      const a     = _angle + t * sweepSpan;
+      const alpha = 0.04 + 0.04 * (1 - t);
+      ctx.strokeStyle = `rgba(88,166,255,${alpha.toFixed(2)})`;
+      ctx.lineWidth   = 1;
+      drawCapsuleOutline(ctx, cx, cy, a, BLADE_HALF, BLADE_THICK / 2);
+    }
+
+    // ── Multi-hit markers — yellow ─────────────────────────────────────────
+    for (const h of _multiHits) {
+      ctx.save();
+      ctx.strokeStyle = "rgba(240,200,60,0.65)";
+      ctx.fillStyle   = "rgba(240,200,60,0.25)";
+      ctx.lineWidth   = 1.5;
+      ctx.beginPath();
+      ctx.arc(h.x, h.y, 5, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+      // Normal arrow
+      ctx.beginPath();
+      ctx.moveTo(h.x, h.y);
+      ctx.lineTo(h.x + h.nx * NORMAL_LEN, h.y + h.ny * NORMAL_LEN);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    // ── First-hit marker — red (drawn on top of yellow markers) ───────────
+    if (_firstHit) {
+      ctx.save();
+      ctx.fillStyle   = "rgba(255,80,80,0.95)";
+      ctx.strokeStyle = "#ff5050";
+      ctx.lineWidth   = 2;
+      ctx.beginPath();
+      ctx.arc(_firstHit.x, _firstHit.y, 7, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+      // Normal arrow
+      ctx.beginPath();
+      ctx.moveTo(_firstHit.x, _firstHit.y);
+      ctx.lineTo(
+        _firstHit.x + _firstHit.nx * (NORMAL_LEN + 6),
+        _firstHit.y + _firstHit.ny * (NORMAL_LEN + 6),
+      );
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    // ── Pivot indicator ────────────────────────────────────────────────────
+    ctx.save();
+    ctx.fillStyle = "rgba(180,180,180,0.5)";
+    ctx.beginPath();
+    ctx.arc(cx, cy, 4, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+
+    // ── HUD ───────────────────────────────────────────────────────────────
+    const hitLabel  = _firstHit  ? "hit"  : "—";
+    const multiLabel = `${_multiHits.length} hit${_multiHits.length !== 1 ? "s" : ""} in ${CAST_DT}s`;
+    ctx.save();
+    ctx.font      = "12px monospace";
+    ctx.fillStyle = "rgba(200,210,230,0.75)";
+    ctx.fillText(`convexCast: ${hitLabel}   convexMultiCast: ${multiLabel}`, 12, 20);
+    ctx.restore();
+  },
+};

--- a/docs/demos/convex-cast.js
+++ b/docs/demos/convex-cast.js
@@ -226,12 +226,14 @@ export default {
     ctx.restore();
 
     // ── HUD ───────────────────────────────────────────────────────────────
-    const hitLabel  = _firstHit  ? "hit"  : "—";
-    const multiLabel = `${_multiHits.length} hit${_multiHits.length !== 1 ? "s" : ""} in ${CAST_DT}s`;
+    // Two fixed-width lines prevent text reflow / width flicker as counts change.
+    const hitLabel   = _firstHit ? "hit" : "—  ";
+    const countPad   = String(_multiHits.length).padStart(2, " ");
     ctx.save();
     ctx.font      = "12px monospace";
     ctx.fillStyle = "rgba(200,210,230,0.75)";
-    ctx.fillText(`convexCast: ${hitLabel}   convexMultiCast: ${multiLabel}`, 12, 20);
+    ctx.fillText(`convexCast:       ${hitLabel}`, 12, 20);
+    ctx.fillText(`convexMultiCast:  ${countPad} hit${_multiHits.length !== 1 ? "s" : " "} in ${CAST_DT}s`, 12, 36);
     ctx.restore();
   },
 };

--- a/docs/demos/convex-cast.js
+++ b/docs/demos/convex-cast.js
@@ -227,7 +227,7 @@ export default {
 
     // ── HUD ───────────────────────────────────────────────────────────────
     // Two fixed-width lines prevent text reflow / width flicker as counts change.
-    const hitLabel   = _firstHit ? "hit" : "—  ";
+    const hitLabel   = _firstHit ? "hit" : "---";
     const countPad   = String(_multiHits.length).padStart(2, " ");
     ctx.save();
     ctx.font      = "12px monospace";

--- a/docs/examples.js
+++ b/docs/examples.js
@@ -67,6 +67,7 @@ import saveLoadRewind      from "./demos/save-load-rewind.js?v=3.35.0";
 import replayRecorder      from "./demos/replay-recorder.js?v=3.35.0";
 import popcorn             from "./demos/popcorn.js?v=3.35.0";
 import rollercoaster       from "./demos/rollercoaster.js?v=3.35.0";
+import convexCast          from "./demos/convex-cast.js?v=3.35.0";
 
 // Note on order: cardEntries reverses ALL_DEMOS, so the LAST tuple entry
 // becomes the TOP card in the grid. New demos go at the end so they take
@@ -103,6 +104,7 @@ const ALL_DEMOS = [
   arenaDefense,
   popcorn,
   rollercoaster,
+  convexCast,
 ];
 
 const gtag = window.gtag || function() {};

--- a/docs/guides/cookbook.md
+++ b/docs/guides/cookbook.md
@@ -17,6 +17,7 @@ Each recipe shows the minimal working code and explains the "why" behind key dec
 - [Vehicle (Top-Down)](#vehicle-top-down)
 - [Fluid / Water Pool](#fluid--water-pool)
 - [Raycasting](#raycasting)
+- [Convex Cast (Swept-Shape Queries)](#convex-cast-swept-shape-queries)
 - [Sensor / Trigger Zone](#sensor--trigger-zone)
 - [Collision Filtering](#collision-filtering)
 - [Explosion Impulse](#explosion-impulse)
@@ -340,6 +341,68 @@ if (result) {
 ```
 
 **Gotcha:** `space.rayCast()` on static bodies may return null if you haven't called `space.step()` at least once — the broadphase needs a step to index the shapes.
+
+---
+
+## Convex Cast (Swept-Shape Queries)
+
+Where `rayCast` queries an infinitely thin ray, `convexCast` and `convexMultiCast`
+sweep a full convex shape along its body's current velocity — useful for wide
+projectile hit-prediction, look-ahead for melee weapons, or tunnelling prevention
+for fast-moving objects.
+
+```typescript
+import { Space, Body, BodyType, Vec2, Capsule } from "@newkrok/nape-js";
+
+// Create a "sword" body — a capsule that rotates around its centre.
+const sword = new Body(BodyType.KINEMATIC, new Vec2(450, 250));
+const blade = new Capsule(160, 10); // 160 px long, 10 px wide
+sword.shapes.add(blade);
+sword.angularVel = 2.0; // radians per second
+sword.space = space;
+
+// Important: the broadphase needs at least one step before casts return results.
+space.step(1 / 60);
+
+// ── convexCast — first hit in the next frame ──────────────────────────────
+const result = space.convexCast(blade, 1 / 60, false);
+if (result) {
+  console.log("First hit at:", result.position.x, result.position.y);
+  console.log("Surface normal:", result.normal.x, result.normal.y);
+  console.log("Time-of-impact (0–1):", result.toi);
+  console.log("Shape hit:", result.shape);
+  result.dispose(); // always dispose to return to pool
+}
+
+// ── convexMultiCast — all hits in the next 0.3 seconds ───────────────────
+const results = space.convexMultiCast(blade, 0.3, false);
+for (const r of results) {
+  console.log("Hit shape:", r.shape, "at toi:", r.toi.toFixed(3));
+  r.dispose(); // dispose each individual result
+}
+```
+
+**`ConvexResult` properties:**
+
+| Property   | Type    | Description |
+|------------|---------|-------------|
+| `position` | `Vec2`  | World-space contact point |
+| `normal`   | `Vec2`  | Surface normal at contact, pointing away from the hit shape |
+| `toi`      | `number`| Time-of-impact — `0` = immediate, `1` = end of `deltaTime` |
+| `shape`    | `Shape` | The shape that was hit |
+
+**Tips:**
+
+- `liveSweep = true` (third argument) accounts for the *other* body's velocity
+  during the sweep — useful when predicting a projectile hitting a moving target.
+- Always call `result.dispose()` (and each item from `convexMultiCast`) to return
+  pooled objects; skipping this causes a small per-frame allocation leak.
+- The shape must belong to a body that is already in the space.
+- Combine with `InteractionFilter` to restrict which shapes are eligible hits
+  (e.g. ignore sensors or specific collision groups).
+
+> **See also:** the [Convex Cast demo](/examples) — spinning sword with real-time
+> swept-arc visualisation and HUD showing both APIs side-by-side.
 
 ---
 

--- a/docs/guides/cookbook.md
+++ b/docs/guides/cookbook.md
@@ -369,7 +369,7 @@ const result = space.convexCast(blade, 1 / 60, false);
 if (result) {
   console.log("First hit at:", result.position.x, result.position.y);
   console.log("Surface normal:", result.normal.x, result.normal.y);
-  console.log("Time-of-impact (0–1):", result.toi);
+  console.log("Time-of-impact (seconds):", result.toi);
   console.log("Shape hit:", result.shape);
   result.dispose(); // always dispose to return to pool
 }
@@ -388,7 +388,7 @@ for (const r of results) {
 |------------|---------|-------------|
 | `position` | `Vec2`  | World-space contact point |
 | `normal`   | `Vec2`  | Surface normal at contact, pointing away from the hit shape |
-| `toi`      | `number`| Time-of-impact — `0` = immediate, `1` = end of `deltaTime` |
+| `toi`      | `number`| Time-of-impact in seconds — `0` = immediate contact, up to `deltaTime` |
 | `shape`    | `Shape` | The shape that was hit |
 
 **Tips:**


### PR DESCRIPTION
## Summary                                                                                                                                                                       

  Adds a interactive demo for `Space.convexCast()` and `Space.convexMultiCast()` — two public API methods that had no demo coverage on the examples grid.

  **What's included:**

  - `docs/demos/convex-cast.js` — a spinning sword (kinematic capsule body) sweeps through a ring of static obstacles. Each frame:
    - `space.convexCast(blade, 1/60)` predicts the **first hit** in the next frame → shown as a red dot with a surface-normal arrow
    - `space.convexMultiCast(blade, 0.35)` predicts **all hits** in the next 0.35 s → shown as yellow dots with normal arrows
    - A translucent swept-arc ghost visualises the predicted sweep volume
    - HUD shows live results from both APIs
    - Click to spawn dynamic bodies into the sweep zone
    - All `ConvexResult` objects are correctly disposed after reading
  - `docs/examples.js` — demo registered, appears first in the grid
  - `docs/guides/cookbook.md` — new **Convex Cast** recipe added after the Raycasting section, with copy-paste code, a `ConvexResult` property table, and usage tips

  ## Test plan

  - [ ] `npm run format:check` passes
  - [ ] `npm run lint` passes
  - [ ] `npm test` passes (5761 + 71 tests)
  - [ ] `npm run build` passes
  - [ ] Demo card appears on `/examples` and the physics runs correctly in the browser
  - [ ] Both `convexCast` and `convexMultiCast` hit markers render as expected

## GIF
<img width="1280" height="720" alt="2D-Physics-Examples-—-nape-js-TypeScript-Physics-Engine-Demos" src="https://github.com/user-attachments/assets/fee1f940-3d0f-45ff-b3cc-200d00bfe6c3" />
