### PR TITLE
Add ZPP_Set pool reuse tests

### DIFF
--- a/packages/nape-js/tests/native/util/ZPP_Set.test.ts
+++ b/packages/nape-js/tests/native/util/ZPP_Set.test.ts
@@ -226,6 +226,37 @@ describe("ZPP_Set", () => {
       set.remove(5);
       expect(SetClass.zpp_pool).not.toBeNull();
     });
+
+    it("reuses freed nodes without keeping stale tree links", () => {
+      SetClass.zpp_pool = null;
+      const set = makeSet();
+      const first = set.insert(5);
+      set.remove(5);
+
+      const reused = set.insert(10);
+
+      expect(reused).toBe(first);
+      expect(reused.parent).toBeNull();
+      expect(reused.prev).toBeNull();
+      expect(reused.next).toBeNull();
+      expect(reused.data).toBe(10);
+      expect(set.verify()).toBe(true);
+    });
+
+    it("can drain and reuse a freed batch in later insertions", () => {
+      SetClass.zpp_pool = null;
+      const set = makeSet();
+      const freed = [1, 2, 3, 4].map((value) => set.insert(value));
+      for (const value of [1, 2, 3, 4]) set.remove(value);
+
+      const reused = [10, 20, 30, 40].map((value) => set.insert(value));
+
+      expect(new Set(reused)).toEqual(new Set(freed));
+      expect(SetClass.zpp_pool).toBeNull();
+      expect(set.size()).toBe(4);
+      expect(set.verify()).toBe(true);
+      expect([10, 20, 30, 40].every((value) => set.has(value))).toBe(true);
+    });
   });
 
   describe("stress test — many insertions and removals", () => {


### PR DESCRIPTION
This adds focused coverage for `ZPP_Set` pool reuse so freed tree nodes are verified before they are recycled into later insertions. The tests check that a reused node does not retain stale parent or child links, that a batch of freed nodes can be drained from the pool for new insertions, and that the tree remains valid after reuse.

Tests: `npm --workspace @newkrok/nape-js test -- tests/native/util/ZPP_Set.test.ts`

Closes #167
