### PR TITLE
Add native body and compound unit coverage

### DIFF
--- a/packages/nape-js/tests/native/phys/ZPP_Body.test.ts
+++ b/packages/nape-js/tests/native/phys/ZPP_Body.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ZPP_Body } from "../../../src/native/phys/ZPP_Body";
+import { ZPP_Interactor } from "../../../src/native/phys/ZPP_Interactor";
+import { createMockNape, createMockZpp, MockZNPList } from "../_mocks";
+
+function makeShape(area: number, inertia: number, density: number) {
+  return {
+    area,
+    inertia,
+    material: { density },
+    refmaterial: { density: 0 },
+    validate_area_inertia: vi.fn(),
+  };
+}
+
+describe("ZPP_Body", () => {
+  beforeEach(() => {
+    const zpp = createMockZpp();
+    zpp.util.ZNPList_ZPP_Arbiter = MockZNPList;
+    zpp.util.ZNPList_ZPP_CallbackSet = MockZNPList;
+    zpp.util.ZPP_ShapeList = {
+      get: (list: any) => ({ zpp_inner: { inner: list } }),
+    };
+    ZPP_Body._zpp = zpp;
+    ZPP_Body._nape = createMockNape();
+    ZPP_Interactor._zpp = zpp;
+    ZPP_Interactor._nape = createMockNape();
+  });
+
+  it("recalculates mass and gravity mass from shape densities", () => {
+    const body = new ZPP_Body();
+    body.type = 2;
+    body.zip_mass = true;
+    body.zip_gravMass = true;
+    body.shapes.add(makeShape(3, 10, 2));
+    body.shapes.add(makeShape(4, 20, 0.5));
+
+    body.validate_mass();
+    body.validate_gravMass();
+
+    expect(body.cmass).toBe(8);
+    expect(body.mass).toBe(8);
+    expect(body.imass).toBe(1 / 8);
+    expect(body.smass).toBe(1 / 8);
+    expect(body.gravMass).toBe(8);
+    expect(body.zip_mass).toBe(false);
+    expect(body.zip_gravMass).toBe(false);
+  });
+
+  it("uses configured gravity mass scaling while preserving computed mass", () => {
+    const body = new ZPP_Body();
+    body.type = 2;
+    body.zip_mass = true;
+    body.gravMassMode = 2;
+    body.zip_gravMass = true;
+    body.gravMassScale = 1.5;
+    body.shapes.add(makeShape(2, 5, 4));
+
+    body.validate_gravMass();
+
+    expect(body.mass).toBe(8);
+    expect(body.gravMass).toBe(12);
+  });
+
+  it("sets infinite mass and inertia for non-dynamic bodies", () => {
+    const body = new ZPP_Body();
+    body.type = 1;
+    body.zip_mass = true;
+    body.zip_inertia = true;
+    body.shapes.add(makeShape(3, 4, 2));
+
+    body.validate_mass();
+    body.validate_inertia();
+
+    expect(body.cmass).toBe(6);
+    expect(body.mass).toBe(Infinity);
+    expect(body.imass).toBe(0);
+    expect(body.cinertia).toBe(24);
+    expect(body.inertia).toBe(Infinity);
+    expect(body.iinertia).toBe(0);
+  });
+
+  it("tracks sweep time and integrates position and rotation", () => {
+    const body = new ZPP_Body();
+    body.posx = 1;
+    body.posy = -2;
+    body.rot = 0;
+    body.axisx = 0;
+    body.axisy = 1;
+    body.velx = 4;
+    body.vely = 3;
+    body.angvel = 1;
+    body.sweep_angvel = 0.5;
+
+    body.sweepIntegrate(2);
+
+    expect(body.sweepTime).toBe(2);
+    expect(body.posx).toBe(9);
+    expect(body.posy).toBe(4);
+    expect(body.rot).toBe(1);
+    expect(body.axisx).toBeCloseTo(Math.sin(1));
+    expect(body.axisy).toBeCloseTo(Math.cos(1));
+  });
+});

--- a/packages/nape-js/tests/native/phys/ZPP_Compound.test.ts
+++ b/packages/nape-js/tests/native/phys/ZPP_Compound.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ZPP_Compound } from "../../../src/native/phys/ZPP_Compound";
+import { ZPP_Interactor } from "../../../src/native/phys/ZPP_Interactor";
+import { createMockNape, createMockZpp, MockZNPList } from "../_mocks";
+
+function listWrapper(list: any) {
+  return {
+    zpp_inner: { inner: list, reverse_flag: false },
+    remove: (x: any) => list.remove(x),
+  };
+}
+
+function setupCompoundStatics() {
+  const zpp = createMockZpp();
+  zpp.util.ZNPList_ZPP_Body = MockZNPList;
+  zpp.util.ZNPList_ZPP_Compound = MockZNPList;
+  zpp.util.ZNPList_ZPP_CallbackSet = MockZNPList;
+  zpp.util.ZPP_BodyList = { get: listWrapper };
+  zpp.util.ZPP_ConstraintList = { get: listWrapper };
+  zpp.util.ZPP_CompoundList = { get: listWrapper };
+  ZPP_Compound._zpp = zpp;
+  ZPP_Compound._nape = createMockNape();
+  ZPP_Interactor._zpp = zpp;
+  ZPP_Interactor._nape = createMockNape();
+}
+
+describe("ZPP_Compound", () => {
+  beforeEach(() => {
+    setupCompoundStatics();
+  });
+
+  it("initializes empty child lists and list callbacks", () => {
+    const compound = new ZPP_Compound();
+
+    expect(compound.depth).toBe(1);
+    expect(compound.bodies.length).toBe(0);
+    expect(compound.constraints.length).toBe(0);
+    expect(compound.compounds.length).toBe(0);
+    expect(compound.wrap_bodies.zpp_inner.adder).toBeTypeOf("function");
+    expect(compound.wrap_constraints.zpp_inner.subber).toBeTypeOf("function");
+    expect(compound.wrap_compounds.zpp_inner._modifiable).toBeTypeOf("function");
+  });
+
+  it("parents and de-parents bodies while forwarding space membership", () => {
+    const compound = new ZPP_Compound();
+    const addBody = vi.fn();
+    const remBody = vi.fn();
+    compound.space = { addBody, remBody };
+    const body = { compound: null, space: null };
+    const wrapper = { zpp_inner: body };
+
+    expect(compound.bodies_adder(wrapper)).toBe(true);
+    expect(body.compound).toBe(compound);
+    expect(addBody).toHaveBeenCalledWith(body);
+
+    compound.bodies_subber(wrapper);
+
+    expect(body.compound).toBeNull();
+    expect(remBody).toHaveBeenCalledWith(body);
+  });
+
+  it("updates nested compound depth and rejects cycles", () => {
+    const parent = new ZPP_Compound();
+    const child = new ZPP_Compound();
+    child.outer = { toString: () => "child" };
+    parent.depth = 3;
+
+    expect(parent.compounds_adder({ zpp_inner: child, toString: () => "child" })).toBe(true);
+    expect(child.compound).toBe(parent);
+    expect(child.depth).toBe(4);
+
+    expect(() => child.compounds_adder({ zpp_inner: parent, toString: () => "parent" })).toThrow(
+      /cycle/,
+    );
+
+    parent.compounds_subber({ zpp_inner: child });
+    expect(child.compound).toBeNull();
+    expect(child.depth).toBe(1);
+  });
+
+  it("breaks apart an empty compound without requiring children", () => {
+    const compound = new ZPP_Compound();
+    compound.__iremovedFromSpace = vi.fn();
+    const remove = vi.fn();
+    compound.space = {
+      nullInteractorType: vi.fn(),
+      compounds: { remove },
+    };
+
+    compound.breakApart();
+
+    expect(compound.__iremovedFromSpace).toHaveBeenCalled();
+    expect(remove).toHaveBeenCalledWith(compound);
+    expect(compound.space).toBeNull();
+    expect(compound.compound).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds direct native tests for ZPP_Body mass, inertia, gravity-mass, and sweep integration behavior, along with ZPP_Compound coverage for empty list setup, body parenting/de-parenting, nested compound depth, cycle rejection, and empty compound break-apart. The targeted Vitest run for the new native phys tests passes.