### PR TITLE
fix: remove redundant "Error: " prefix from all throw new Error() mes…

### DIFF
--- a/packages/nape-js/src/callbacks/BodyListener.ts
+++ b/packages/nape-js/src/callbacks/BodyListener.ts
@@ -53,7 +53,7 @@ export class BodyListener extends Listener {
     ZPP_Listener.internal = false;
 
     if (handler == null) {
-      throw new Error("Error: BodyListener::handler cannot be null");
+      throw new Error("BodyListener::handler cannot be null");
     }
 
     let xevent: number;
@@ -93,7 +93,7 @@ export class BodyListener extends Listener {
 
   set handler(handler: (cb: BodyCallback) => void) {
     if (handler == null) {
-      throw new Error("Error: BodyListener::handler cannot be null");
+      throw new Error("BodyListener::handler cannot be null");
     }
     this.zpp_inner_zn.handler = handler;
   }

--- a/packages/nape-js/src/callbacks/Callback.ts
+++ b/packages/nape-js/src/callbacks/Callback.ts
@@ -24,7 +24,7 @@ export class Callback {
 
   constructor() {
     if (!ZPP_Callback.internal) {
-      throw new Error("Error: Callback cannot be instantiated derp!");
+      throw new Error("Callback cannot be instantiated derp!");
     }
   }
 

--- a/packages/nape-js/src/callbacks/CbEvent.ts
+++ b/packages/nape-js/src/callbacks/CbEvent.ts
@@ -26,7 +26,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class CbEvent {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate CbEvent derp!");
+      throw new Error("Cannot instantiate CbEvent derp!");
     }
   }
 

--- a/packages/nape-js/src/callbacks/ConstraintListener.ts
+++ b/packages/nape-js/src/callbacks/ConstraintListener.ts
@@ -56,7 +56,7 @@ export class ConstraintListener extends Listener {
     ZPP_Listener.internal = false;
 
     if (handler == null) {
-      throw new Error("Error: ConstraintListener::handler cannot be null");
+      throw new Error("ConstraintListener::handler cannot be null");
     }
 
     let xevent: number;
@@ -104,7 +104,7 @@ export class ConstraintListener extends Listener {
 
   set handler(handler: (cb: ConstraintCallback) => void) {
     if (handler == null) {
-      throw new Error("Error: ConstraintListener::handler cannot be null");
+      throw new Error("ConstraintListener::handler cannot be null");
     }
     this.zpp_inner_zn.handler = handler;
   }

--- a/packages/nape-js/src/callbacks/InteractionListener.ts
+++ b/packages/nape-js/src/callbacks/InteractionListener.ts
@@ -86,10 +86,10 @@ export class InteractionListener extends Listener {
     ZPP_Listener.internal = false;
 
     if (handler == null) {
-      throw new Error("Error: InteractionListener::handler cannot be null");
+      throw new Error("InteractionListener::handler cannot be null");
     }
     if (event == null) {
-      throw new Error("Error: CbEvent cannot be null for InteractionListener");
+      throw new Error("CbEvent cannot be null for InteractionListener");
     }
 
     let xevent: number;
@@ -121,7 +121,7 @@ export class InteractionListener extends Listener {
 
     // Set interaction type
     if (interactionType == null) {
-      throw new Error("Error: Cannot set listener interaction type to null");
+      throw new Error("Cannot set listener interaction type to null");
     }
     const currentType = numberToInteractionType(this.zpp_inner_zn.itype);
     if (currentType != interactionType) {
@@ -154,7 +154,7 @@ export class InteractionListener extends Listener {
 
   set handler(handler: (cb: InteractionCallback) => void) {
     if (handler == null) {
-      throw new Error("Error: InteractionListener::handler cannot be null");
+      throw new Error("InteractionListener::handler cannot be null");
     }
     this.zpp_inner_zn.handleri = handler as (cb: any) => void;
   }
@@ -166,7 +166,7 @@ export class InteractionListener extends Listener {
 
   set interactionType(interactionType: InteractionType | null) {
     if (interactionType == null) {
-      throw new Error("Error: Cannot set listener interaction type to null");
+      throw new Error("Cannot set listener interaction type to null");
     }
     const currentType = numberToInteractionType(this.zpp_inner_zn.itype);
     if (currentType != interactionType) {

--- a/packages/nape-js/src/callbacks/InteractionType.ts
+++ b/packages/nape-js/src/callbacks/InteractionType.ts
@@ -15,7 +15,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class InteractionType {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate InteractionType derp!");
+      throw new Error("Cannot instantiate InteractionType derp!");
     }
   }
 

--- a/packages/nape-js/src/callbacks/Listener.ts
+++ b/packages/nape-js/src/callbacks/Listener.ts
@@ -50,7 +50,7 @@ export class Listener {
 
   constructor() {
     if (!ZPP_Listener.internal) {
-      throw new Error("Error: Cannot instantiate Listener derp!");
+      throw new Error("Cannot instantiate Listener derp!");
     }
     this.zpp_inner = null as unknown as ZPP_Listener;
   }
@@ -88,7 +88,7 @@ export class Listener {
 
   set event(event: CbEvent) {
     if (event == null) {
-      throw new Error("Error: Cannot set listener event type to null");
+      throw new Error("Cannot set listener event type to null");
     }
     if (ZPP_Listener.events[this.zpp_inner.event] != event) {
       const xevent = cbEventToNumber(event);

--- a/packages/nape-js/src/callbacks/ListenerType.ts
+++ b/packages/nape-js/src/callbacks/ListenerType.ts
@@ -14,7 +14,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class ListenerType {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate ListenerType derp!");
+      throw new Error("Cannot instantiate ListenerType derp!");
     }
   }
 

--- a/packages/nape-js/src/callbacks/PreFlag.ts
+++ b/packages/nape-js/src/callbacks/PreFlag.ts
@@ -18,7 +18,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class PreFlag {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate PreFlag derp!");
+      throw new Error("Cannot instantiate PreFlag derp!");
     }
   }
 

--- a/packages/nape-js/src/callbacks/PreListener.ts
+++ b/packages/nape-js/src/callbacks/PreListener.ts
@@ -75,7 +75,7 @@ export class PreListener extends Listener {
     ZPP_Listener.internal = false;
 
     if (handler == null) {
-      throw new Error("Error: PreListener must take a handler!");
+      throw new Error("PreListener must take a handler!");
     }
 
     this.zpp_inner_zn = new ZPP_InteractionListener(
@@ -93,7 +93,7 @@ export class PreListener extends Listener {
 
     // Set interaction type
     if (interactionType == null) {
-      throw new Error("Error: Cannot set listener interaction type to null");
+      throw new Error("Cannot set listener interaction type to null");
     }
     const currentType = numberToInteractionType(this.zpp_inner_zn.itype);
     if (currentType != interactionType) {
@@ -129,7 +129,7 @@ export class PreListener extends Listener {
 
   set handler(handler: (cb: PreCallback) => PreFlag | null) {
     if (handler == null) {
-      throw new Error("Error: PreListener must take a non-null handler!");
+      throw new Error("PreListener must take a non-null handler!");
     }
     this.zpp_inner_zn.handlerp = handler as (cb: any) => any;
     this.zpp_inner_zn.wake();
@@ -161,7 +161,7 @@ export class PreListener extends Listener {
 
   set interactionType(interactionType: InteractionType | null) {
     if (interactionType == null) {
-      throw new Error("Error: Cannot set listener interaction type to null");
+      throw new Error("Cannot set listener interaction type to null");
     }
     const currentType = numberToInteractionType(this.zpp_inner_zn.itype);
     if (currentType != interactionType) {

--- a/packages/nape-js/src/constraint/AngleJoint.ts
+++ b/packages/nape-js/src/constraint/AngleJoint.ts
@@ -4,6 +4,7 @@ import { Body } from "../phys/Body";
 import { MatMN } from "../geom/MatMN";
 import { Vec3 } from "../geom/Vec3";
 import { Constraint } from "./Constraint";
+import { IMPULSE_ERROR_NULL_BODY } from "./Constraint";
 import { ZPP_AngleJoint } from "../native/constraint/ZPP_AngleJoint";
 
 /**
@@ -60,7 +61,7 @@ export class AngleJoint extends Constraint {
     // Set joint parameters with validation
     this.zpp_inner.immutable_midstep("AngleJoint::jointMin");
     if (jointMin !== jointMin) {
-      throw new Error("Error: AngleJoint::jointMin cannot be NaN");
+      throw new Error("AngleJoint::jointMin cannot be NaN");
     }
     if (zpp.jointMin != jointMin) {
       zpp.jointMin = jointMin;
@@ -69,7 +70,7 @@ export class AngleJoint extends Constraint {
 
     this.zpp_inner.immutable_midstep("AngleJoint::jointMax");
     if (jointMax !== jointMax) {
-      throw new Error("Error: AngleJoint::jointMax cannot be NaN");
+      throw new Error("AngleJoint::jointMax cannot be NaN");
     }
     if (zpp.jointMax != jointMax) {
       zpp.jointMax = jointMax;
@@ -78,7 +79,7 @@ export class AngleJoint extends Constraint {
 
     this.zpp_inner.immutable_midstep("AngleJoint::ratio");
     if (ratio !== ratio) {
-      throw new Error("Error: AngleJoint::ratio cannot be NaN");
+      throw new Error("AngleJoint::ratio cannot be NaN");
     }
     if (zpp.ratio != ratio) {
       zpp.ratio = ratio;
@@ -197,7 +198,7 @@ export class AngleJoint extends Constraint {
   set jointMin(value: number) {
     this.zpp_inner.immutable_midstep("AngleJoint::jointMin");
     if (value !== value) {
-      throw new Error("Error: AngleJoint::jointMin cannot be NaN");
+      throw new Error("AngleJoint::jointMin cannot be NaN");
     }
     if (this.zpp_inner.jointMin != value) {
       this.zpp_inner.jointMin = value;
@@ -212,7 +213,7 @@ export class AngleJoint extends Constraint {
   set jointMax(value: number) {
     this.zpp_inner.immutable_midstep("AngleJoint::jointMax");
     if (value !== value) {
-      throw new Error("Error: AngleJoint::jointMax cannot be NaN");
+      throw new Error("AngleJoint::jointMax cannot be NaN");
     }
     if (this.zpp_inner.jointMax != value) {
       this.zpp_inner.jointMax = value;
@@ -232,7 +233,7 @@ export class AngleJoint extends Constraint {
   set ratio(value: number) {
     this.zpp_inner.immutable_midstep("AngleJoint::ratio");
     if (value !== value) {
-      throw new Error("Error: AngleJoint::ratio cannot be NaN");
+      throw new Error("AngleJoint::ratio cannot be NaN");
     }
     if (this.zpp_inner.ratio != value) {
       this.zpp_inner.ratio = value;
@@ -252,7 +253,7 @@ export class AngleJoint extends Constraint {
    */
   isSlack(): boolean {
     if (this.zpp_inner.b1 == null || this.zpp_inner.b2 == null) {
-      throw new Error("Error: Cannot compute slack for AngleJoint if either body is null.");
+      throw new Error("Cannot compute slack for AngleJoint if either body is null.");
     }
     return this.zpp_inner.is_slack();
   }
@@ -261,7 +262,7 @@ export class AngleJoint extends Constraint {
     const nape = getNape();
     const ret = new nape.geom.MatMN(1, 1);
     if (0 >= ret.zpp_inner.m || 0 >= ret.zpp_inner.n) {
-      throw new Error("Error: MatMN indices out of range");
+      throw new Error("MatMN indices out of range");
     }
     ret.zpp_inner.x[0 * ret.zpp_inner.n] = this.zpp_inner.jAcc;
     return ret;
@@ -270,12 +271,12 @@ export class AngleJoint extends Constraint {
   override bodyImpulse(body: Body): Vec3 {
     const nape = getNape();
     if (body == null) {
-      throw new Error("Error: Cannot evaluate impulse on null body");
+      throw new Error(IMPULSE_ERROR_NULL_BODY);
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     const b2outer = this.zpp_inner.b2 == null ? null : this.zpp_inner.b2.outer;
     if (body != b1outer && body != b2outer) {
-      throw new Error("Error: Body is not linked to this constraint");
+      throw new Error("Body is not linked to this constraint");
     }
     if (!this.zpp_inner.active) {
       return nape.geom.Vec3.get(0, 0, 0);
@@ -286,7 +287,7 @@ export class AngleJoint extends Constraint {
 
   override visitBodies(lambda: (body: Body) => void): void {
     if (lambda == null) {
-      throw new Error("Error: Cannot apply null lambda to bodies");
+      throw new Error("Cannot apply null lambda to bodies");
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     if (b1outer != null) {

--- a/packages/nape-js/src/constraint/Constraint.ts
+++ b/packages/nape-js/src/constraint/Constraint.ts
@@ -6,6 +6,9 @@ import { MatMN } from "../geom/MatMN";
 import { Vec3 } from "../geom/Vec3";
 import { ZPP_Constraint } from "../native/constraint/ZPP_Constraint";
 
+/** @internal Shared error message for impulse evaluation on a null body. */
+export const IMPULSE_ERROR_NULL_BODY = "Cannot evaluate impulse on null body";
+
 /**
  * Base class for all physics constraints (joints).
  *
@@ -218,10 +221,10 @@ export class Constraint {
   }
   set frequency(value: number) {
     if (value !== value) {
-      throw new Error("Error: Constraint::Frequency cannot be NaN");
+      throw new Error("Constraint::Frequency cannot be NaN");
     }
     if (value <= 0) {
-      throw new Error("Error: Constraint::Frequency must be >0");
+      throw new Error("Constraint::Frequency must be >0");
     }
     if (this.zpp_inner.frequency != value) {
       this.zpp_inner.frequency = value;
@@ -243,10 +246,10 @@ export class Constraint {
   }
   set damping(value: number) {
     if (value !== value) {
-      throw new Error("Error: Constraint::Damping cannot be Nan");
+      throw new Error("Constraint::Damping cannot be Nan");
     }
     if (value < 0) {
-      throw new Error("Error: Constraint::Damping must be >=0");
+      throw new Error("Constraint::Damping must be >=0");
     }
     if (this.zpp_inner.damping != value) {
       this.zpp_inner.damping = value;
@@ -269,10 +272,10 @@ export class Constraint {
   }
   set maxForce(value: number) {
     if (value !== value) {
-      throw new Error("Error: Constraint::maxForce cannot be NaN");
+      throw new Error("Constraint::maxForce cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: Constraint::maxForce must be >=0");
+      throw new Error("Constraint::maxForce must be >=0");
     }
     if (this.zpp_inner.maxForce != value) {
       this.zpp_inner.maxForce = value;
@@ -292,10 +295,10 @@ export class Constraint {
   }
   set maxError(value: number) {
     if (value !== value) {
-      throw new Error("Error: Constraint::maxError cannot be NaN");
+      throw new Error("Constraint::maxError cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: Constraint::maxError must be >=0");
+      throw new Error("Constraint::maxError must be >=0");
     }
     if (this.zpp_inner.maxError != value) {
       this.zpp_inner.maxError = value;

--- a/packages/nape-js/src/constraint/DistanceJoint.ts
+++ b/packages/nape-js/src/constraint/DistanceJoint.ts
@@ -5,12 +5,13 @@ import { Body } from "../phys/Body";
 import { MatMN } from "../geom/MatMN";
 import { Vec3 } from "../geom/Vec3";
 import { Constraint } from "./Constraint";
+import { IMPULSE_ERROR_NULL_BODY } from "./Constraint";
 import { ZPP_DistanceJoint } from "../native/constraint/ZPP_DistanceJoint";
 
 /** Read validated x from a Vec2 input. */
 function _readVec2X(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -20,7 +21,7 @@ function _readVec2X(v: Vec2): number {
 /** Read validated y from a Vec2 input. */
 function _readVec2Y(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -91,10 +92,10 @@ export class DistanceJoint extends Constraint {
 
     // Set anchor1
     if ((anchor1 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor1 == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     const a1x = _readVec2X(anchor1);
     const a1y = _readVec2Y(anchor1);
@@ -104,10 +105,10 @@ export class DistanceJoint extends Constraint {
 
     // Set anchor2
     if ((anchor2 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor2 == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     const a2x = _readVec2X(anchor2);
     const a2y = _readVec2Y(anchor2);
@@ -118,10 +119,10 @@ export class DistanceJoint extends Constraint {
     // Set jointMin with validation
     this.zpp_inner.immutable_midstep("DistanceJoint::jointMin");
     if (jointMin !== jointMin) {
-      throw new Error("Error: DistanceJoint::jointMin cannot be NaN");
+      throw new Error("DistanceJoint::jointMin cannot be NaN");
     }
     if (jointMin < 0) {
-      throw new Error("Error: DistanceJoint::jointMin must be >= 0");
+      throw new Error("DistanceJoint::jointMin must be >= 0");
     }
     if (zpp.jointMin != jointMin) {
       zpp.jointMin = jointMin;
@@ -131,10 +132,10 @@ export class DistanceJoint extends Constraint {
     // Set jointMax with validation
     this.zpp_inner.immutable_midstep("DistanceJoint::jointMax");
     if (jointMax !== jointMax) {
-      throw new Error("Error: DistanceJoint::jointMax cannot be NaN");
+      throw new Error("DistanceJoint::jointMax cannot be NaN");
     }
     if (jointMax < 0) {
-      throw new Error("Error: DistanceJoint::jointMax must be >= 0");
+      throw new Error("DistanceJoint::jointMax must be >= 0");
     }
     if (zpp.jointMax != jointMax) {
       zpp.jointMax = jointMax;
@@ -255,10 +256,10 @@ export class DistanceJoint extends Constraint {
   }
   set anchor1(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     if (this.zpp_inner.wrap_a1 == null) {
       this.zpp_inner.setup_a1();
@@ -276,10 +277,10 @@ export class DistanceJoint extends Constraint {
   }
   set anchor2(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     if (this.zpp_inner.wrap_a2 == null) {
       this.zpp_inner.setup_a2();
@@ -299,10 +300,10 @@ export class DistanceJoint extends Constraint {
   set jointMin(value: number) {
     this.zpp_inner.immutable_midstep("DistanceJoint::jointMin");
     if (value !== value) {
-      throw new Error("Error: DistanceJoint::jointMin cannot be NaN");
+      throw new Error("DistanceJoint::jointMin cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: DistanceJoint::jointMin must be >= 0");
+      throw new Error("DistanceJoint::jointMin must be >= 0");
     }
     if (this.zpp_inner.jointMin != value) {
       this.zpp_inner.jointMin = value;
@@ -317,10 +318,10 @@ export class DistanceJoint extends Constraint {
   set jointMax(value: number) {
     this.zpp_inner.immutable_midstep("DistanceJoint::jointMax");
     if (value !== value) {
-      throw new Error("Error: DistanceJoint::jointMax cannot be NaN");
+      throw new Error("DistanceJoint::jointMax cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: DistanceJoint::jointMax must be >= 0");
+      throw new Error("DistanceJoint::jointMax must be >= 0");
     }
     if (this.zpp_inner.jointMax != value) {
       this.zpp_inner.jointMax = value;
@@ -340,7 +341,7 @@ export class DistanceJoint extends Constraint {
    */
   isSlack(): boolean {
     if (this.zpp_inner.b1 == null || this.zpp_inner.b2 == null) {
-      throw new Error("Error: Cannot compute slack for DistanceJoint if either body is null.");
+      throw new Error("Cannot compute slack for DistanceJoint if either body is null.");
     }
     return this.zpp_inner.is_slack();
   }
@@ -349,7 +350,7 @@ export class DistanceJoint extends Constraint {
     const nape = getNape();
     const ret = new nape.geom.MatMN(1, 1);
     if (0 >= ret.zpp_inner.m || 0 >= ret.zpp_inner.n) {
-      throw new Error("Error: MatMN indices out of range");
+      throw new Error("MatMN indices out of range");
     }
     ret.zpp_inner.x[0 * ret.zpp_inner.n] = this.zpp_inner.jAcc;
     return ret;
@@ -358,12 +359,12 @@ export class DistanceJoint extends Constraint {
   override bodyImpulse(body: Body): Vec3 {
     const nape = getNape();
     if (body == null) {
-      throw new Error("Error: Cannot evaluate impulse on null body");
+      throw new Error(IMPULSE_ERROR_NULL_BODY);
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     const b2outer = this.zpp_inner.b2 == null ? null : this.zpp_inner.b2.outer;
     if (body != b1outer && body != b2outer) {
-      throw new Error("Error: Body is not linked to this constraint");
+      throw new Error("Body is not linked to this constraint");
     }
     if (!this.zpp_inner.active) {
       return nape.geom.Vec3.get(0, 0, 0);
@@ -374,7 +375,7 @@ export class DistanceJoint extends Constraint {
 
   override visitBodies(lambda: (body: Body) => void): void {
     if (lambda == null) {
-      throw new Error("Error: Cannot apply null lambda to bodies");
+      throw new Error("Cannot apply null lambda to bodies");
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     if (b1outer != null) {

--- a/packages/nape-js/src/constraint/LineJoint.ts
+++ b/packages/nape-js/src/constraint/LineJoint.ts
@@ -5,12 +5,13 @@ import { Body } from "../phys/Body";
 import { MatMN } from "../geom/MatMN";
 import { Vec3 } from "../geom/Vec3";
 import { Constraint } from "./Constraint";
+import { IMPULSE_ERROR_NULL_BODY } from "./Constraint";
 import { ZPP_LineJoint } from "../native/constraint/ZPP_LineJoint";
 
 /** Read validated x from a Vec2 input. */
 function _readVec2X(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -20,7 +21,7 @@ function _readVec2X(v: Vec2): number {
 /** Read validated y from a Vec2 input. */
 function _readVec2Y(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -91,10 +92,10 @@ export class LineJoint extends Constraint {
 
     // Set anchor1
     if ((anchor1 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor1 == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     zpp.a1localx = _readVec2X(anchor1);
     zpp.a1localy = _readVec2Y(anchor1);
@@ -102,10 +103,10 @@ export class LineJoint extends Constraint {
 
     // Set anchor2
     if ((anchor2 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor2 == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     zpp.a2localx = _readVec2X(anchor2);
     zpp.a2localy = _readVec2Y(anchor2);
@@ -113,10 +114,10 @@ export class LineJoint extends Constraint {
 
     // Set direction
     if ((direction as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (direction == null) {
-      throw new Error("Error: Constraint::direction cannot be null");
+      throw new Error("Constraint::direction cannot be null");
     }
     zpp.nlocalx = _readVec2X(direction);
     zpp.nlocaly = _readVec2Y(direction);
@@ -126,7 +127,7 @@ export class LineJoint extends Constraint {
     // Set jointMin with validation
     this.zpp_inner.immutable_midstep("LineJoint::jointMin");
     if (jointMin !== jointMin) {
-      throw new Error("Error: AngleJoint::jointMin cannot be NaN");
+      throw new Error("AngleJoint::jointMin cannot be NaN");
     }
     if (zpp.jointMin != jointMin) {
       zpp.jointMin = jointMin;
@@ -136,7 +137,7 @@ export class LineJoint extends Constraint {
     // Set jointMax with validation
     this.zpp_inner.immutable_midstep("LineJoint::jointMax");
     if (jointMax !== jointMax) {
-      throw new Error("Error: AngleJoint::jointMax cannot be NaN");
+      throw new Error("AngleJoint::jointMax cannot be NaN");
     }
     if (zpp.jointMax != jointMax) {
       zpp.jointMax = jointMax;
@@ -257,10 +258,10 @@ export class LineJoint extends Constraint {
   }
   set anchor1(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     if (this.zpp_inner.wrap_a1 == null) {
       this.zpp_inner.setup_a1();
@@ -278,10 +279,10 @@ export class LineJoint extends Constraint {
   }
   set anchor2(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     if (this.zpp_inner.wrap_a2 == null) {
       this.zpp_inner.setup_a2();
@@ -299,10 +300,10 @@ export class LineJoint extends Constraint {
   }
   set direction(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::direction cannot be null");
+      throw new Error("Constraint::direction cannot be null");
     }
     if (this.zpp_inner.wrap_n == null) {
       this.zpp_inner.setup_n();
@@ -322,7 +323,7 @@ export class LineJoint extends Constraint {
   set jointMin(value: number) {
     this.zpp_inner.immutable_midstep("LineJoint::jointMin");
     if (value !== value) {
-      throw new Error("Error: AngleJoint::jointMin cannot be NaN");
+      throw new Error("AngleJoint::jointMin cannot be NaN");
     }
     if (this.zpp_inner.jointMin != value) {
       this.zpp_inner.jointMin = value;
@@ -337,7 +338,7 @@ export class LineJoint extends Constraint {
   set jointMax(value: number) {
     this.zpp_inner.immutable_midstep("LineJoint::jointMax");
     if (value !== value) {
-      throw new Error("Error: AngleJoint::jointMax cannot be NaN");
+      throw new Error("AngleJoint::jointMax cannot be NaN");
     }
     if (this.zpp_inner.jointMax != value) {
       this.zpp_inner.jointMax = value;
@@ -360,12 +361,12 @@ export class LineJoint extends Constraint {
   override bodyImpulse(body: Body): Vec3 {
     const nape = getNape();
     if (body == null) {
-      throw new Error("Error: Cannot evaluate impulse on null body");
+      throw new Error(IMPULSE_ERROR_NULL_BODY);
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     const b2outer = this.zpp_inner.b2 == null ? null : this.zpp_inner.b2.outer;
     if (body != b1outer && body != b2outer) {
-      throw new Error("Error: Body is not linked to this constraint");
+      throw new Error("Body is not linked to this constraint");
     }
     if (!this.zpp_inner.active) {
       return nape.geom.Vec3.get();
@@ -376,7 +377,7 @@ export class LineJoint extends Constraint {
 
   override visitBodies(lambda: (body: Body) => void): void {
     if (lambda == null) {
-      throw new Error("Error: Cannot apply null lambda to bodies");
+      throw new Error("Cannot apply null lambda to bodies");
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     if (b1outer != null) {

--- a/packages/nape-js/src/constraint/MotorJoint.ts
+++ b/packages/nape-js/src/constraint/MotorJoint.ts
@@ -4,6 +4,7 @@ import { Body } from "../phys/Body";
 import { MatMN } from "../geom/MatMN";
 import { Vec3 } from "../geom/Vec3";
 import { Constraint } from "./Constraint";
+import { IMPULSE_ERROR_NULL_BODY } from "./Constraint";
 import { ZPP_MotorJoint } from "../native/constraint/ZPP_MotorJoint";
 
 /**
@@ -51,7 +52,7 @@ export class MotorJoint extends Constraint {
     // Set joint parameters with validation
     this.zpp_inner.immutable_midstep("MotorJoint::rate");
     if (rate !== rate) {
-      throw new Error("Error: MotorJoint::rate cannot be NaN");
+      throw new Error("MotorJoint::rate cannot be NaN");
     }
     if (zpp.rate != rate) {
       zpp.rate = rate;
@@ -60,7 +61,7 @@ export class MotorJoint extends Constraint {
 
     this.zpp_inner.immutable_midstep("MotorJoint::ratio");
     if (ratio !== ratio) {
-      throw new Error("Error: MotorJoint::ratio cannot be NaN");
+      throw new Error("MotorJoint::ratio cannot be NaN");
     }
     if (zpp.ratio != ratio) {
       zpp.ratio = ratio;
@@ -184,7 +185,7 @@ export class MotorJoint extends Constraint {
   set rate(value: number) {
     this.zpp_inner.immutable_midstep("MotorJoint::rate");
     if (value !== value) {
-      throw new Error("Error: MotorJoint::rate cannot be NaN");
+      throw new Error("MotorJoint::rate cannot be NaN");
     }
     if (this.zpp_inner.rate != value) {
       this.zpp_inner.rate = value;
@@ -204,7 +205,7 @@ export class MotorJoint extends Constraint {
   set ratio(value: number) {
     this.zpp_inner.immutable_midstep("MotorJoint::ratio");
     if (value !== value) {
-      throw new Error("Error: MotorJoint::ratio cannot be NaN");
+      throw new Error("MotorJoint::ratio cannot be NaN");
     }
     if (this.zpp_inner.ratio != value) {
       this.zpp_inner.ratio = value;
@@ -220,7 +221,7 @@ export class MotorJoint extends Constraint {
     const nape = getNape();
     const ret = new nape.geom.MatMN(1, 1);
     if (0 >= ret.zpp_inner.m || 0 >= ret.zpp_inner.n) {
-      throw new Error("Error: MatMN indices out of range");
+      throw new Error("MatMN indices out of range");
     }
     ret.zpp_inner.x[0 * ret.zpp_inner.n] = this.zpp_inner.jAcc;
     return ret;
@@ -229,12 +230,12 @@ export class MotorJoint extends Constraint {
   override bodyImpulse(body: Body): Vec3 {
     const nape = getNape();
     if (body == null) {
-      throw new Error("Error: Cannot evaluate impulse on null body");
+      throw new Error(IMPULSE_ERROR_NULL_BODY);
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     const b2outer = this.zpp_inner.b2 == null ? null : this.zpp_inner.b2.outer;
     if (body != b1outer && body != b2outer) {
-      throw new Error("Error: Body is not linked to this constraint");
+      throw new Error("Body is not linked to this constraint");
     }
     if (!this.zpp_inner.active) {
       return nape.geom.Vec3.get();

--- a/packages/nape-js/src/constraint/PivotJoint.ts
+++ b/packages/nape-js/src/constraint/PivotJoint.ts
@@ -5,12 +5,13 @@ import { Body } from "../phys/Body";
 import { MatMN } from "../geom/MatMN";
 import { Vec3 } from "../geom/Vec3";
 import { Constraint } from "./Constraint";
+import { IMPULSE_ERROR_NULL_BODY } from "./Constraint";
 import { ZPP_PivotJoint } from "../native/constraint/ZPP_PivotJoint";
 
 /** Read validated x from a Vec2 input. */
 function _readVec2X(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -20,7 +21,7 @@ function _readVec2X(v: Vec2): number {
 /** Read validated y from a Vec2 input. */
 function _readVec2Y(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -81,10 +82,10 @@ export class PivotJoint extends Constraint {
 
     // Set anchor1
     if ((anchor1 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor1 == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     zpp.a1localx = _readVec2X(anchor1);
     zpp.a1localy = _readVec2Y(anchor1);
@@ -92,10 +93,10 @@ export class PivotJoint extends Constraint {
 
     // Set anchor2
     if ((anchor2 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor2 == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     zpp.a2localx = _readVec2X(anchor2);
     zpp.a2localy = _readVec2Y(anchor2);
@@ -215,10 +216,10 @@ export class PivotJoint extends Constraint {
   }
   set anchor1(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     if (this.zpp_inner.wrap_a1 == null) {
       this.zpp_inner.setup_a1();
@@ -236,10 +237,10 @@ export class PivotJoint extends Constraint {
   }
   set anchor2(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     if (this.zpp_inner.wrap_a2 == null) {
       this.zpp_inner.setup_a2();
@@ -263,12 +264,12 @@ export class PivotJoint extends Constraint {
   override bodyImpulse(body: Body): Vec3 {
     const nape = getNape();
     if (body == null) {
-      throw new Error("Error: Cannot evaluate impulse on null body");
+      throw new Error(IMPULSE_ERROR_NULL_BODY);
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     const b2outer = this.zpp_inner.b2 == null ? null : this.zpp_inner.b2.outer;
     if (body != b1outer && body != b2outer) {
-      throw new Error("Error: Body is not linked to this constraint");
+      throw new Error("Body is not linked to this constraint");
     }
     if (!this.zpp_inner.active) {
       return nape.geom.Vec3.get();
@@ -279,7 +280,7 @@ export class PivotJoint extends Constraint {
 
   override visitBodies(lambda: (body: Body) => void): void {
     if (lambda == null) {
-      throw new Error("Error: Cannot apply null lambda to bodies");
+      throw new Error("Cannot apply null lambda to bodies");
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     if (b1outer != null) {

--- a/packages/nape-js/src/constraint/PulleyJoint.ts
+++ b/packages/nape-js/src/constraint/PulleyJoint.ts
@@ -4,12 +4,13 @@ import { Vec3 } from "../geom/Vec3";
 import { MatMN } from "../geom/MatMN";
 import { Body } from "../phys/Body";
 import { Constraint } from "./Constraint";
+import { IMPULSE_ERROR_NULL_BODY } from "./Constraint";
 import { ZPP_PulleyJoint } from "../native/constraint/ZPP_PulleyJoint";
 
 /** Read validated x from a Vec2 input. */
 function _readVec2X(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -19,7 +20,7 @@ function _readVec2X(v: Vec2): number {
 /** Read validated y from a Vec2 input. */
 function _readVec2Y(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -120,10 +121,10 @@ export class PulleyJoint extends Constraint {
     // Set jointMin
     zpp.immutable_midstep("PulleyJoint::jointMin");
     if (jointMin !== jointMin) {
-      throw new Error("Error: PulleyJoint::jointMin cannot be NaN");
+      throw new Error("PulleyJoint::jointMin cannot be NaN");
     }
     if (jointMin < 0) {
-      throw new Error("Error: PulleyJoint::jointMin must be >= 0");
+      throw new Error("PulleyJoint::jointMin must be >= 0");
     }
     if (zpp.jointMin != jointMin) {
       zpp.jointMin = jointMin;
@@ -133,10 +134,10 @@ export class PulleyJoint extends Constraint {
     // Set jointMax
     zpp.immutable_midstep("PulleyJoint::jointMax");
     if (jointMax !== jointMax) {
-      throw new Error("Error: PulleyJoint::jointMax cannot be NaN");
+      throw new Error("PulleyJoint::jointMax cannot be NaN");
     }
     if (jointMax < 0) {
-      throw new Error("Error: PulleyJoint::jointMax must be >= 0");
+      throw new Error("PulleyJoint::jointMax must be >= 0");
     }
     if (zpp.jointMax != jointMax) {
       zpp.jointMax = jointMax;
@@ -146,7 +147,7 @@ export class PulleyJoint extends Constraint {
     // Set ratio
     zpp.immutable_midstep("PulleyJoint::ratio");
     if (ratio !== ratio) {
-      throw new Error("Error: PulleyJoint::ratio cannot be NaN");
+      throw new Error("PulleyJoint::ratio cannot be NaN");
     }
     if (zpp.ratio != ratio) {
       zpp.ratio = ratio;
@@ -157,10 +158,10 @@ export class PulleyJoint extends Constraint {
   /** @internal Helper to set an anchor during construction. */
   private _setAnchorInit(anchor: Vec2, name: string, set: (x: number, y: number) => void): void {
     if ((anchor as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor == null) {
-      throw new Error("Error: Constraint::" + name + " cannot be null");
+      throw new Error("Constraint::" + name + " cannot be null");
     }
     set(_readVec2X(anchor), _readVec2Y(anchor));
     _disposeWeakVec2(anchor);
@@ -383,10 +384,10 @@ export class PulleyJoint extends Constraint {
   }
   set anchor1(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     if (this.zpp_inner.wrap_a1 == null) this.zpp_inner.setup_a1();
     _readVec2X(value);
@@ -402,10 +403,10 @@ export class PulleyJoint extends Constraint {
   }
   set anchor2(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     if (this.zpp_inner.wrap_a2 == null) this.zpp_inner.setup_a2();
     _readVec2X(value);
@@ -421,10 +422,10 @@ export class PulleyJoint extends Constraint {
   }
   set anchor3(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor3 cannot be null");
+      throw new Error("Constraint::anchor3 cannot be null");
     }
     if (this.zpp_inner.wrap_a3 == null) this.zpp_inner.setup_a3();
     _readVec2X(value);
@@ -440,10 +441,10 @@ export class PulleyJoint extends Constraint {
   }
   set anchor4(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor4 cannot be null");
+      throw new Error("Constraint::anchor4 cannot be null");
     }
     if (this.zpp_inner.wrap_a4 == null) this.zpp_inner.setup_a4();
     _readVec2X(value);
@@ -463,10 +464,10 @@ export class PulleyJoint extends Constraint {
   set jointMin(value: number) {
     this.zpp_inner.immutable_midstep("PulleyJoint::jointMin");
     if (value !== value) {
-      throw new Error("Error: PulleyJoint::jointMin cannot be NaN");
+      throw new Error("PulleyJoint::jointMin cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: PulleyJoint::jointMin must be >= 0");
+      throw new Error("PulleyJoint::jointMin must be >= 0");
     }
     if (this.zpp_inner.jointMin != value) {
       this.zpp_inner.jointMin = value;
@@ -481,10 +482,10 @@ export class PulleyJoint extends Constraint {
   set jointMax(value: number) {
     this.zpp_inner.immutable_midstep("PulleyJoint::jointMax");
     if (value !== value) {
-      throw new Error("Error: PulleyJoint::jointMax cannot be NaN");
+      throw new Error("PulleyJoint::jointMax cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: PulleyJoint::jointMax must be >= 0");
+      throw new Error("PulleyJoint::jointMax must be >= 0");
     }
     if (this.zpp_inner.jointMax != value) {
       this.zpp_inner.jointMax = value;
@@ -504,7 +505,7 @@ export class PulleyJoint extends Constraint {
   set ratio(value: number) {
     this.zpp_inner.immutable_midstep("PulleyJoint::ratio");
     if (value !== value) {
-      throw new Error("Error: PulleyJoint::ratio cannot be NaN");
+      throw new Error("PulleyJoint::ratio cannot be NaN");
     }
     if (this.zpp_inner.ratio != value) {
       this.zpp_inner.ratio = value;
@@ -529,7 +530,7 @@ export class PulleyJoint extends Constraint {
       this.zpp_inner.b3 == null ||
       this.zpp_inner.b4 == null
     ) {
-      throw new Error("Error: Cannot compute slack for PulleyJoint if either body is null.");
+      throw new Error("Cannot compute slack for PulleyJoint if either body is null.");
     }
     return this.zpp_inner.slack;
   }
@@ -537,7 +538,7 @@ export class PulleyJoint extends Constraint {
   override impulse(): MatMN {
     const ret = new MatMN(1, 1);
     if (0 >= ret.zpp_inner.m || 0 >= ret.zpp_inner.n) {
-      throw new Error("Error: MatMN indices out of range");
+      throw new Error("MatMN indices out of range");
     }
     ret.zpp_inner.x[0 * ret.zpp_inner.n] = this.zpp_inner.jAcc;
     return ret;
@@ -545,14 +546,14 @@ export class PulleyJoint extends Constraint {
 
   override bodyImpulse(body: Body): Vec3 {
     if (body == null) {
-      throw new Error("Error: Cannot evaluate impulse on null body");
+      throw new Error(IMPULSE_ERROR_NULL_BODY);
     }
     const b1outer = this.zpp_inner.b1?.outer ?? null;
     const b2outer = this.zpp_inner.b2?.outer ?? null;
     const b3outer = this.zpp_inner.b3?.outer ?? null;
     const b4outer = this.zpp_inner.b4?.outer ?? null;
     if (body != b1outer && body != b2outer && body != b3outer && body != b4outer) {
-      throw new Error("Error: Body is not linked to this constraint");
+      throw new Error("Body is not linked to this constraint");
     }
     if (!this.zpp_inner.active) {
       return Vec3.get(0, 0, 0);
@@ -563,7 +564,7 @@ export class PulleyJoint extends Constraint {
 
   override visitBodies(lambda: (body: Body) => void): void {
     if (lambda == null) {
-      throw new Error("Error: Cannot apply null lambda to bodies");
+      throw new Error("Cannot apply null lambda to bodies");
     }
     const b1 = this.zpp_inner.b1?.outer ?? null;
     const b2 = this.zpp_inner.b2?.outer ?? null;

--- a/packages/nape-js/src/constraint/SpringJoint.ts
+++ b/packages/nape-js/src/constraint/SpringJoint.ts
@@ -5,12 +5,13 @@ import { Body } from "../phys/Body";
 import { MatMN } from "../geom/MatMN";
 import { Vec3 } from "../geom/Vec3";
 import { Constraint } from "./Constraint";
+import { IMPULSE_ERROR_NULL_BODY } from "./Constraint";
 import { ZPP_SpringJoint } from "../native/constraint/ZPP_SpringJoint";
 
 /** Read validated x from a Vec2 input. */
 function _readVec2X(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -20,7 +21,7 @@ function _readVec2X(v: Vec2): number {
 /** Read validated y from a Vec2 input. */
 function _readVec2Y(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -94,10 +95,10 @@ export class SpringJoint extends Constraint {
 
     // Set anchor1
     if ((anchor1 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor1 == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     const a1x = _readVec2X(anchor1);
     const a1y = _readVec2Y(anchor1);
@@ -107,10 +108,10 @@ export class SpringJoint extends Constraint {
 
     // Set anchor2
     if ((anchor2 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor2 == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     const a2x = _readVec2X(anchor2);
     const a2y = _readVec2Y(anchor2);
@@ -121,10 +122,10 @@ export class SpringJoint extends Constraint {
     // Set restLength
     this.zpp_inner.immutable_midstep("SpringJoint::restLength");
     if (restLength !== restLength) {
-      throw new Error("Error: SpringJoint::restLength cannot be NaN");
+      throw new Error("SpringJoint::restLength cannot be NaN");
     }
     if (restLength < 0) {
-      throw new Error("Error: SpringJoint::restLength must be >= 0");
+      throw new Error("SpringJoint::restLength must be >= 0");
     }
     zpp.restLength = restLength;
   }
@@ -242,10 +243,10 @@ export class SpringJoint extends Constraint {
   }
   set anchor1(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     if (this.zpp_inner.wrap_a1 == null) {
       this.zpp_inner.setup_a1();
@@ -263,10 +264,10 @@ export class SpringJoint extends Constraint {
   }
   set anchor2(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     if (this.zpp_inner.wrap_a2 == null) {
       this.zpp_inner.setup_a2();
@@ -286,10 +287,10 @@ export class SpringJoint extends Constraint {
   set restLength(value: number) {
     this.zpp_inner.immutable_midstep("SpringJoint::restLength");
     if (value !== value) {
-      throw new Error("Error: SpringJoint::restLength cannot be NaN");
+      throw new Error("SpringJoint::restLength cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: SpringJoint::restLength must be >= 0");
+      throw new Error("SpringJoint::restLength must be >= 0");
     }
     if (this.zpp_inner.restLength != value) {
       this.zpp_inner.restLength = value;
@@ -316,7 +317,7 @@ export class SpringJoint extends Constraint {
     const nape = getNape();
     const ret = new nape.geom.MatMN(1, 1);
     if (0 >= ret.zpp_inner.m || 0 >= ret.zpp_inner.n) {
-      throw new Error("Error: MatMN indices out of range");
+      throw new Error("MatMN indices out of range");
     }
     ret.zpp_inner.x[0 * ret.zpp_inner.n] = this.zpp_inner.jAcc;
     return ret;
@@ -325,12 +326,12 @@ export class SpringJoint extends Constraint {
   override bodyImpulse(body: Body): Vec3 {
     const nape = getNape();
     if (body == null) {
-      throw new Error("Error: Cannot evaluate impulse on null body");
+      throw new Error(IMPULSE_ERROR_NULL_BODY);
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     const b2outer = this.zpp_inner.b2 == null ? null : this.zpp_inner.b2.outer;
     if (body != b1outer && body != b2outer) {
-      throw new Error("Error: Body is not linked to this constraint");
+      throw new Error("Body is not linked to this constraint");
     }
     if (!this.zpp_inner.active) {
       return nape.geom.Vec3.get(0, 0, 0);
@@ -341,7 +342,7 @@ export class SpringJoint extends Constraint {
 
   override visitBodies(lambda: (body: Body) => void): void {
     if (lambda == null) {
-      throw new Error("Error: Cannot apply null lambda to bodies");
+      throw new Error("Cannot apply null lambda to bodies");
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     if (b1outer != null) {

--- a/packages/nape-js/src/constraint/UserConstraint.ts
+++ b/packages/nape-js/src/constraint/UserConstraint.ts
@@ -4,6 +4,7 @@ import { Vec3 } from "../geom/Vec3";
 import { MatMN } from "../geom/MatMN";
 import { Body } from "../phys/Body";
 import { Constraint } from "./Constraint";
+import { IMPULSE_ERROR_NULL_BODY } from "./Constraint";
 import { ZPP_UserConstraint } from "../native/constraint/ZPP_UserConstraint";
 
 /**
@@ -19,7 +20,7 @@ export abstract class UserConstraint extends Constraint {
     super();
 
     if (dimensions < 1) {
-      throw new Error("Error: Constraint dimension must be at least 1");
+      throw new Error("Constraint dimension must be at least 1");
     }
 
     const zpp = new ZPP_UserConstraint(dimensions, velocityOnly);
@@ -60,7 +61,7 @@ export abstract class UserConstraint extends Constraint {
 
   /** Create a copy of this constraint. Must be overridden. */
   __copy(): UserConstraint {
-    throw new Error("Error: UserConstraint::__copy must be overriden");
+    throw new Error("UserConstraint::__copy must be overriden");
   }
 
   /** Called when the constraint breaks. Optional override. */
@@ -77,17 +78,17 @@ export abstract class UserConstraint extends Constraint {
 
   /** Compute positional error. Must be overridden for non-velocity-only constraints. */
   __position(_err: number[]): void {
-    throw new Error("Error: UserConstraint::__position must be overriden");
+    throw new Error("UserConstraint::__position must be overriden");
   }
 
   /** Compute velocity error. Must be overridden. */
   __velocity(_err: number[]): void {
-    throw new Error("Error: Userconstraint::__velocity must be overriden");
+    throw new Error("Userconstraint::__velocity must be overriden");
   }
 
   /** Compute effective mass matrix (upper triangle). Must be overridden. */
   __eff_mass(_eff: number[]): void {
-    throw new Error("Error: UserConstraint::__eff_mass must be overriden");
+    throw new Error("UserConstraint::__eff_mass must be overriden");
   }
 
   /** Clamp accumulated impulse. Optional override. */
@@ -95,7 +96,7 @@ export abstract class UserConstraint extends Constraint {
 
   /** Apply impulse to a body. Must be overridden. */
   __impulse(_imp: number[], _body: Body, _out: any): void {
-    throw new Error("Error: UserConstraint::__impulse must be overriden");
+    throw new Error("UserConstraint::__impulse must be overriden");
   }
 
   // ---------------------------------------------------------------------------
@@ -107,7 +108,7 @@ export abstract class UserConstraint extends Constraint {
     const ret = new MatMN(dim, 1);
     for (let i = 0; i < dim; i++) {
       if (i < 0 || i >= ret.zpp_inner.m || 0 >= ret.zpp_inner.n) {
-        throw new Error("Error: MatMN indices out of range");
+        throw new Error("MatMN indices out of range");
       }
       ret.zpp_inner.x[i * ret.zpp_inner.n] = this.zpp_inner.jAcc[i];
     }
@@ -116,7 +117,7 @@ export abstract class UserConstraint extends Constraint {
 
   override bodyImpulse(body: Body): Vec3 {
     if (body == null) {
-      throw new Error("Error: Cannot evaluate impulse on null body");
+      throw new Error(IMPULSE_ERROR_NULL_BODY);
     }
     let found = false;
     for (const b of this.zpp_inner.bodies) {
@@ -126,7 +127,7 @@ export abstract class UserConstraint extends Constraint {
       }
     }
     if (!found) {
-      throw new Error("Error: Body is not linked to this constraint");
+      throw new Error("Body is not linked to this constraint");
     }
     if (!this.zpp_inner.active) {
       return Vec3.get();
@@ -177,7 +178,7 @@ export abstract class UserConstraint extends Constraint {
     if (oldBody != newBody) {
       if (oldBody != null) {
         if (!this.zpp_inner.remBody((oldBody as any).zpp_inner)) {
-          throw new Error("Error: oldBody is not registered to the cosntraint");
+          throw new Error("oldBody is not registered to the cosntraint");
         }
         if (
           this.zpp_inner.active &&

--- a/packages/nape-js/src/constraint/WeldJoint.ts
+++ b/packages/nape-js/src/constraint/WeldJoint.ts
@@ -5,12 +5,13 @@ import { Body } from "../phys/Body";
 import { MatMN } from "../geom/MatMN";
 import { Vec3 } from "../geom/Vec3";
 import { Constraint } from "./Constraint";
+import { IMPULSE_ERROR_NULL_BODY } from "./Constraint";
 import { ZPP_WeldJoint } from "../native/constraint/ZPP_WeldJoint";
 
 /** Read validated x from a Vec2 input. */
 function _readVec2X(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -20,7 +21,7 @@ function _readVec2X(v: Vec2): number {
 /** Read validated y from a Vec2 input. */
 function _readVec2Y(v: Vec2): number {
   if ((v as any).zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -86,10 +87,10 @@ export class WeldJoint extends Constraint {
 
     // Set anchor1
     if ((anchor1 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor1 == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     zpp.a1localx = _readVec2X(anchor1);
     zpp.a1localy = _readVec2Y(anchor1);
@@ -97,10 +98,10 @@ export class WeldJoint extends Constraint {
 
     // Set anchor2
     if ((anchor2 as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (anchor2 == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     zpp.a2localx = _readVec2X(anchor2);
     zpp.a2localy = _readVec2Y(anchor2);
@@ -109,7 +110,7 @@ export class WeldJoint extends Constraint {
     // Set phase with validation
     this.zpp_inner.immutable_midstep("WeldJoint::phase");
     if (phase !== phase) {
-      throw new Error("Error: WeldJoint::phase cannot be NaN");
+      throw new Error("WeldJoint::phase cannot be NaN");
     }
     if (zpp.phase != phase) {
       zpp.phase = phase;
@@ -230,10 +231,10 @@ export class WeldJoint extends Constraint {
   }
   set anchor1(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor1 cannot be null");
+      throw new Error("Constraint::anchor1 cannot be null");
     }
     if (this.zpp_inner.wrap_a1 == null) {
       this.zpp_inner.setup_a1();
@@ -251,10 +252,10 @@ export class WeldJoint extends Constraint {
   }
   set anchor2(value: Vec2) {
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Constraint::anchor2 cannot be null");
+      throw new Error("Constraint::anchor2 cannot be null");
     }
     if (this.zpp_inner.wrap_a2 == null) {
       this.zpp_inner.setup_a2();
@@ -278,7 +279,7 @@ export class WeldJoint extends Constraint {
   set phase(value: number) {
     this.zpp_inner.immutable_midstep("WeldJoint::phase");
     if (value !== value) {
-      throw new Error("Error: WeldJoint::phase cannot be NaN");
+      throw new Error("WeldJoint::phase cannot be NaN");
     }
     if (this.zpp_inner.phase != value) {
       this.zpp_inner.phase = value;
@@ -302,12 +303,12 @@ export class WeldJoint extends Constraint {
   override bodyImpulse(body: Body): Vec3 {
     const nape = getNape();
     if (body == null) {
-      throw new Error("Error: Cannot evaluate impulse on null body");
+      throw new Error(IMPULSE_ERROR_NULL_BODY);
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     const b2outer = this.zpp_inner.b2 == null ? null : this.zpp_inner.b2.outer;
     if (body != b1outer && body != b2outer) {
-      throw new Error("Error: Body is not linked to this constraint");
+      throw new Error("Body is not linked to this constraint");
     }
     if (!this.zpp_inner.active) {
       return nape.geom.Vec3.get();
@@ -318,7 +319,7 @@ export class WeldJoint extends Constraint {
 
   override visitBodies(lambda: (body: Body) => void): void {
     if (lambda == null) {
-      throw new Error("Error: Cannot apply null lambda to bodies");
+      throw new Error("Cannot apply null lambda to bodies");
     }
     const b1outer = this.zpp_inner.b1 == null ? null : this.zpp_inner.b1.outer;
     if (b1outer != null) {

--- a/packages/nape-js/src/dynamics/Arbiter.ts
+++ b/packages/nape-js/src/dynamics/Arbiter.ts
@@ -40,7 +40,7 @@ export class Arbiter {
   constructor() {
     this.zpp_inner = null as any;
     if (!ZPP_Arbiter.internal) {
-      throw new Error("Error: Cannot instantiate Arbiter derp!");
+      throw new Error("Cannot instantiate Arbiter derp!");
     }
   }
 
@@ -225,7 +225,7 @@ export class Arbiter {
   /** @internal */
   protected _activeCheck(): void {
     if (!this.zpp_inner.active) {
-      throw new Error("Error: Arbiter not currently in use");
+      throw new Error("Arbiter not currently in use");
     }
   }
 
@@ -235,7 +235,7 @@ export class Arbiter {
     const b1 = inner.ws1.id > inner.ws2.id ? inner.b2.outer : inner.b1.outer;
     const b2 = inner.ws1.id > inner.ws2.id ? inner.b1.outer : inner.b2.outer;
     if (body != b1 && body != b2) {
-      throw new Error("Error: Arbiter does not relate to body");
+      throw new Error("Arbiter does not relate to body");
     }
   }
 }

--- a/packages/nape-js/src/dynamics/ArbiterType.ts
+++ b/packages/nape-js/src/dynamics/ArbiterType.ts
@@ -13,7 +13,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class ArbiterType {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate ArbiterType derp!");
+      throw new Error("Cannot instantiate ArbiterType derp!");
     }
   }
 

--- a/packages/nape-js/src/dynamics/CollisionArbiter.ts
+++ b/packages/nape-js/src/dynamics/CollisionArbiter.ts
@@ -116,10 +116,10 @@ export class CollisionArbiter extends Arbiter {
   set elasticity(value: number) {
     this._mutableCheck("elasticity");
     if (value !== value) {
-      throw new Error("Error: CollisionArbiter::elasticity cannot be NaN");
+      throw new Error("CollisionArbiter::elasticity cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: CollisionArbiter::elasticity cannot be negative");
+      throw new Error("CollisionArbiter::elasticity cannot be negative");
     }
     this.zpp_inner.colarb.restitution = value;
     this.zpp_inner.colarb.userdef_restitution = true;
@@ -139,10 +139,10 @@ export class CollisionArbiter extends Arbiter {
   set dynamicFriction(value: number) {
     this._mutableCheck("dynamicFriction");
     if (value !== value) {
-      throw new Error("Error: CollisionArbiter::dynamicFriction cannot be NaN");
+      throw new Error("CollisionArbiter::dynamicFriction cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: CollisionArbiter::dynamicFriction cannot be negative");
+      throw new Error("CollisionArbiter::dynamicFriction cannot be negative");
     }
     this.zpp_inner.colarb.dyn_fric = value;
     this.zpp_inner.colarb.userdef_dyn_fric = true;
@@ -162,10 +162,10 @@ export class CollisionArbiter extends Arbiter {
   set staticFriction(value: number) {
     this._mutableCheck("staticFriction");
     if (value !== value) {
-      throw new Error("Error: CollisionArbiter::staticFriction cannot be NaN");
+      throw new Error("CollisionArbiter::staticFriction cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: CollisionArbiter::staticFriction cannot be negative");
+      throw new Error("CollisionArbiter::staticFriction cannot be negative");
     }
     this.zpp_inner.colarb.stat_fric = value;
     this.zpp_inner.colarb.userdef_stat_fric = true;
@@ -185,10 +185,10 @@ export class CollisionArbiter extends Arbiter {
   set rollingFriction(value: number) {
     this._mutableCheck("rollingFriction");
     if (value !== value) {
-      throw new Error("Error: CollisionArbiter::rollingFriction cannot be NaN");
+      throw new Error("CollisionArbiter::rollingFriction cannot be NaN");
     }
     if (value < 0) {
-      throw new Error("Error: CollisionArbiter::rollingFriction cannot be negative");
+      throw new Error("CollisionArbiter::rollingFriction cannot be negative");
     }
     this.zpp_inner.colarb.rfric = value;
     this.zpp_inner.colarb.userdef_rfric = true;
@@ -271,7 +271,7 @@ export class CollisionArbiter extends Arbiter {
   /** @internal Throw if not in pre-handler mutable window. */
   private _mutableCheck(prop: string): void {
     if (!this.zpp_inner.colarb.mutable) {
-      throw new Error("Error: CollisionArbiter::" + prop + " is only mutable during a pre-handler");
+      throw new Error("CollisionArbiter::" + prop + " is only mutable during a pre-handler");
     }
   }
 

--- a/packages/nape-js/src/dynamics/Contact.ts
+++ b/packages/nape-js/src/dynamics/Contact.ts
@@ -27,7 +27,7 @@ export class Contact {
   constructor() {
     this.zpp_inner = null as any;
     if (!ZPP_Contact.internal) {
-      throw new Error("Error: Cannot instantiate Contact derp!");
+      throw new Error("Cannot instantiate Contact derp!");
     }
   }
 
@@ -196,14 +196,14 @@ export class Contact {
   /** @internal */
   private _inactiveCheck(): void {
     if (this.zpp_inner.inactiveme()) {
-      throw new Error("Error: Contact not currently in use");
+      throw new Error("Contact not currently in use");
     }
   }
 
   /** @internal */
   private _checkBody(body: Body, colarb: ZPP_ColArbiter): void {
     if (body != colarb.b1.outer && body != colarb.b2.outer) {
-      throw new Error("Error: Contact does not relate to the given body");
+      throw new Error("Contact does not relate to the given body");
     }
   }
 }

--- a/packages/nape-js/src/dynamics/ContactList.ts
+++ b/packages/nape-js/src/dynamics/ContactList.ts
@@ -48,7 +48,7 @@ function ContactIterator(this: any) {
   this.zpp_i = 0;
   this.zpp_inner = null;
   if (!ZPP_ContactList.internal) {
-    throw new Error("Error: Cannot instantiate ContactIterator derp!");
+    throw new Error("Cannot instantiate ContactIterator derp!");
   }
 }
 
@@ -106,7 +106,7 @@ function ContactListCtor(this: any) {
 
 ContactListCtor.fromArray = function (array: any[]): any {
   if (array == null) {
-    throw new Error("Error: Cannot convert null Array to Nape list");
+    throw new Error("Cannot convert null Array to Nape list");
   }
   const nape = getNape();
   const ret = new nape.dynamics.ContactList();
@@ -133,7 +133,7 @@ ContactListCtor.prototype.at = function (this: any, index: number): any {
   this.zpp_inner.valmod();
   const len = ensureLength(this.zpp_inner);
   if (index < 0 || index >= len) {
-    throw new Error("Error: Index out of bounds");
+    throw new Error("Index out of bounds");
   }
   if (this.zpp_inner.reverse_flag) {
     index = ensureLength(this.zpp_inner) - 1 - index;
@@ -165,7 +165,7 @@ ContactListCtor.prototype.at = function (this: any, index: number): any {
 
 ContactListCtor.prototype.push = function (this: any, obj: any): boolean {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: ContactList is immutable");
+    throw new Error("ContactList is immutable");
   }
   this.zpp_inner.modify_test();
   this.zpp_inner.valmod();
@@ -194,7 +194,7 @@ ContactListCtor.prototype.push = function (this: any, obj: any): boolean {
 
 ContactListCtor.prototype.unshift = function (this: any, obj: any): boolean {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: ContactList is immutable");
+    throw new Error("ContactList is immutable");
   }
   this.zpp_inner.modify_test();
   this.zpp_inner.valmod();
@@ -223,12 +223,12 @@ ContactListCtor.prototype.unshift = function (this: any, obj: any): boolean {
 
 ContactListCtor.prototype.pop = function (this: any): any {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: ContactList is immutable");
+    throw new Error("ContactList is immutable");
   }
   this.zpp_inner.modify_test();
   const len = ensureLength(this.zpp_inner);
   if (len == 0) {
-    throw new Error("Error: Cannot remove from empty list");
+    throw new Error("Cannot remove from empty list");
   }
   this.zpp_inner.valmod();
   let ret: any;
@@ -267,12 +267,12 @@ ContactListCtor.prototype.pop = function (this: any): any {
 
 ContactListCtor.prototype.shift = function (this: any): any {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: ContactList is immutable");
+    throw new Error("ContactList is immutable");
   }
   this.zpp_inner.modify_test();
   const len = ensureLength(this.zpp_inner);
   if (len == 0) {
-    throw new Error("Error: Cannot remove from empty list");
+    throw new Error("Cannot remove from empty list");
   }
   this.zpp_inner.valmod();
   let ret: any;
@@ -319,7 +319,7 @@ ContactListCtor.prototype.add = function (this: any, obj: any): boolean {
 
 ContactListCtor.prototype.remove = function (this: any, obj: any): boolean {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: ContactList is immutable");
+    throw new Error("ContactList is immutable");
   }
   this.zpp_inner.modify_test();
   this.zpp_inner.valmod();
@@ -346,7 +346,7 @@ ContactListCtor.prototype.remove = function (this: any, obj: any): boolean {
 
 ContactListCtor.prototype.clear = function (this: any): void {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: ContactList is immutable");
+    throw new Error("ContactList is immutable");
   }
   if (this.zpp_inner.reverse_flag) {
     while (ensureLength(this.zpp_inner) != 0) {
@@ -377,7 +377,7 @@ ContactListCtor.prototype.copy = function (this: any, deep?: boolean): any {
   while (it.hasNext()) {
     const i = it.next();
     if (deep) {
-      throw new Error("Error: Contact is not a copyable type");
+      throw new Error("Contact is not a copyable type");
     }
     ret.push(i);
   }
@@ -386,7 +386,7 @@ ContactListCtor.prototype.copy = function (this: any, deep?: boolean): any {
 
 ContactListCtor.prototype.merge = function (this: any, xs: any): void {
   if (xs == null) {
-    throw new Error("Error: Cannot merge with null list");
+    throw new Error("Cannot merge with null list");
   }
   xs.zpp_inner.valmod();
   const it = ContactIterator.get(xs);
@@ -418,7 +418,7 @@ ContactListCtor.prototype.toString = function (this: any): string {
 
 ContactListCtor.prototype.foreach = function (this: any, lambda: any): any {
   if (lambda == null) {
-    throw new Error("Error: Cannot execute null on list elements");
+    throw new Error("Cannot execute null on list elements");
   }
   this.zpp_inner.valmod();
   const it = ContactIterator.get(this);
@@ -453,7 +453,7 @@ ContactListCtor.prototype.foreach = function (this: any, lambda: any): any {
 
 ContactListCtor.prototype.filter = function (this: any, lambda: any): any {
   if (lambda == null) {
-    throw new Error("Error: Cannot select elements of list with null");
+    throw new Error("Cannot select elements of list with null");
   }
   let i = 0;
   while (true) {

--- a/packages/nape-js/src/dynamics/FluidArbiter.ts
+++ b/packages/nape-js/src/dynamics/FluidArbiter.ts
@@ -36,10 +36,10 @@ export class FluidArbiter extends Arbiter {
   }
   set position(value: Vec2) {
     if (!this.zpp_inner.fluidarb.mutable) {
-      throw new Error("Error: Arbiter is mutable only within a pre-handler");
+      throw new Error("Arbiter is mutable only within a pre-handler");
     }
     if (value == null) {
-      throw new Error("Error: FluidArbiter::position cannot be null");
+      throw new Error("FluidArbiter::position cannot be null");
     }
     this._activeCheck();
     if (this.zpp_inner.fluidarb.wrap_position == null) {
@@ -60,13 +60,13 @@ export class FluidArbiter extends Arbiter {
   }
   set overlap(value: number) {
     if (!this.zpp_inner.fluidarb.mutable) {
-      throw new Error("Error: Arbiter is mutable only within a pre-handler");
+      throw new Error("Arbiter is mutable only within a pre-handler");
     }
     if (value !== value) {
-      throw new Error("Error: FluidArbiter::overlap cannot be NaN");
+      throw new Error("FluidArbiter::overlap cannot be NaN");
     }
     if (value <= 0 || value == Infinity) {
-      throw new Error("Error: FluidArbiter::overlap must be strictly positive and non infinite");
+      throw new Error("FluidArbiter::overlap must be strictly positive and non infinite");
     }
     this.zpp_inner.fluidarb.overlap = value;
   }

--- a/packages/nape-js/src/dynamics/InteractionFilter.ts
+++ b/packages/nape-js/src/dynamics/InteractionFilter.ts
@@ -207,7 +207,7 @@ export class InteractionFilter {
    */
   shouldCollide(filter: InteractionFilter): boolean {
     if (filter == null) {
-      throw new Error("Error: filter argument cannot be null for shouldCollide");
+      throw new Error("filter argument cannot be null for shouldCollide");
     }
     return this.zpp_inner.shouldCollide(filter.zpp_inner);
   }
@@ -219,7 +219,7 @@ export class InteractionFilter {
    */
   shouldSense(filter: InteractionFilter): boolean {
     if (filter == null) {
-      throw new Error("Error: filter argument cannot be null for shouldSense");
+      throw new Error("filter argument cannot be null for shouldSense");
     }
     return this.zpp_inner.shouldSense(filter.zpp_inner);
   }
@@ -231,7 +231,7 @@ export class InteractionFilter {
    */
   shouldFlow(filter: InteractionFilter): boolean {
     if (filter == null) {
-      throw new Error("Error: filter argument cannot be null for shouldFlow");
+      throw new Error("filter argument cannot be null for shouldFlow");
     }
     return this.zpp_inner.shouldFlow(filter.zpp_inner);
   }

--- a/packages/nape-js/src/dynamics/InteractionGroup.ts
+++ b/packages/nape-js/src/dynamics/InteractionGroup.ts
@@ -73,7 +73,7 @@ export class InteractionGroup {
   }
   set group(value: InteractionGroup | null) {
     if (value === (this as any)) {
-      throw new Error("Error: Cannot assign InteractionGroup to itself");
+      throw new Error("Cannot assign InteractionGroup to itself");
     }
     this.zpp_inner.setGroup(value == null ? null : value.zpp_inner);
   }

--- a/packages/nape-js/src/geom/AABB.ts
+++ b/packages/nape-js/src/geom/AABB.ts
@@ -39,10 +39,10 @@ export class AABB {
   constructor(x: number = 0, y: number = 0, width: number = 0, height: number = 0) {
     // NaN checks
     if (x !== x || y !== y) {
-      throw new Error("Error: AABB position cannot be NaN");
+      throw new Error("AABB position cannot be NaN");
     }
     if (width !== width || height !== height) {
-      throw new Error("Error: AABB dimensions cannot be NaN");
+      throw new Error("AABB dimensions cannot be NaN");
     }
 
     // Acquire a ZPP_AABB from the pool or create a new one
@@ -72,14 +72,14 @@ export class AABB {
    */
   static fromPoints(points: Vec2[]): AABB {
     if (points == null || points.length === 0) {
-      throw new Error("Error: AABB::fromPoints requires at least one point");
+      throw new Error("AABB::fromPoints requires at least one point");
     }
     const first = points[0];
     if (first != null && first.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (first == null) {
-      throw new Error("Error: AABB::fromPoints cannot contain null Vec2");
+      throw new Error("AABB::fromPoints cannot contain null Vec2");
     }
     first.zpp_inner.validate();
     let minx = first.zpp_inner.x;
@@ -89,10 +89,10 @@ export class AABB {
     for (let i = 1; i < points.length; i++) {
       const p = points[i];
       if (p != null && p.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       if (p == null) {
-        throw new Error("Error: AABB::fromPoints cannot contain null Vec2");
+        throw new Error("AABB::fromPoints cannot contain null Vec2");
       }
       p.zpp_inner.validate();
       const px = p.zpp_inner.x;
@@ -139,12 +139,12 @@ export class AABB {
   /** The x position of the left edge (minx). Setting shifts the box horizontally. */
   set x(x: number) {
     if (this.zpp_inner._immutable) {
-      throw new Error("Error: AABB is immutable");
+      throw new Error("AABB is immutable");
     }
     this.zpp_inner.validate();
     if (this.zpp_inner.minx != x) {
       if (x !== x) {
-        throw new Error("Error: AABB::x cannot be NaN");
+        throw new Error("AABB::x cannot be NaN");
       }
       this.zpp_inner.maxx += x - this.zpp_inner.minx;
       this.zpp_inner.minx = x;
@@ -160,12 +160,12 @@ export class AABB {
   /** The y position of the top edge (miny). Setting shifts the box vertically. */
   set y(y: number) {
     if (this.zpp_inner._immutable) {
-      throw new Error("Error: AABB is immutable");
+      throw new Error("AABB is immutable");
     }
     this.zpp_inner.validate();
     if (this.zpp_inner.miny != y) {
       if (y !== y) {
-        throw new Error("Error: AABB::y cannot be NaN");
+        throw new Error("AABB::y cannot be NaN");
       }
       this.zpp_inner.maxy += y - this.zpp_inner.miny;
       this.zpp_inner.miny = y;
@@ -181,15 +181,15 @@ export class AABB {
   /** Width of the box (maxx − minx). Must be ≥ 0. */
   set width(width: number) {
     if (this.zpp_inner._immutable) {
-      throw new Error("Error: AABB is immutable");
+      throw new Error("AABB is immutable");
     }
     this.zpp_inner.validate();
     if (this.zpp_inner.maxx - this.zpp_inner.minx != width) {
       if (width !== width) {
-        throw new Error("Error: AABB::width cannot be NaN");
+        throw new Error("AABB::width cannot be NaN");
       }
       if (width < 0) {
-        throw new Error("Error: AABB::width (" + width + ") must be >= 0");
+        throw new Error("AABB::width (" + width + ") must be >= 0");
       }
       this.zpp_inner.validate();
       this.zpp_inner.maxx = this.zpp_inner.minx + width;
@@ -205,15 +205,15 @@ export class AABB {
   /** Height of the box (maxy − miny). Must be ≥ 0. */
   set height(height: number) {
     if (this.zpp_inner._immutable) {
-      throw new Error("Error: AABB is immutable");
+      throw new Error("AABB is immutable");
     }
     this.zpp_inner.validate();
     if (this.zpp_inner.maxy - this.zpp_inner.miny != height) {
       if (height !== height) {
-        throw new Error("Error: AABB::height cannot be NaN");
+        throw new Error("AABB::height cannot be NaN");
       }
       if (height < 0) {
-        throw new Error("Error: AABB::height (" + height + ") must be >= 0");
+        throw new Error("AABB::height (" + height + ") must be >= 0");
       }
       this.zpp_inner.validate();
       this.zpp_inner.maxy = this.zpp_inner.miny + height;
@@ -240,13 +240,13 @@ export class AABB {
    */
   set min(min: any) {
     if (min != null && min.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (this.zpp_inner._immutable) {
-      throw new Error("Error: AABB is immutable");
+      throw new Error("AABB is immutable");
     }
     if (min == null) {
-      throw new Error("Error: Cannot assign null to AABB::min");
+      throw new Error("Cannot assign null to AABB::min");
     }
 
     // NaN check on current bounds
@@ -254,18 +254,18 @@ export class AABB {
     const curMinX = this.zpp_inner.minx;
     this.zpp_inner.validate();
     if (curMinX != this.zpp_inner.minx) {
-      throw new Error("Error: AABB::min components cannot be NaN");
+      throw new Error("AABB::min components cannot be NaN");
     }
     this.zpp_inner.validate();
     const curMinY = this.zpp_inner.miny;
     this.zpp_inner.validate();
     if (curMinY != this.zpp_inner.miny) {
-      throw new Error("Error: AABB::min components cannot be NaN");
+      throw new Error("AABB::min components cannot be NaN");
     }
 
     // Validate min.x <= max.x
     if (min != null && min.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (min.zpp_inner._validate != null) {
       min.zpp_inner._validate();
@@ -275,18 +275,18 @@ export class AABB {
     this.zpp_inner.getmax();
     const maxVec = this.zpp_inner.wrap_max;
     if (maxVec != null && maxVec.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (maxVec.zpp_inner._validate != null) {
       maxVec.zpp_inner._validate();
     }
     if (newX > maxVec.zpp_inner.x) {
-      throw new Error("Error: Assignment would cause negative width");
+      throw new Error("Assignment would cause negative width");
     }
 
     // Validate min.y <= max.y
     if (min != null && min.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (min.zpp_inner._validate != null) {
       min.zpp_inner._validate();
@@ -296,13 +296,13 @@ export class AABB {
     this.zpp_inner.getmin();
     const minVecForMaxY = this.zpp_inner.wrap_max;
     if (minVecForMaxY != null && minVecForMaxY.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (minVecForMaxY.zpp_inner._validate != null) {
       minVecForMaxY.zpp_inner._validate();
     }
     if (newY > minVecForMaxY.zpp_inner.y) {
-      throw new Error("Error: Assignment would cause negative height");
+      throw new Error("Assignment would cause negative height");
     }
 
     // Assign via Vec2 set
@@ -331,13 +331,13 @@ export class AABB {
    */
   set max(max: any) {
     if (max != null && max.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (this.zpp_inner._immutable) {
-      throw new Error("Error: AABB is immutable");
+      throw new Error("AABB is immutable");
     }
     if (max == null) {
-      throw new Error("Error: Cannot assign null to AABB::max");
+      throw new Error("Cannot assign null to AABB::max");
     }
 
     // NaN check on current bounds
@@ -345,18 +345,18 @@ export class AABB {
     const curMinX = this.zpp_inner.minx;
     this.zpp_inner.validate();
     if (curMinX != this.zpp_inner.minx) {
-      throw new Error("Error: AABB::max components cannot be NaN");
+      throw new Error("AABB::max components cannot be NaN");
     }
     this.zpp_inner.validate();
     const curMinY = this.zpp_inner.miny;
     this.zpp_inner.validate();
     if (curMinY != this.zpp_inner.miny) {
-      throw new Error("Error: AABB::max components cannot be NaN");
+      throw new Error("AABB::max components cannot be NaN");
     }
 
     // Validate max.x >= min.x
     if (max != null && max.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (max.zpp_inner._validate != null) {
       max.zpp_inner._validate();
@@ -366,18 +366,18 @@ export class AABB {
     this.zpp_inner.getmin();
     const minVec = this.zpp_inner.wrap_min;
     if (minVec != null && minVec.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (minVec.zpp_inner._validate != null) {
       minVec.zpp_inner._validate();
     }
     if (newX < minVec.zpp_inner.x) {
-      throw new Error("Error: Assignment would cause negative width");
+      throw new Error("Assignment would cause negative width");
     }
 
     // Validate max.y >= min.y
     if (max != null && max.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (max.zpp_inner._validate != null) {
       max.zpp_inner._validate();
@@ -387,13 +387,13 @@ export class AABB {
     this.zpp_inner.getmin();
     const minVecForY = this.zpp_inner.wrap_min;
     if (minVecForY != null && minVecForY.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (minVecForY.zpp_inner._validate != null) {
       minVecForY.zpp_inner._validate();
     }
     if (newY < minVecForY.zpp_inner.y) {
-      throw new Error("Error: Assignment would cause negative height");
+      throw new Error("Assignment would cause negative height");
     }
 
     // Assign via Vec2 set
@@ -413,30 +413,30 @@ export class AABB {
   /** @internal Assign source Vec2 values to target Vec2 wrapper. */
   private _assignVec2(target: any, source: any): void {
     if (target != null && target.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (source != null && source.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const inner = target.zpp_inner;
     if (inner._immutable) {
-      throw new Error("Error: Vec2 is immutable");
+      throw new Error("Vec2 is immutable");
     }
     if (inner._isimmutable != null) {
       inner._isimmutable();
     }
     if (source == null) {
-      throw new Error("Error: Cannot assign null Vec2");
+      throw new Error("Cannot assign null Vec2");
     }
     if (source != null && source.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (source.zpp_inner._validate != null) {
       source.zpp_inner._validate();
     }
     const x = source.zpp_inner.x;
     if (source != null && source.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (source.zpp_inner._validate != null) {
       source.zpp_inner._validate();
@@ -444,29 +444,29 @@ export class AABB {
     const y = source.zpp_inner.y;
 
     if (target != null && target.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const inner2 = target.zpp_inner;
     if (inner2._immutable) {
-      throw new Error("Error: Vec2 is immutable");
+      throw new Error("Vec2 is immutable");
     }
     if (inner2._isimmutable != null) {
       inner2._isimmutable();
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
 
     let same;
     if (target != null && target.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (target.zpp_inner._validate != null) {
       target.zpp_inner._validate();
     }
     if (target.zpp_inner.x == x) {
       if (target != null && target.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       if (target.zpp_inner._validate != null) {
         target.zpp_inner._validate();
@@ -490,17 +490,17 @@ export class AABB {
     const zpp_nape = napeNs.zpp_nape;
 
     if (vec != null && vec.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const inner = vec.zpp_inner;
     if (inner._immutable) {
-      throw new Error("Error: Vec2 is immutable");
+      throw new Error("Vec2 is immutable");
     }
     if (inner._isimmutable != null) {
       inner._isimmutable();
     }
     if (vec.zpp_inner._inuse) {
-      throw new Error("Error: This Vec2 is not disposable");
+      throw new Error("This Vec2 is not disposable");
     }
     const innerRef = vec.zpp_inner;
     vec.zpp_inner.outer = null;

--- a/packages/nape-js/src/geom/ConvexResult.ts
+++ b/packages/nape-js/src/geom/ConvexResult.ts
@@ -21,7 +21,7 @@ export class ConvexResult {
   constructor() {
     this.zpp_inner = null!;
     if (!ZPP_ConvexRayResult.internal) {
-      throw new Error("Error: ConvexResult cannot be instantiated derp!");
+      throw new Error("ConvexResult cannot be instantiated derp!");
     }
   }
 
@@ -84,7 +84,7 @@ export class ConvexResult {
   /** @internal */
   private _disposed(): void {
     if (this.zpp_inner.next != null) {
-      throw new Error("Error: This object has been disposed of and cannot be used");
+      throw new Error("This object has been disposed of and cannot be used");
     }
   }
 }

--- a/packages/nape-js/src/geom/Geom.ts
+++ b/packages/nape-js/src/geom/Geom.ts
@@ -19,11 +19,11 @@ function getZppBody(b: any): any {
 /** Validate a Vec2 output parameter: not disposed, not immutable. */
 function validateOutVec2(v: any, _name: string): void {
   if (v != null && v.zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._immutable) {
-    throw new Error("Error: Vec2 is immutable");
+    throw new Error("Vec2 is immutable");
   }
   if (inner._isimmutable != null) {
     inner._isimmutable();
@@ -34,7 +34,7 @@ function validateOutVec2(v: any, _name: string): void {
 function validateShapeHasBody(s: any, method: string): void {
   const zpp = getZppShape(s);
   if (zpp?.body?.outer == null) {
-    throw new Error(`Error: Shape must be part of a Body to calculate ${method}`);
+    throw new Error(`Shape must be part of a Body to calculate ${method}`);
   }
 }
 
@@ -55,7 +55,7 @@ export class Geom {
     const zb2 = getZppBody(body2);
 
     if (zb1.shapes.head == null || zb2.shapes.head == null) {
-      throw new Error("Error: Bodies cannot be empty in calculating distances");
+      throw new Error("Bodies cannot be empty in calculating distances");
     }
 
     // Validate all shapes on both bodies
@@ -128,7 +128,7 @@ export class Geom {
     const zb2 = getZppBody(body2);
 
     if (zb1.shapes.head == null || zb2.shapes.head == null) {
-      throw new Error("Error: Bodies must have shapes to test for intersection.");
+      throw new Error("Bodies must have shapes to test for intersection.");
     }
 
     // Validate all shapes on both bodies

--- a/packages/nape-js/src/geom/GeomPoly.ts
+++ b/packages/nape-js/src/geom/GeomPoly.ts
@@ -53,7 +53,7 @@ export class GeomPoly {
 
   private _checkDisposed(): void {
     if (this.zpp_disp) {
-      throw new Error("Error: GeomPoly has been disposed and cannot be used!");
+      throw new Error("GeomPoly has been disposed and cannot be used!");
     }
   }
 
@@ -167,7 +167,7 @@ export class GeomPoly {
         : prop === "y"
           ? "bottommost"
           : "rightmost";
-      throw new Error("Error: empty GeomPoly has no defineable " + label + " vertex");
+      throw new Error("empty GeomPoly has no defineable " + label + " vertex");
     }
     let best = this.zpp_inner.vertices;
     let cur = best.next;
@@ -188,14 +188,14 @@ export class GeomPoly {
       for (let i = 0; i < vertices.length; i++) {
         const vite = vertices[i];
         if (vite == null) {
-          throw new Error("Error: Array<Vec2> contains null objects");
+          throw new Error("Array<Vec2> contains null objects");
         }
         if (!(vite instanceof Vec2)) {
-          throw new Error("Error: Array<Vec2> contains non Vec2 objects");
+          throw new Error("Array<Vec2> contains non Vec2 objects");
         }
         const v = vite as Vec2;
         if (v.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         v.zpp_inner.validate();
         const x = v.zpp_inner.x;
@@ -209,10 +209,10 @@ export class GeomPoly {
       while (iter.hasNext()) {
         const v1 = iter.next();
         if (v1 == null) {
-          throw new Error("Error: Vec2List contains null objects");
+          throw new Error("Vec2List contains null objects");
         }
         if (v1.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         v1.zpp_inner.validate();
         const x = v1.zpp_inner.x;
@@ -223,7 +223,7 @@ export class GeomPoly {
       }
     } else if (vertices instanceof GeomPoly) {
       if (vertices.zpp_disp) {
-        throw new Error("Error: GeomPoly has been disposed and cannot be used!");
+        throw new Error("GeomPoly has been disposed and cannot be used!");
       }
       const verts = vertices.zpp_inner.vertices;
       if (verts != null) {
@@ -336,7 +336,7 @@ export class GeomPoly {
   current(): Vec2 {
     this._checkDisposed();
     if (this.zpp_inner.vertices == null) {
-      throw new Error("Error: GeomPoly is empty");
+      throw new Error("GeomPoly is empty");
     }
     return this.zpp_inner.vertices.wrapper();
   }
@@ -348,10 +348,10 @@ export class GeomPoly {
   push(vertex: Vec2): this {
     this._checkDisposed();
     if (vertex != null && vertex.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (vertex == null) {
-      throw new Error("Error: Cannot push null vertex");
+      throw new Error("Cannot push null vertex");
     }
     vertex.zpp_inner.validate();
     const x = vertex.zpp_inner.x;
@@ -368,7 +368,7 @@ export class GeomPoly {
   pop(): this {
     this._checkDisposed();
     if (this.zpp_inner.vertices == null) {
-      throw new Error("Error: Cannot pop from empty polygon");
+      throw new Error("Cannot pop from empty polygon");
     }
     const retv = this._popHead();
     GeomPoly._freeVert(retv);
@@ -378,10 +378,10 @@ export class GeomPoly {
   unshift(vertex: Vec2): this {
     this._checkDisposed();
     if (vertex != null && vertex.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (vertex == null) {
-      throw new Error("Error: Cannot unshift null vertex");
+      throw new Error("Cannot unshift null vertex");
     }
     vertex.zpp_inner.validate();
     const x = vertex.zpp_inner.x;
@@ -398,7 +398,7 @@ export class GeomPoly {
   shift(): this {
     this._checkDisposed();
     if (this.zpp_inner.vertices == null) {
-      throw new Error("Error: Cannot shift from empty polygon");
+      throw new Error("Cannot shift from empty polygon");
     }
     const retv = this._shiftHead();
     GeomPoly._freeVert(retv);
@@ -459,7 +459,7 @@ export class GeomPoly {
 
   dispose(): void {
     if (this.zpp_disp) {
-      throw new Error("Error: GeomPoly has been disposed and cannot be used!");
+      throw new Error("GeomPoly has been disposed and cannot be used!");
     }
     this.clear();
     this.zpp_pool = null;
@@ -529,10 +529,10 @@ export class GeomPoly {
   contains(point: Vec2): boolean {
     this._checkDisposed();
     if (point != null && point.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (point == null) {
-      throw new Error("Error: GeomPoly::contains point cannot be null");
+      throw new Error("GeomPoly::contains point cannot be null");
     }
     point.zpp_inner.validate();
     const px = point.zpp_inner.x;
@@ -619,7 +619,7 @@ export class GeomPoly {
   simplify(epsilon: number): GeomPoly {
     this._checkDisposed();
     if (epsilon <= 0.0) {
-      throw new Error("Error: Epsilon should be > 0 for simplifying a GeomPoly");
+      throw new Error("Epsilon should be > 0 for simplifying a GeomPoly");
     }
     if (this._isDegenRing()) return this.copy();
     const x = ZPP_Simplify.simplify(this.zpp_inner.vertices, epsilon);
@@ -631,7 +631,7 @@ export class GeomPoly {
   simpleDecomposition(output?: any): any {
     this._checkDisposed();
     if (this._isDegenRing()) {
-      throw new Error("Error: Cannot decompose a degenerate polygon");
+      throw new Error("Cannot decompose a degenerate polygon");
     }
     const nape = getNape();
     const MPs = this.zpp_inner.vertices;
@@ -656,7 +656,7 @@ export class GeomPoly {
   monotoneDecomposition(output?: any): any {
     this._checkDisposed();
     if (this._isDegenRing()) {
-      throw new Error("Error: Cannot decompose a degenerate polygon");
+      throw new Error("Cannot decompose a degenerate polygon");
     }
     const nape = getNape();
     const poly = this.zpp_inner.vertices;
@@ -685,7 +685,7 @@ export class GeomPoly {
   convexDecomposition(delaunay: boolean = false, output?: any): any {
     this._checkDisposed();
     if (this._isDegenRing()) {
-      throw new Error("Error: Cannot decompose a degenerate polygon");
+      throw new Error("Cannot decompose a degenerate polygon");
     }
     const nape = getNape();
     const poly = this.zpp_inner.vertices;
@@ -729,7 +729,7 @@ export class GeomPoly {
   triangularDecomposition(delaunay: boolean = false, output?: any): any {
     this._checkDisposed();
     if (this._isDegenRing()) {
-      throw new Error("Error: Cannot decompose a degenerate polygon");
+      throw new Error("Cannot decompose a degenerate polygon");
     }
     const nape = getNape();
     const poly = this.zpp_inner.vertices;
@@ -825,16 +825,16 @@ export class GeomPoly {
   ): any {
     this._checkDisposed();
     if (!(this._isDegenRing() ? true : ZPP_Simple.isSimple(this.zpp_inner.vertices))) {
-      throw new Error("Error: Cut requires a truly simple polygon");
+      throw new Error("Cut requires a truly simple polygon");
     }
     if (start == null || end == null) {
-      throw new Error("Error: Cannot cut with null start/end's");
+      throw new Error("Cannot cut with null start/end's");
     }
     if (start.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (end.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
 
     const ret = ZPP_Cutter.run(
@@ -858,7 +858,7 @@ export class GeomPoly {
   transform(matrix: any): this {
     this._checkDisposed();
     if (matrix == null) {
-      throw new Error("Error: Cannot transform by null matrix");
+      throw new Error("Cannot transform by null matrix");
     }
     this._forEachVert((v: any) => {
       const t = matrix.zpp_inner.a * v.x + matrix.zpp_inner.b * v.y + matrix.zpp_inner.tx;
@@ -871,7 +871,7 @@ export class GeomPoly {
   bounds(): any {
     this._checkDisposed();
     if (this.zpp_inner.vertices == null) {
-      throw new Error("Error: empty GeomPoly has no defineable bounds");
+      throw new Error("empty GeomPoly has no defineable bounds");
     }
     let minx = 1e100;
     let miny = 1e100;

--- a/packages/nape-js/src/geom/GeomVertexIterator.ts
+++ b/packages/nape-js/src/geom/GeomVertexIterator.ts
@@ -14,7 +14,7 @@ import { ZPP_PubPool } from "../native/util/ZPP_PubPool";
 
 function GeomVertexIteratorCtor(this: any) {
   if (!ZPP_GeomVertexIterator.internal) {
-    throw new Error("Error: Cannot instantiate GeomVertexIterator");
+    throw new Error("Cannot instantiate GeomVertexIterator");
   }
 }
 
@@ -22,7 +22,7 @@ GeomVertexIteratorCtor.prototype.zpp_inner = null;
 
 GeomVertexIteratorCtor.prototype.hasNext = function (this: any): boolean {
   if (this.zpp_inner == null) {
-    throw new Error("Error: Iterator has been disposed");
+    throw new Error("Iterator has been disposed");
   }
   const ret = this.zpp_inner.ptr != this.zpp_inner.start || this.zpp_inner.first;
   this.zpp_inner.first = false;
@@ -38,7 +38,7 @@ GeomVertexIteratorCtor.prototype.hasNext = function (this: any): boolean {
 
 GeomVertexIteratorCtor.prototype.next = function (this: any): any {
   if (this.zpp_inner == null) {
-    throw new Error("Error: Iterator has been disposed");
+    throw new Error("Iterator has been disposed");
   }
   const vert = this.zpp_inner.ptr;
   if (vert.wrap == null) {
@@ -46,7 +46,7 @@ GeomVertexIteratorCtor.prototype.next = function (this: any): any {
     const y = vert.y;
 
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
 
     const nape = getNape();
@@ -80,11 +80,11 @@ GeomVertexIteratorCtor.prototype.next = function (this: any): any {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const inner = ret.zpp_inner;
       if (inner._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (inner._isimmutable != null) {
         inner._isimmutable();

--- a/packages/nape-js/src/geom/MarchingSquares.ts
+++ b/packages/nape-js/src/geom/MarchingSquares.ts
@@ -39,15 +39,15 @@ export class MarchingSquares {
   ): any {
     // --- Validate disposed Vec2 ---
     if (cellsize != null && (cellsize as any).zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (subgrid != null && (subgrid as any).zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
 
     // --- Validate required parameters ---
     if (iso == null) {
-      throw new Error("Error: MarchingSquares requires an iso function to operate");
+      throw new Error("MarchingSquares requires an iso function to operate");
     }
     if (bounds == null) {
       throw new Error(
@@ -66,7 +66,7 @@ export class MarchingSquares {
       cellZpp._validate();
     }
     if (cellZpp.x <= 0 || cellZpp.y <= 0) {
-      throw new Error("Error: MarchingSquares cannot operate with non-positive cell dimensions");
+      throw new Error("MarchingSquares cannot operate with non-positive cell dimensions");
     }
 
     // --- Validate quality ---
@@ -83,7 +83,7 @@ export class MarchingSquares {
         subZpp._validate();
       }
       if (subZpp.x <= 0 || subZpp.y <= 0) {
-        throw new Error("Error: MarchingSquares cannot with non-positive sub-grid dimensions");
+        throw new Error("MarchingSquares cannot with non-positive sub-grid dimensions");
       }
     }
 

--- a/packages/nape-js/src/geom/Mat23.ts
+++ b/packages/nape-js/src/geom/Mat23.ts
@@ -43,7 +43,7 @@ export class Mat23 {
     const vals = [a, b, tx, c, d, ty];
     for (let i = 0; i < vals.length; i++) {
       if (vals[i] !== vals[i]) {
-        throw new Error("Error: Mat23::" + names[i] + " cannot be NaN");
+        throw new Error("Mat23::" + names[i] + " cannot be NaN");
       }
     }
     zpp.setas(a, b, c, d, tx, ty);
@@ -60,7 +60,7 @@ export class Mat23 {
    */
   static rotation(angle: number): Mat23 {
     if (angle !== angle) {
-      throw new Error("Error: Cannot create rotation matrix with NaN angle");
+      throw new Error("Cannot create rotation matrix with NaN angle");
     }
     const cos = Math.cos(angle);
     const sin = Math.sin(angle);
@@ -108,7 +108,7 @@ export class Mat23 {
 
   private _setProp(name: string, value: number): void {
     if (value !== value) {
-      throw new Error("Error: Mat23::" + name + " cannot be NaN");
+      throw new Error("Mat23::" + name + " cannot be NaN");
     }
     (this.zpp_inner as any)[name] = value;
     this.zpp_inner.invalidate();
@@ -236,7 +236,7 @@ export class Mat23 {
    */
   set(matrix: Mat23): this {
     if (matrix == null) {
-      throw new Error("Error: Cannot set form null matrix");
+      throw new Error("Cannot set form null matrix");
     }
     const m = matrix.zpp_inner;
     this.zpp_inner.setas(m.a, m.b, m.c, m.d, m.tx, m.ty);
@@ -295,7 +295,7 @@ export class Mat23 {
    */
   inverse(): Mat23 {
     if (this.singular()) {
-      throw new Error("Error: Matrix is singular and cannot be inverted");
+      throw new Error("Matrix is singular and cannot be inverted");
     }
     const { a, b, c, d, tx, ty } = this.zpp_inner;
     const idet = 1.0 / (a * d - b * c);
@@ -325,7 +325,7 @@ export class Mat23 {
    */
   concat(matrix: Mat23): Mat23 {
     if (matrix == null) {
-      throw new Error("Error: Cannot concatenate with null Mat23");
+      throw new Error("Cannot concatenate with null Mat23");
     }
     const m = matrix.zpp_inner;
     const t = this.zpp_inner;
@@ -348,10 +348,10 @@ export class Mat23 {
    */
   transform(point: Vec2, noTranslation: boolean = false, weak: boolean = false): Vec2 {
     if (point != null && point.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (point == null) {
-      throw new Error("Error: Cannot transform null Vec2");
+      throw new Error("Cannot transform null Vec2");
     }
     point.zpp_inner.validate();
     const px = point.zpp_inner.x;
@@ -384,13 +384,13 @@ export class Mat23 {
    */
   inverseTransform(point: Vec2, noTranslation: boolean = false, weak: boolean = false): Vec2 {
     if (point != null && point.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (point == null) {
-      throw new Error("Error: Cannot transform null Vec2");
+      throw new Error("Cannot transform null Vec2");
     }
     if (this.singular()) {
-      throw new Error("Error: Matrix is singular and inverse transformation cannot be performed");
+      throw new Error("Matrix is singular and inverse transformation cannot be performed");
     }
     const { a, b, c, d, tx: mtx, ty: mty } = this.zpp_inner;
     const idet = 1.0 / (a * d - b * c);

--- a/packages/nape-js/src/geom/MatMN.ts
+++ b/packages/nape-js/src/geom/MatMN.ts
@@ -24,7 +24,7 @@ export class MatMN {
    */
   constructor(rows: number, cols: number) {
     if (rows <= 0 || cols <= 0) {
-      throw new Error("Error: MatMN::dimensions cannot be < 1");
+      throw new Error("MatMN::dimensions cannot be < 1");
     }
     this.zpp_inner = new ZPP_MatMN(rows, cols);
     this.zpp_inner.outer = this;
@@ -76,7 +76,7 @@ export class MatMN {
    */
   x(row: number, col: number): number {
     if (row < 0 || col < 0 || row >= this.zpp_inner.m || col >= this.zpp_inner.n) {
-      throw new Error("Error: MatMN indices out of range");
+      throw new Error("MatMN indices out of range");
     }
     return this.zpp_inner.x[row * this.zpp_inner.n + col];
   }
@@ -90,7 +90,7 @@ export class MatMN {
    */
   setx(row: number, col: number, value: number): number {
     if (row < 0 || col < 0 || row >= this.zpp_inner.m || col >= this.zpp_inner.n) {
-      throw new Error("Error: MatMN indices out of range");
+      throw new Error("MatMN indices out of range");
     }
     return (this.zpp_inner.x[row * this.zpp_inner.n + col] = value);
   }
@@ -149,7 +149,7 @@ export class MatMN {
       fst = false;
       for (let j = 0; j < this.zpp_inner.n; j++) {
         if (i < 0 || j < 0 || i >= this.zpp_inner.m || j >= this.zpp_inner.n) {
-          throw new Error("Error: MatMN indices out of range");
+          throw new Error("MatMN indices out of range");
         }
         ret += this.zpp_inner.x[i * this.zpp_inner.n + j] + " ";
       }
@@ -180,7 +180,7 @@ export class MatMN {
   mul(matrix: MatMN): MatMN {
     const y = matrix;
     if (this.zpp_inner.n !== y.zpp_inner.m) {
-      throw new Error("Error: Matrix dimensions aren't compatible");
+      throw new Error("Matrix dimensions aren't compatible");
     }
     const ret = new MatMN(this.zpp_inner.m, y.zpp_inner.n);
     for (let i = 0; i < this.zpp_inner.m; i++) {

--- a/packages/nape-js/src/geom/Ray.ts
+++ b/packages/nape-js/src/geom/Ray.ts
@@ -6,7 +6,7 @@ import { ZPP_Ray } from "../native/geom/ZPP_Ray";
 /** Read validated x from a Vec2. */
 function _readVec2X(v: Vec2): number {
   if (v.zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -16,7 +16,7 @@ function _readVec2X(v: Vec2): number {
 /** Read validated y from a Vec2. */
 function _readVec2Y(v: Vec2): number {
   if (v.zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -53,18 +53,18 @@ export class Ray {
   constructor(origin: Vec2, direction: Vec2) {
     // Validate origin
     if (origin?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (origin == null) {
-      throw new Error("Error: Ray::origin cannot be null");
+      throw new Error("Ray::origin cannot be null");
     }
 
     // Validate direction
     if (direction?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (direction == null) {
-      throw new Error("Error: Ray::direction cannot be null");
+      throw new Error("Ray::direction cannot be null");
     }
 
     // Create internal ZPP_Ray (allocates owned origin/direction Vec2 wrappers)
@@ -119,16 +119,16 @@ export class Ray {
    */
   static fromSegment(start: Vec2, end: Vec2): Ray {
     if (start?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (start == null) {
-      throw new Error("Error: Ray::fromSegment::start is null");
+      throw new Error("Ray::fromSegment::start is null");
     }
     if (end?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (end == null) {
-      throw new Error("Error: Ray::fromSegment::end is null");
+      throw new Error("Ray::fromSegment::end is null");
     }
 
     // Compute direction as (end - start), weak
@@ -145,7 +145,7 @@ export class Ray {
     const maxDist = Math.sqrt(ddx * ddx + ddy * ddy);
 
     if (maxDist !== maxDist) {
-      throw new Error("Error: maxDistance cannot be NaN");
+      throw new Error("maxDistance cannot be NaN");
     }
     ray.zpp_inner.maxdist = maxDist;
 
@@ -167,10 +167,10 @@ export class Ray {
   /** The ray's start point in world coordinates. */
   set origin(value: Vec2) {
     if (value?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Ray::origin cannot be null");
+      throw new Error("Ray::origin cannot be null");
     }
     this.zpp_inner.origin.set(value);
     _disposeWeakVec2(value);
@@ -184,10 +184,10 @@ export class Ray {
   /** The ray's direction vector (need not be unit length; the engine normalises internally). */
   set direction(value: Vec2) {
     if (value?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Ray::direction cannot be null");
+      throw new Error("Ray::direction cannot be null");
     }
     this.zpp_inner.direction.set(value);
     this.zpp_inner.zip_dir = true;
@@ -202,7 +202,7 @@ export class Ray {
   /** Maximum travel distance for raycasting queries. Defaults to `Infinity`. */
   set maxDistance(value: number) {
     if (value !== value) {
-      throw new Error("Error: maxDistance cannot be NaN");
+      throw new Error("maxDistance cannot be NaN");
     }
     this.zpp_inner.maxdist = value;
   }
@@ -264,7 +264,7 @@ export class Ray {
     const ret = new Ray(this.zpp_inner.origin, this.zpp_inner.direction);
     const md = this.zpp_inner.maxdist;
     if (md !== md) {
-      throw new Error("Error: maxDistance cannot be NaN");
+      throw new Error("maxDistance cannot be NaN");
     }
     ret.zpp_inner.maxdist = md;
     return ret;

--- a/packages/nape-js/src/geom/RayResult.ts
+++ b/packages/nape-js/src/geom/RayResult.ts
@@ -21,7 +21,7 @@ export class RayResult {
   constructor() {
     this.zpp_inner = null!;
     if (!ZPP_ConvexRayResult.internal) {
-      throw new Error("Error: RayResult cannot be instantiated derp!");
+      throw new Error("RayResult cannot be instantiated derp!");
     }
   }
 
@@ -90,7 +90,7 @@ export class RayResult {
   /** @internal */
   private _disposed(): void {
     if (this.zpp_inner.next != null) {
-      throw new Error("Error: This object has been disposed of and cannot be used");
+      throw new Error("This object has been disposed of and cannot be used");
     }
   }
 }

--- a/packages/nape-js/src/geom/Vec2.ts
+++ b/packages/nape-js/src/geom/Vec2.ts
@@ -40,7 +40,7 @@ export class Vec2 {
    */
   constructor(x: number = 0, y: number = 0) {
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
 
     let zpp: ZPP_Vec2;
@@ -67,7 +67,7 @@ export class Vec2 {
   /** @internal Check that this Vec2 has not been disposed. */
   private _checkDisposed(): void {
     if (this.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
   }
 
@@ -101,7 +101,7 @@ export class Vec2 {
     this._checkDisposed();
     this._checkImmutable();
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     this._validate();
     if (this.zpp_inner.x !== x || this.zpp_inner.y !== y) {
@@ -204,7 +204,7 @@ export class Vec2 {
    */
   static get(x: number = 0, y: number = 0, weak: boolean = false): Vec2 {
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     return Vec2._poolGet(x, y, weak);
   }
@@ -218,7 +218,7 @@ export class Vec2 {
    */
   static weak(x: number = 0, y: number = 0): Vec2 {
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     return Vec2._poolGet(x, y, true);
   }
@@ -235,10 +235,10 @@ export class Vec2 {
    */
   static fromPolar(length: number, angle: number, weak: boolean = false): Vec2 {
     if (length !== length) {
-      throw new Error("Error: Vec2::length cannot be NaN");
+      throw new Error("Vec2::length cannot be NaN");
     }
     if (angle !== angle) {
-      throw new Error("Error: Vec2::angle cannot be NaN");
+      throw new Error("Vec2::angle cannot be NaN");
     }
     const x = length * Math.cos(angle);
     const y = length * Math.sin(angle);
@@ -269,16 +269,16 @@ export class Vec2 {
    */
   static lerp(a: Vec2, b: Vec2, t: number, weak: boolean = false): Vec2 {
     if (a != null && a.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (b != null && b.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (a == null || b == null) {
-      throw new Error("Error: Cannot lerp with null Vec2");
+      throw new Error("Cannot lerp with null Vec2");
     }
     if (t !== t) {
-      throw new Error("Error: Cannot lerp with NaN t");
+      throw new Error("Cannot lerp with NaN t");
     }
     a.zpp_inner.validate();
     b.zpp_inner.validate();
@@ -301,10 +301,10 @@ export class Vec2 {
    */
   static eq(a: Vec2, b: Vec2, epsilon: number = 0): boolean {
     if (a != null && a.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (b != null && b.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (a == null || b == null) {
       const ret = a == null && b == null;
@@ -332,13 +332,13 @@ export class Vec2 {
    */
   static dsq(a: Vec2, b: Vec2): number {
     if (a != null && a.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (b != null && b.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (a == null || b == null) {
-      throw new Error("Error: Cannot compute squared distance between null Vec2");
+      throw new Error("Cannot compute squared distance between null Vec2");
     }
     a.zpp_inner.validate();
     const ax = a.zpp_inner.x;
@@ -363,13 +363,13 @@ export class Vec2 {
    */
   static distance(a: Vec2, b: Vec2): number {
     if (a != null && a.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (b != null && b.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (a == null || b == null) {
-      throw new Error("Error: Cannot compute squared distance between null Vec2");
+      throw new Error("Cannot compute squared distance between null Vec2");
     }
     a.zpp_inner.validate();
     const ax = a.zpp_inner.x;
@@ -403,7 +403,7 @@ export class Vec2 {
     this._validate();
     if (this.zpp_inner.x !== value) {
       if (value !== value) {
-        throw new Error("Error: Vec2::x cannot be NaN");
+        throw new Error("Vec2::x cannot be NaN");
       }
       this.zpp_inner.x = value;
       this._invalidate();
@@ -424,7 +424,7 @@ export class Vec2 {
     this._validate();
     if (this.zpp_inner.y !== value) {
       if (value !== value) {
-        throw new Error("Error: Vec2::y cannot be NaN");
+        throw new Error("Vec2::y cannot be NaN");
       }
       this.zpp_inner.y = value;
       this._invalidate();
@@ -450,14 +450,14 @@ export class Vec2 {
     this._checkDisposed();
     this._checkImmutable();
     if (value !== value) {
-      throw new Error("Error: Vec2::length cannot be NaN");
+      throw new Error("Vec2::length cannot be NaN");
     }
     this._validate();
     const x = this.zpp_inner.x;
     const y = this.zpp_inner.y;
     const lsq = x * x + y * y;
     if (lsq === 0) {
-      throw new Error("Error: Cannot set length of a zero vector");
+      throw new Error("Cannot set length of a zero vector");
     }
     const scale = value / Math.sqrt(lsq);
     this._setXY(x * scale, y * scale);
@@ -489,7 +489,7 @@ export class Vec2 {
     this._checkDisposed();
     this._checkImmutable();
     if (value !== value) {
-      throw new Error("Error: Vec2::angle cannot be NaN");
+      throw new Error("Vec2::angle cannot be NaN");
     }
     this._validate();
     const x = this.zpp_inner.x;
@@ -527,11 +527,11 @@ export class Vec2 {
   set(vector: Vec2): this {
     this._checkDisposed();
     if (vector != null && vector.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     this._checkImmutable();
     if (vector == null) {
-      throw new Error("Error: Cannot assign null Vec2");
+      throw new Error("Cannot assign null Vec2");
     }
     vector.zpp_inner.validate();
     const x = vector.zpp_inner.x;
@@ -574,7 +574,7 @@ export class Vec2 {
   equals(other: Vec2, epsilon: number = 0): boolean {
     this._checkDisposed();
     if (other != null && other.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (other == null) {
       return false;
@@ -610,7 +610,7 @@ export class Vec2 {
     this._checkDisposed();
     this._checkImmutable();
     if (angle !== angle) {
-      throw new Error("Error: Cannot rotate Vec2 by NaN");
+      throw new Error("Cannot rotate Vec2 by NaN");
     }
     if (angle % (Math.PI * 2) !== 0) {
       const s = Math.sin(angle);
@@ -633,13 +633,13 @@ export class Vec2 {
   reflect(vec: Vec2, weak: boolean = false): Vec2 {
     this._checkDisposed();
     if (vec != null && vec.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     this._validate();
     const x = this.zpp_inner.x;
     const y = this.zpp_inner.y;
     if (Math.sqrt(x * x + y * y) === 0) {
-      throw new Error("Error: Cannot reflect in zero vector");
+      throw new Error("Cannot reflect in zero vector");
     }
     // normal = unit of this, then: result = vec - 2*(normal·vec)*normal
     const normal = Vec2._poolGet(x, y, true);
@@ -663,7 +663,7 @@ export class Vec2 {
     const y = this.zpp_inner.y;
     const lsq = x * x + y * y;
     if (Math.sqrt(lsq) === 0) {
-      throw new Error("Error: Cannot normalise vector of length 0");
+      throw new Error("Cannot normalise vector of length 0");
     }
     const imag = 1.0 / Math.sqrt(lsq);
     this._setXY(x * imag, y * imag);
@@ -685,7 +685,7 @@ export class Vec2 {
     const y = this.zpp_inner.y;
     const lsq = x * x + y * y;
     if (Math.sqrt(lsq) === 0) {
-      throw new Error("Error: Cannot normalise vector of length 0");
+      throw new Error("Cannot normalise vector of length 0");
     }
     const scale = 1 / Math.sqrt(lsq);
     return Vec2._poolGet(x * scale, y * scale, weak);
@@ -701,10 +701,10 @@ export class Vec2 {
   add(vector: Vec2, weak: boolean = false): Vec2 {
     this._checkDisposed();
     if (vector != null && vector.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (vector == null) {
-      throw new Error("Error: Cannot add null vectors");
+      throw new Error("Cannot add null vectors");
     }
     this._validate();
     vector.zpp_inner.validate();
@@ -726,10 +726,10 @@ export class Vec2 {
   addMul(vector: Vec2, scalar: number, weak: boolean = false): Vec2 {
     this._checkDisposed();
     if (vector != null && vector.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (vector == null) {
-      throw new Error("Error: Cannot add null vectors");
+      throw new Error("Cannot add null vectors");
     }
     this._validate();
     vector.zpp_inner.validate();
@@ -750,10 +750,10 @@ export class Vec2 {
   sub(vector: Vec2, weak: boolean = false): Vec2 {
     this._checkDisposed();
     if (vector != null && vector.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (vector == null) {
-      throw new Error("Error: Cannot subtract null vectors");
+      throw new Error("Cannot subtract null vectors");
     }
     this._validate();
     vector.zpp_inner.validate();
@@ -774,7 +774,7 @@ export class Vec2 {
   mul(scalar: number, weak: boolean = false): Vec2 {
     this._checkDisposed();
     if (scalar !== scalar) {
-      throw new Error("Error: Cannot multiply with NaN");
+      throw new Error("Cannot multiply with NaN");
     }
     this._validate();
     const x = this.zpp_inner.x * scalar;
@@ -791,11 +791,11 @@ export class Vec2 {
   addeq(vector: Vec2): this {
     this._checkDisposed();
     if (vector != null && vector.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     this._checkImmutable();
     if (vector == null) {
-      throw new Error("Error: Cannot add null vectors");
+      throw new Error("Cannot add null vectors");
     }
     this._validate();
     vector.zpp_inner.validate();
@@ -815,11 +815,11 @@ export class Vec2 {
   subeq(vector: Vec2): this {
     this._checkDisposed();
     if (vector != null && vector.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     this._checkImmutable();
     if (vector == null) {
-      throw new Error("Error: Cannot subtract null vectors");
+      throw new Error("Cannot subtract null vectors");
     }
     this._validate();
     vector.zpp_inner.validate();
@@ -840,7 +840,7 @@ export class Vec2 {
     this._checkDisposed();
     this._checkImmutable();
     if (scalar !== scalar) {
-      throw new Error("Error: Cannot multiply with NaN");
+      throw new Error("Cannot multiply with NaN");
     }
     this._validate();
     const x = this.zpp_inner.x * scalar;
@@ -858,10 +858,10 @@ export class Vec2 {
   dot(vector: Vec2): number {
     this._checkDisposed();
     if (vector != null && vector.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (vector == null) {
-      throw new Error("Error: Cannot take dot product with null vector");
+      throw new Error("Cannot take dot product with null vector");
     }
     this._validate();
     vector.zpp_inner.validate();
@@ -880,10 +880,10 @@ export class Vec2 {
   cross(vector: Vec2): number {
     this._checkDisposed();
     if (vector != null && vector.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (vector == null) {
-      throw new Error("Error: Cannot take cross product with null vector");
+      throw new Error("Cannot take cross product with null vector");
     }
     this._validate();
     vector.zpp_inner.validate();
@@ -912,11 +912,11 @@ export class Vec2 {
    */
   dispose(): void {
     if (this.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     this._checkImmutable();
     if (this.zpp_inner._inuse) {
-      throw new Error("Error: This Vec2 is not disposable");
+      throw new Error("This Vec2 is not disposable");
     }
 
     // Free the ZPP_Vec2 back to internal pool

--- a/packages/nape-js/src/geom/Vec2List.ts
+++ b/packages/nape-js/src/geom/Vec2List.ts
@@ -53,7 +53,7 @@ function Vec2Iterator(this: any) {
   this.zpp_i = 0;
   this.zpp_inner = null;
   if (!ZPP_Vec2List.internal) {
-    throw new Error("Error: Cannot instantiate Vec2Iterator derp!");
+    throw new Error("Cannot instantiate Vec2Iterator derp!");
   }
 }
 
@@ -111,7 +111,7 @@ function Vec2ListCtor(this: any) {
 
 Vec2ListCtor.fromArray = function (array: any[]): any {
   if (array == null) {
-    throw new Error("Error: Cannot convert null Array to Nape list");
+    throw new Error("Cannot convert null Array to Nape list");
   }
   const nape = getNape();
   const ret = new nape.geom.Vec2List();
@@ -150,7 +150,7 @@ Vec2ListCtor.prototype.has = function (this: any, obj: any): boolean {
 Vec2ListCtor.prototype.at = function (this: any, index: number): any {
   this.zpp_vm();
   if (index < 0 || index >= this.zpp_gl()) {
-    throw new Error("Error: Index out of bounds");
+    throw new Error("Index out of bounds");
   }
   if (this.zpp_inner.reverse_flag) {
     index = this.zpp_gl() - 1 - index;
@@ -169,7 +169,7 @@ Vec2ListCtor.prototype.at = function (this: any, index: number): any {
 
 Vec2ListCtor.prototype.push = function (this: any, obj: any): boolean {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   this.zpp_vm();
@@ -195,7 +195,7 @@ Vec2ListCtor.prototype.push = function (this: any, obj: any): boolean {
 
 Vec2ListCtor.prototype.unshift = function (this: any, obj: any): boolean {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   this.zpp_vm();
@@ -221,11 +221,11 @@ Vec2ListCtor.prototype.unshift = function (this: any, obj: any): boolean {
 
 Vec2ListCtor.prototype.pop = function (this: any): any {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   if (this.empty()) {
-    throw new Error("Error: Cannot remove from empty list");
+    throw new Error("Cannot remove from empty list");
   }
   this.zpp_vm();
   let ret: any;
@@ -258,11 +258,11 @@ Vec2ListCtor.prototype.pop = function (this: any): any {
 
 Vec2ListCtor.prototype.shift = function (this: any): any {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   if (this.empty()) {
-    throw new Error("Error: Cannot remove from empty list");
+    throw new Error("Cannot remove from empty list");
   }
   this.zpp_vm();
   let ret: any;
@@ -303,7 +303,7 @@ Vec2ListCtor.prototype.add = function (this: any, obj: any): boolean {
 
 Vec2ListCtor.prototype.remove = function (this: any, obj: any): boolean {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   this.zpp_vm();
@@ -330,7 +330,7 @@ Vec2ListCtor.prototype.remove = function (this: any, obj: any): boolean {
 
 Vec2ListCtor.prototype.clear = function (this: any): void {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   if (this.zpp_inner.reverse_flag) {
     while (!this.empty()) this.pop();
@@ -359,7 +359,7 @@ Vec2ListCtor.prototype.copy = function (this: any, deep?: boolean): any {
     if (deep) {
       // Deep copy: create a new Vec2 with same coordinates
       if (i != null && i.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = i.zpp_inner;
       if (_this._validate != null) _this._validate();
@@ -414,7 +414,7 @@ Vec2ListCtor.prototype.copy = function (this: any, deep?: boolean): any {
 
 Vec2ListCtor.prototype.merge = function (this: any, xs: any): void {
   if (xs == null) {
-    throw new Error("Error: Cannot merge with null list");
+    throw new Error("Cannot merge with null list");
   }
   const it = xs.iterator();
   while (it.hasNext()) {
@@ -440,7 +440,7 @@ Vec2ListCtor.prototype.toString = function (this: any): string {
 
 Vec2ListCtor.prototype.foreach = function (this: any, lambda: any): any {
   if (lambda == null) {
-    throw new Error("Error: Cannot execute null on list elements");
+    throw new Error("Cannot execute null on list elements");
   }
   const it = this.iterator();
   while (it.hasNext()) {
@@ -474,7 +474,7 @@ Vec2ListCtor.prototype.foreach = function (this: any, lambda: any): any {
 
 Vec2ListCtor.prototype.filter = function (this: any, lambda: any): any {
   if (lambda == null) {
-    throw new Error("Error: Cannot select elements of list with null");
+    throw new Error("Cannot select elements of list with null");
   }
   let i = 0;
   while (i < this.zpp_gl()) {

--- a/packages/nape-js/src/geom/Vec3.ts
+++ b/packages/nape-js/src/geom/Vec3.ts
@@ -55,14 +55,14 @@ export class Vec3 {
   /** @internal Check that this Vec3 has not been disposed. */
   private _checkDisposed(): void {
     if (this.zpp_disp) {
-      throw new Error("Error: Vec3 has been disposed and cannot be used!");
+      throw new Error("Vec3 has been disposed and cannot be used!");
     }
   }
 
   /** @internal Check immutability. */
   private _checkImmutable(): void {
     if (this.zpp_inner.immutable) {
-      throw new Error("Error: Vec3 is immutable");
+      throw new Error("Vec3 is immutable");
     }
   }
 
@@ -184,13 +184,13 @@ export class Vec3 {
   set length(value: number) {
     this._checkDisposed();
     if (value !== value) {
-      throw new Error("Error: Vec3::length cannot be NaN");
+      throw new Error("Vec3::length cannot be NaN");
     }
     this.zpp_inner.validate();
     const { x, y, z } = this.zpp_inner;
     const lsq = x * x + y * y + z * z;
     if (lsq === 0) {
-      throw new Error("Error: Cannot set length of a zero vector");
+      throw new Error("Cannot set length of a zero vector");
     }
     const scale = value / Math.sqrt(lsq);
     this._checkImmutable();
@@ -222,10 +222,10 @@ export class Vec3 {
   set(vector: Vec3): this {
     this._checkDisposed();
     if (vector != null && vector.zpp_disp) {
-      throw new Error("Error: Vec3 has been disposed and cannot be used!");
+      throw new Error("Vec3 has been disposed and cannot be used!");
     }
     if (vector == null) {
-      throw new Error("Error: Cannot assign null Vec3");
+      throw new Error("Cannot assign null Vec3");
     }
     vector.zpp_inner.validate();
     return this.setxyz(vector.zpp_inner.x, vector.zpp_inner.y, vector.zpp_inner.z);
@@ -259,7 +259,7 @@ export class Vec3 {
   equals(other: Vec3, epsilon: number = 0): boolean {
     this._checkDisposed();
     if (other != null && other.zpp_disp) {
-      throw new Error("Error: Vec3 has been disposed and cannot be used!");
+      throw new Error("Vec3 has been disposed and cannot be used!");
     }
     if (other == null) {
       return false;
@@ -303,10 +303,10 @@ export class Vec3 {
    */
   dispose(): void {
     if (this.zpp_disp) {
-      throw new Error("Error: Vec3 has been disposed and cannot be used!");
+      throw new Error("Vec3 has been disposed and cannot be used!");
     }
     if (this.zpp_inner.immutable) {
-      throw new Error("Error: This Vec3 is not disposable");
+      throw new Error("This Vec3 is not disposable");
     }
     this.zpp_pool = null;
     if (ZPP_PubPool.nextVec3 != null) {

--- a/packages/nape-js/src/geom/Winding.ts
+++ b/packages/nape-js/src/geom/Winding.ts
@@ -13,7 +13,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class Winding {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate Winding derp!");
+      throw new Error("Cannot instantiate Winding derp!");
     }
   }
 

--- a/packages/nape-js/src/helpers/ParticleEmitter.ts
+++ b/packages/nape-js/src/helpers/ParticleEmitter.ts
@@ -322,43 +322,43 @@ export class ParticleEmitter {
   private _destroyed = false;
 
   constructor(options: ParticleEmitterOptions) {
-    if (options == null) throw new Error("Error: options is required");
-    if (options.space == null) throw new Error("Error: options.space is required");
-    if (options.origin == null) throw new Error("Error: options.origin is required");
+    if (options == null) throw new Error("options is required");
+    if (options.space == null) throw new Error("options.space is required");
+    if (options.origin == null) throw new Error("options.origin is required");
 
     const lifetimeMin = options.lifetimeMin ?? 1;
     const lifetimeMax = options.lifetimeMax ?? 1;
     if (!isFinite(lifetimeMin) || lifetimeMin < 0) {
-      throw new Error("Error: options.lifetimeMin must be >= 0");
+      throw new Error("options.lifetimeMin must be >= 0");
     }
     if (!isFinite(lifetimeMax) || lifetimeMax < 0) {
-      throw new Error("Error: options.lifetimeMax must be >= 0");
+      throw new Error("options.lifetimeMax must be >= 0");
     }
     if (lifetimeMax < lifetimeMin) {
-      throw new Error("Error: options.lifetimeMax must be >= options.lifetimeMin");
+      throw new Error("options.lifetimeMax must be >= options.lifetimeMin");
     }
 
     const maxParticles = options.maxParticles ?? 512;
     if (!Number.isInteger(maxParticles) || maxParticles < 0) {
-      throw new Error("Error: options.maxParticles must be a non-negative integer");
+      throw new Error("options.maxParticles must be a non-negative integer");
     }
 
     const rate = options.rate ?? 0;
     if (!isFinite(rate) || rate < 0) {
-      throw new Error("Error: options.rate must be >= 0");
+      throw new Error("options.rate must be >= 0");
     }
     const burstCount = options.burstCount ?? 0;
     if (!Number.isInteger(burstCount) || burstCount < 0) {
-      throw new Error("Error: options.burstCount must be a non-negative integer");
+      throw new Error("options.burstCount must be a non-negative integer");
     }
     const burstInterval = options.burstInterval ?? 0;
     if (!isFinite(burstInterval) || burstInterval < 0) {
-      throw new Error("Error: options.burstInterval must be >= 0");
+      throw new Error("options.burstInterval must be >= 0");
     }
 
     const radius = options.particleRadius ?? 2;
     if (!isFinite(radius) || radius <= 0) {
-      throw new Error("Error: options.particleRadius must be > 0");
+      throw new Error("options.particleRadius must be > 0");
     }
 
     this.space = options.space;
@@ -574,7 +574,7 @@ export class ParticleEmitter {
    */
   emit(count: number): Body[] {
     if (this._destroyed) {
-      throw new Error("Error: ParticleEmitter has been destroyed");
+      throw new Error("ParticleEmitter has been destroyed");
     }
     if (!this.enabled) return [];
     if (count <= 0) return [];
@@ -692,9 +692,9 @@ export class ParticleEmitter {
    */
   update(dt: number): void {
     if (this._destroyed) {
-      throw new Error("Error: ParticleEmitter has been destroyed");
+      throw new Error("ParticleEmitter has been destroyed");
     }
-    if (dt < 0) throw new Error("Error: dt must be >= 0");
+    if (dt < 0) throw new Error("dt must be >= 0");
 
     // 1) deferred kills first so `_alive` reflects user requests before we
     //    apply lifetime / bounds checks.

--- a/packages/nape-js/src/helpers/RadialGravityField.ts
+++ b/packages/nape-js/src/helpers/RadialGravityField.ts
@@ -121,13 +121,13 @@ export class RadialGravityField {
 
   constructor(options: RadialGravityFieldOptions) {
     if (options == null) {
-      throw new Error("Error: options is required");
+      throw new Error("options is required");
     }
     if (options.source == null) {
-      throw new Error("Error: options.source is required (Vec2 or Body)");
+      throw new Error("options.source is required (Vec2 or Body)");
     }
     if (typeof options.strength !== "number" || !isFinite(options.strength)) {
-      throw new Error("Error: options.strength must be a finite number");
+      throw new Error("options.strength must be a finite number");
     }
 
     this.source = options.source;
@@ -141,13 +141,13 @@ export class RadialGravityField {
     this.enabled = options.enabled ?? true;
 
     if (this.maxRadius < 0) {
-      throw new Error("Error: options.maxRadius must be >= 0");
+      throw new Error("options.maxRadius must be >= 0");
     }
     if (this.minRadius < 0) {
-      throw new Error("Error: options.minRadius must be >= 0");
+      throw new Error("options.minRadius must be >= 0");
     }
     if (this.softening < 0) {
-      throw new Error("Error: options.softening must be >= 0");
+      throw new Error("options.softening must be >= 0");
     }
   }
 

--- a/packages/nape-js/src/helpers/createConcaveBody.ts
+++ b/packages/nape-js/src/helpers/createConcaveBody.ts
@@ -60,26 +60,26 @@ export interface ConcaveBodyOptions {
 export function createConcaveBody(vertices: Vec2[] | GeomPoly, options?: ConcaveBodyOptions): Body {
   // --- Validate input ---
   if (vertices == null) {
-    throw new Error("Error: vertices cannot be null");
+    throw new Error("vertices cannot be null");
   }
 
   // Build a GeomPoly (copy to avoid mutating user input)
   let geom: GeomPoly;
   if (vertices instanceof GeomPoly) {
     if (vertices.zpp_disp) {
-      throw new Error("Error: GeomPoly has been disposed and cannot be used!");
+      throw new Error("GeomPoly has been disposed and cannot be used!");
     }
     geom = vertices.copy();
   } else {
     if (!Array.isArray(vertices)) {
-      throw new Error("Error: vertices must be an Array<Vec2> or GeomPoly");
+      throw new Error("vertices must be an Array<Vec2> or GeomPoly");
     }
     if (vertices.length < 3) {
-      throw new Error("Error: At least 3 vertices are required, got " + vertices.length);
+      throw new Error("At least 3 vertices are required, got " + vertices.length);
     }
     for (let i = 0; i < vertices.length; i++) {
       if (vertices[i] == null) {
-        throw new Error("Error: vertices[" + i + "] is null");
+        throw new Error("vertices[" + i + "] is null");
       }
     }
     geom = new GeomPoly(vertices);
@@ -88,15 +88,15 @@ export function createConcaveBody(vertices: Vec2[] | GeomPoly, options?: Concave
   // Validate geometry
   if (geom.size() < 3) {
     geom.dispose();
-    throw new Error("Error: At least 3 vertices are required, got " + geom.size());
+    throw new Error("At least 3 vertices are required, got " + geom.size());
   }
   if (geom.isDegenerate()) {
     geom.dispose();
-    throw new Error("Error: Polygon is degenerate (zero area)");
+    throw new Error("Polygon is degenerate (zero area)");
   }
   if (!geom.isSimple()) {
     geom.dispose();
-    throw new Error("Error: Polygon is self-intersecting");
+    throw new Error("Polygon is self-intersecting");
   }
 
   // --- Optional simplification ---
@@ -108,7 +108,7 @@ export function createConcaveBody(vertices: Vec2[] | GeomPoly, options?: Concave
 
     if (geom.size() < 3 || geom.isDegenerate()) {
       geom.dispose();
-      throw new Error("Error: Polygon became degenerate after simplification (epsilon too large)");
+      throw new Error("Polygon became degenerate after simplification (epsilon too large)");
     }
   }
 

--- a/packages/nape-js/src/helpers/fractureBody.ts
+++ b/packages/nape-js/src/helpers/fractureBody.ts
@@ -90,13 +90,13 @@ export function fractureBody(
   // Find the first polygon shape on the body
   const shape = findPolygonShape(body);
   if (!shape) {
-    throw new Error("Error: fractureBody requires a body with at least one Polygon shape");
+    throw new Error("fractureBody requires a body with at least one Polygon shape");
   }
 
   // Extract world-space polygon vertices
   const worldVerts = getWorldVertices(shape);
   if (worldVerts.length < 3) {
-    throw new Error("Error: Polygon shape has fewer than 3 world vertices");
+    throw new Error("Polygon shape has fewer than 3 world vertices");
   }
 
   // Compute AABB of the polygon

--- a/packages/nape-js/src/helpers/tilemap.ts
+++ b/packages/nape-js/src/helpers/tilemap.ts
@@ -116,7 +116,7 @@ const DEFAULT_SOLID: TilemapSolidPredicate = (v) => v !== 0;
 function normalizeTileSize(tileSize: number | TilemapTileSize): TilemapTileSize {
   if (typeof tileSize === "number") {
     if (!isFinite(tileSize) || tileSize <= 0) {
-      throw new Error("Error: tileSize must be a positive finite number");
+      throw new Error("tileSize must be a positive finite number");
     }
     return { w: tileSize, h: tileSize };
   }
@@ -127,14 +127,14 @@ function normalizeTileSize(tileSize: number | TilemapTileSize): TilemapTileSize 
     tileSize.w <= 0 ||
     tileSize.h <= 0
   ) {
-    throw new Error("Error: tileSize.w and tileSize.h must be positive finite numbers");
+    throw new Error("tileSize.w and tileSize.h must be positive finite numbers");
   }
   return { w: tileSize.w, h: tileSize.h };
 }
 
 function gridDimensions(grid: TilemapGrid): { rows: number; cols: number } {
   if (grid == null) {
-    throw new Error("Error: grid cannot be null");
+    throw new Error("grid cannot be null");
   }
   const rows = grid.length;
   if (rows === 0) return { rows: 0, cols: 0 };
@@ -142,7 +142,7 @@ function gridDimensions(grid: TilemapGrid): { rows: number; cols: number } {
   for (let y = 0; y < rows; y++) {
     const row = grid[y];
     if (row == null) {
-      throw new Error("Error: grid row " + y + " is null");
+      throw new Error("grid row " + y + " is null");
     }
     if (row.length > cols) cols = row.length;
   }
@@ -283,7 +283,7 @@ export function meshTilemap(
  */
 export function buildTilemapBody(grid: TilemapGrid, options: TilemapOptions): Body {
   if (options == null) {
-    throw new Error("Error: options is required");
+    throw new Error("options is required");
   }
   const tileSize = normalizeTileSize(options.tileSize);
   const rects = meshTilemap(grid, { solid: options.solid, merge: options.merge });
@@ -327,19 +327,19 @@ export function buildTilemapBody(grid: TilemapGrid, options: TilemapOptions): Bo
  */
 export function tiledLayerToGrid(layer: TiledTileLayer): number[][] {
   if (layer == null) {
-    throw new Error("Error: layer cannot be null");
+    throw new Error("layer cannot be null");
   }
   const data = layer.data;
   if (data == null || typeof data.length !== "number") {
-    throw new Error("Error: layer.data must be array-like");
+    throw new Error("layer.data must be array-like");
   }
   const w = layer.width | 0;
   const h = layer.height | 0;
   if (w <= 0 || h <= 0) {
-    throw new Error("Error: layer.width / layer.height must be positive integers");
+    throw new Error("layer.width / layer.height must be positive integers");
   }
   if (data.length < w * h) {
-    throw new Error("Error: layer.data length is less than width * height");
+    throw new Error("layer.data length is less than width * height");
   }
   const grid: number[][] = [];
   for (let y = 0; y < h; y++) {
@@ -365,19 +365,19 @@ export function tiledLayerToGrid(layer: TiledTileLayer): number[][] {
  */
 export function ldtkLayerToGrid(layer: LDtkIntGridLayer): number[][] {
   if (layer == null) {
-    throw new Error("Error: layer cannot be null");
+    throw new Error("layer cannot be null");
   }
   const data = layer.intGridCsv;
   if (data == null || typeof data.length !== "number") {
-    throw new Error("Error: layer.intGridCsv must be array-like");
+    throw new Error("layer.intGridCsv must be array-like");
   }
   const w = (layer.__cWid ?? layer.cWid ?? 0) | 0;
   const h = (layer.__cHei ?? layer.cHei ?? 0) | 0;
   if (w <= 0 || h <= 0) {
-    throw new Error("Error: layer.__cWid / __cHei (or cWid / cHei) must be positive integers");
+    throw new Error("layer.__cWid / __cHei (or cWid / cHei) must be positive integers");
   }
   if (data.length < w * h) {
-    throw new Error("Error: layer.intGridCsv length is less than __cWid * __cHei");
+    throw new Error("layer.intGridCsv length is less than __cWid * __cHei");
   }
   const grid: number[][] = [];
   for (let y = 0; y < h; y++) {

--- a/packages/nape-js/src/native/callbacks/ZPP_BodyListener.ts
+++ b/packages/nape-js/src/native/callbacks/ZPP_BodyListener.ts
@@ -25,7 +25,7 @@ export class ZPP_BodyListener extends ZPP_Listener {
 
   immutable_options(): void {
     if (this.space != null && this.space.midstep) {
-      throw new Error("Error: Cannot change listener type options during space.step()");
+      throw new Error("Cannot change listener type options during space.step()");
     }
   }
 
@@ -118,7 +118,7 @@ export class ZPP_BodyListener extends ZPP_Listener {
 
   swapEvent(newev: number): void {
     if (newev != 2 && newev != 3) {
-      throw new Error("Error: BodyListener event must be either WAKE or SLEEP only");
+      throw new Error("BodyListener event must be either WAKE or SLEEP only");
     }
     this.removedFromSpace();
     this.event = newev;

--- a/packages/nape-js/src/native/callbacks/ZPP_ConstraintListener.ts
+++ b/packages/nape-js/src/native/callbacks/ZPP_ConstraintListener.ts
@@ -25,7 +25,7 @@ export class ZPP_ConstraintListener extends ZPP_Listener {
 
   immutable_options(): void {
     if (this.space != null && this.space.midstep) {
-      throw new Error("Error: Cannot change listener type options during space.step()");
+      throw new Error("Cannot change listener type options during space.step()");
     }
   }
 
@@ -118,7 +118,7 @@ export class ZPP_ConstraintListener extends ZPP_Listener {
 
   swapEvent(newev: number): void {
     if (newev != 2 && newev != 3 && newev != 4) {
-      throw new Error("Error: ConstraintListener event must be either WAKE or SLEEP only");
+      throw new Error("ConstraintListener event must be either WAKE or SLEEP only");
     }
     this.removedFromSpace();
     this.event = newev;

--- a/packages/nape-js/src/native/callbacks/ZPP_InteractionListener.ts
+++ b/packages/nape-js/src/native/callbacks/ZPP_InteractionListener.ts
@@ -506,9 +506,9 @@ export class ZPP_InteractionListener extends ZPP_Listener {
 
   swapEvent(newev: number): void {
     if (this.type == 3) {
-      throw new Error("Error: PreListener event can only be PRE");
+      throw new Error("PreListener event can only be PRE");
     } else if (newev != 0 && newev != 1 && newev != 6) {
-      throw new Error("Error: InteractionListener event must be either BEGIN, END, ONGOING");
+      throw new Error("InteractionListener event must be either BEGIN, END, ONGOING");
     }
     this.removedFromSpace();
     this.event = newev;

--- a/packages/nape-js/src/native/callbacks/ZPP_OptionType.ts
+++ b/packages/nape-js/src/native/callbacks/ZPP_OptionType.ts
@@ -196,7 +196,7 @@ export class ZPP_OptionType {
   append(list: any, val: any): void {
     const napeNs = ZPP_OptionType._nape;
     if (val == null) {
-      throw new Error("Error: Cannot append null, only CbType and CbType list values");
+      throw new Error("Cannot append null, only CbType and CbType list values");
     }
     // Check zpp_inner instanceof ZPP_CbType first (robust against bundler
     // code-splitting that duplicates the public CbType class), then fall back
@@ -239,13 +239,13 @@ export class ZPP_OptionType {
         const cb2 = cbs1[_g1];
         ++_g1;
         if (!(cb2?.zpp_inner instanceof ZPP_CbType) && !(cb2 instanceof napeNs.callbacks.CbType)) {
-          throw new Error("Error: Cannot append non-CbType or CbType list value");
+          throw new Error("Cannot append non-CbType or CbType list value");
         }
         const cbx = cb2;
         this.append_type(list, cbx.zpp_inner as ZPP_CbType);
       }
     } else {
-      throw new Error("Error: Cannot append non-CbType or CbType list value");
+      throw new Error("Cannot append non-CbType or CbType list value");
     }
   }
 }

--- a/packages/nape-js/src/native/constraint/ZPP_AngleJoint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_AngleJoint.ts
@@ -147,10 +147,10 @@ export class ZPP_AngleJoint extends ZPP_Constraint {
 
   override validate(): void {
     if (this.b1 == null || this.b2 == null) {
-      throw new Error("Error: AngleJoint cannot be simulated null bodies");
+      throw new Error("AngleJoint cannot be simulated null bodies");
     }
     if (this.b1 == this.b2) {
-      throw new Error("Error: AngleJoint cannot be simulated with body1 == body2");
+      throw new Error("AngleJoint cannot be simulated with body1 == body2");
     }
     if (this.b1.space != this.space || this.b2.space != this.space) {
       throw new Error(
@@ -158,10 +158,10 @@ export class ZPP_AngleJoint extends ZPP_Constraint {
       );
     }
     if (this.jointMin > this.jointMax) {
-      throw new Error("Error: AngleJoint must have jointMin <= jointMax");
+      throw new Error("AngleJoint must have jointMin <= jointMax");
     }
     if (this.b1.type != 2 && this.b2.type != 2) {
-      throw new Error("Error: Constraints cannot have both bodies non-dynamic");
+      throw new Error("Constraints cannot have both bodies non-dynamic");
     }
   }
 

--- a/packages/nape-js/src/native/constraint/ZPP_Constraint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_Constraint.ts
@@ -105,7 +105,7 @@ export class ZPP_Constraint {
   // --- Mid-step guard ---
   immutable_midstep(name: string): void {
     if (this.space != null && this.space.midstep) {
-      throw new Error("Error: Constraint::" + name + " cannot be set during space step()");
+      throw new Error("Constraint::" + name + " cannot be set during space step()");
     }
   }
 
@@ -352,10 +352,10 @@ export class ZPP_Constraint {
 
     const maxError = me.zpp_inner.maxError;
     if (maxError !== maxError) {
-      throw new Error("Error: Constraint::maxError cannot be NaN");
+      throw new Error("Constraint::maxError cannot be NaN");
     }
     if (maxError < 0) {
-      throw new Error("Error: Constraint::maxError must be >=0");
+      throw new Error("Constraint::maxError must be >=0");
     }
     if (ret.zpp_inner.maxError != maxError) {
       ret.zpp_inner.maxError = maxError;
@@ -364,10 +364,10 @@ export class ZPP_Constraint {
 
     const maxForce = me.zpp_inner.maxForce;
     if (maxForce !== maxForce) {
-      throw new Error("Error: Constraint::maxForce cannot be NaN");
+      throw new Error("Constraint::maxForce cannot be NaN");
     }
     if (maxForce < 0) {
-      throw new Error("Error: Constraint::maxForce must be >=0");
+      throw new Error("Constraint::maxForce must be >=0");
     }
     if (ret.zpp_inner.maxForce != maxForce) {
       ret.zpp_inner.maxForce = maxForce;
@@ -376,10 +376,10 @@ export class ZPP_Constraint {
 
     const damping = me.zpp_inner.damping;
     if (damping !== damping) {
-      throw new Error("Error: Constraint::Damping cannot be Nan");
+      throw new Error("Constraint::Damping cannot be Nan");
     }
     if (damping < 0) {
-      throw new Error("Error: Constraint::Damping must be >=0");
+      throw new Error("Constraint::Damping must be >=0");
     }
     if (ret.zpp_inner.damping != damping) {
       ret.zpp_inner.damping = damping;
@@ -390,10 +390,10 @@ export class ZPP_Constraint {
 
     const frequency = me.zpp_inner.frequency;
     if (frequency !== frequency) {
-      throw new Error("Error: Constraint::Frequency cannot be NaN");
+      throw new Error("Constraint::Frequency cannot be NaN");
     }
     if (frequency <= 0) {
-      throw new Error("Error: Constraint::Frequency must be >0");
+      throw new Error("Constraint::Frequency must be >0");
     }
     if (ret.zpp_inner.frequency != frequency) {
       ret.zpp_inner.frequency = frequency;

--- a/packages/nape-js/src/native/constraint/ZPP_DistanceJoint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_DistanceJoint.ts
@@ -194,10 +194,10 @@ export class ZPP_DistanceJoint extends ZPP_Constraint {
 
   override validate(): void {
     if (this.b1 == null || this.b2 == null) {
-      throw new Error("Error: DistanceJoint cannot be simulated null bodies");
+      throw new Error("DistanceJoint cannot be simulated null bodies");
     }
     if (this.b1 == this.b2) {
-      throw new Error("Error: DistanceJoint cannot be simulated with body1 == body2");
+      throw new Error("DistanceJoint cannot be simulated with body1 == body2");
     }
     if (this.b1.space != this.space || this.b2.space != this.space) {
       throw new Error(
@@ -205,10 +205,10 @@ export class ZPP_DistanceJoint extends ZPP_Constraint {
       );
     }
     if (this.jointMin > this.jointMax) {
-      throw new Error("Error: DistanceJoint must have jointMin <= jointMax");
+      throw new Error("DistanceJoint must have jointMin <= jointMax");
     }
     if (this.b1.type != 2 && this.b2.type != 2) {
-      throw new Error("Error: Constraints cannot have both bodies non-dynamic");
+      throw new Error("Constraints cannot have both bodies non-dynamic");
     }
   }
 
@@ -521,7 +521,7 @@ export class ZPP_DistanceJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (ZPP_PubPool.poolVec2 == null) {
@@ -552,21 +552,21 @@ export class ZPP_DistanceJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -574,7 +574,7 @@ export class ZPP_DistanceJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {

--- a/packages/nape-js/src/native/constraint/ZPP_LineJoint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_LineJoint.ts
@@ -102,7 +102,7 @@ export class ZPP_LineJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
 
     let ret: any;
@@ -135,20 +135,20 @@ export class ZPP_LineJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x !== x || y !== y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -157,7 +157,7 @@ export class ZPP_LineJoint extends ZPP_Constraint {
       let tmp: boolean;
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -337,10 +337,10 @@ export class ZPP_LineJoint extends ZPP_Constraint {
   override validate(): void {
     const napeNs = ZPP_Constraint._nape;
     if (this.b1 == null || this.b2 == null) {
-      throw new Error("Error: AngleJoint cannot be simulated null bodies");
+      throw new Error("AngleJoint cannot be simulated null bodies");
     }
     if (this.b1 == this.b2) {
-      throw new Error("Error: DistanceJoint cannot be simulated with body1 == body2");
+      throw new Error("DistanceJoint cannot be simulated with body1 == body2");
     }
     if (this.b1.space != this.space || this.b2.space != this.space) {
       throw new Error(
@@ -348,13 +348,13 @@ export class ZPP_LineJoint extends ZPP_Constraint {
       );
     }
     if (this.jointMin > this.jointMax) {
-      throw new Error("Error: DistanceJoint must have jointMin <= jointMax");
+      throw new Error("DistanceJoint must have jointMin <= jointMax");
     }
     if (this.nlocalx * this.nlocalx + this.nlocaly * this.nlocaly < napeNs.Config.epsilon) {
-      throw new Error("Error: DistanceJoint direction must be non-degenerate");
+      throw new Error("DistanceJoint direction must be non-degenerate");
     }
     if (this.b1.type != 2 && this.b2.type != 2) {
-      throw new Error("Error: Constraints cannot have both bodies non-dynamic");
+      throw new Error("Constraints cannot have both bodies non-dynamic");
     }
   }
 

--- a/packages/nape-js/src/native/constraint/ZPP_MotorJoint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_MotorJoint.ts
@@ -123,10 +123,10 @@ export class ZPP_MotorJoint extends ZPP_Constraint {
   override validate(): void {
     // Note: "AngleJoint" in the first error message matches the original Haxe source
     if (this.b1 == null || this.b2 == null) {
-      throw new Error("Error: AngleJoint cannot be simulated null bodies");
+      throw new Error("AngleJoint cannot be simulated null bodies");
     }
     if (this.b1 == this.b2) {
-      throw new Error("Error: MotorJoint cannot be simulated with body1 == body2");
+      throw new Error("MotorJoint cannot be simulated with body1 == body2");
     }
     if (this.b1.space != this.space || this.b2.space != this.space) {
       throw new Error(
@@ -134,7 +134,7 @@ export class ZPP_MotorJoint extends ZPP_Constraint {
       );
     }
     if (this.b1.type != 2 && this.b2.type != 2) {
-      throw new Error("Error: Constraints cannot have both bodies non-dynamic");
+      throw new Error("Constraints cannot have both bodies non-dynamic");
     }
   }
 

--- a/packages/nape-js/src/native/constraint/ZPP_PivotJoint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_PivotJoint.ts
@@ -122,7 +122,7 @@ export class ZPP_PivotJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -153,21 +153,21 @@ export class ZPP_PivotJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -175,7 +175,7 @@ export class ZPP_PivotJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -225,7 +225,7 @@ export class ZPP_PivotJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -256,21 +256,21 @@ export class ZPP_PivotJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -278,7 +278,7 @@ export class ZPP_PivotJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -323,7 +323,7 @@ export class ZPP_PivotJoint extends ZPP_Constraint {
 
   override validate(): void {
     if (this.b1 == null || this.b2 == null) {
-      throw new Error("Error: PivotJoint cannot be simulated null bodies");
+      throw new Error("PivotJoint cannot be simulated null bodies");
     }
     if (this.b1 == this.b2) {
       throw new Error(

--- a/packages/nape-js/src/native/constraint/ZPP_PulleyJoint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_PulleyJoint.ts
@@ -222,7 +222,7 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -253,21 +253,21 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -275,7 +275,7 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -327,7 +327,7 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -358,21 +358,21 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -380,7 +380,7 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -432,7 +432,7 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -463,21 +463,21 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -485,7 +485,7 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -537,7 +537,7 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -568,21 +568,21 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -590,7 +590,7 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -659,10 +659,10 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
 
   override validate(): void {
     if (this.b1 == null || this.b2 == null || this.b3 == null || this.b4 == null) {
-      throw new Error("Error: PulleyJoint cannot be simulated with null bodies");
+      throw new Error("PulleyJoint cannot be simulated with null bodies");
     }
     if (this.b1 == this.b2 || this.b3 == this.b4) {
-      throw new Error("Error: PulleyJoint cannot have body1==body2 or body3==body4");
+      throw new Error("PulleyJoint cannot have body1==body2 or body3==body4");
     }
     if (
       this.b1.space != this.space ||
@@ -675,13 +675,13 @@ export class ZPP_PulleyJoint extends ZPP_Constraint {
       );
     }
     if (this.jointMin > this.jointMax) {
-      throw new Error("Error: PulleyJoint must have jointMin <= jointMax");
+      throw new Error("PulleyJoint must have jointMin <= jointMax");
     }
     if (this.b1.type != 2 && this.b2.type != 2) {
-      throw new Error("Error: PulleyJoint cannot have both bodies in a linked pair non-dynamic");
+      throw new Error("PulleyJoint cannot have both bodies in a linked pair non-dynamic");
     }
     if (this.b3.type != 2 && this.b4.type != 2) {
-      throw new Error("Error: PulleyJoint cannot have both bodies in a linked pair non-dynamic");
+      throw new Error("PulleyJoint cannot have both bodies in a linked pair non-dynamic");
     }
   }
 

--- a/packages/nape-js/src/native/constraint/ZPP_SpringJoint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_SpringJoint.ts
@@ -169,10 +169,10 @@ export class ZPP_SpringJoint extends ZPP_Constraint {
 
   override validate(): void {
     if (this.b1 == null || this.b2 == null) {
-      throw new Error("Error: SpringJoint cannot be simulated null bodies");
+      throw new Error("SpringJoint cannot be simulated null bodies");
     }
     if (this.b1 == this.b2) {
-      throw new Error("Error: SpringJoint cannot be simulated with body1 == body2");
+      throw new Error("SpringJoint cannot be simulated with body1 == body2");
     }
     if (this.b1.space != this.space || this.b2.space != this.space) {
       throw new Error(
@@ -180,7 +180,7 @@ export class ZPP_SpringJoint extends ZPP_Constraint {
       );
     }
     if (this.b1.type != 2 && this.b2.type != 2) {
-      throw new Error("Error: Constraints cannot have both bodies non-dynamic");
+      throw new Error("Constraints cannot have both bodies non-dynamic");
     }
   }
 
@@ -367,7 +367,7 @@ export class ZPP_SpringJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (ZPP_PubPool.poolVec2 == null) {
@@ -398,21 +398,21 @@ export class ZPP_SpringJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -420,7 +420,7 @@ export class ZPP_SpringJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {

--- a/packages/nape-js/src/native/constraint/ZPP_UserConstraint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_UserConstraint.ts
@@ -458,7 +458,7 @@ export class ZPP_UserConstraint extends ZPP_Constraint {
       const b2 = b1.velx;
       const _this = this.vec3;
       if (_this != null && _this.zpp_disp) {
-        throw new Error("Error: " + "Vec3" + " has been disposed and cannot be used!");
+        throw new Error("Vec3 has been disposed and cannot be used!");
       }
       const _this1 = _this.zpp_inner;
       if (_this1._validate != null) {
@@ -470,7 +470,7 @@ export class ZPP_UserConstraint extends ZPP_Constraint {
       const b4 = b3.vely;
       const _this2 = this.vec3;
       if (_this2 != null && _this2.zpp_disp) {
-        throw new Error("Error: " + "Vec3" + " has been disposed and cannot be used!");
+        throw new Error("Vec3 has been disposed and cannot be used!");
       }
       const _this3 = _this2.zpp_inner;
       if (_this3._validate != null) {
@@ -482,7 +482,7 @@ export class ZPP_UserConstraint extends ZPP_Constraint {
       const b6 = b5.angvel;
       const _this4 = this.vec3;
       if (_this4 != null && _this4.zpp_disp) {
-        throw new Error("Error: " + "Vec3" + " has been disposed and cannot be used!");
+        throw new Error("Vec3 has been disposed and cannot be used!");
       }
       const _this5 = _this4.zpp_inner;
       if (_this5._validate != null) {
@@ -525,7 +525,7 @@ export class ZPP_UserConstraint extends ZPP_Constraint {
       const b2 = b1.velx;
       const _this = this.vec3;
       if (_this != null && _this.zpp_disp) {
-        throw new Error("Error: " + "Vec3" + " has been disposed and cannot be used!");
+        throw new Error("Vec3 has been disposed and cannot be used!");
       }
       const _this1 = _this.zpp_inner;
       if (_this1._validate != null) {
@@ -537,7 +537,7 @@ export class ZPP_UserConstraint extends ZPP_Constraint {
       const b4 = b3.vely;
       const _this2 = this.vec3;
       if (_this2 != null && _this2.zpp_disp) {
-        throw new Error("Error: " + "Vec3" + " has been disposed and cannot be used!");
+        throw new Error("Vec3 has been disposed and cannot be used!");
       }
       const _this3 = _this2.zpp_inner;
       if (_this3._validate != null) {
@@ -549,7 +549,7 @@ export class ZPP_UserConstraint extends ZPP_Constraint {
       const b6 = b5.angvel;
       const _this4 = this.vec3;
       if (_this4 != null && _this4.zpp_disp) {
-        throw new Error("Error: " + "Vec3" + " has been disposed and cannot be used!");
+        throw new Error("Vec3 has been disposed and cannot be used!");
       }
       const _this5 = _this4.zpp_inner;
       if (_this5._validate != null) {
@@ -594,7 +594,7 @@ export class ZPP_UserConstraint extends ZPP_Constraint {
       const b2 = b1.posx;
       const _this = this.vec3;
       if (_this != null && _this.zpp_disp) {
-        throw new Error("Error: " + "Vec3" + " has been disposed and cannot be used!");
+        throw new Error("Vec3 has been disposed and cannot be used!");
       }
       const _this1 = _this.zpp_inner;
       if (_this1._validate != null) {
@@ -606,7 +606,7 @@ export class ZPP_UserConstraint extends ZPP_Constraint {
       const b4 = b3.posy;
       const _this2 = this.vec3;
       if (_this2 != null && _this2.zpp_disp) {
-        throw new Error("Error: " + "Vec3" + " has been disposed and cannot be used!");
+        throw new Error("Vec3 has been disposed and cannot be used!");
       }
       const _this3 = _this2.zpp_inner;
       if (_this3._validate != null) {
@@ -616,7 +616,7 @@ export class ZPP_UserConstraint extends ZPP_Constraint {
 
       const _this4 = this.vec3;
       if (_this4 != null && _this4.zpp_disp) {
-        throw new Error("Error: " + "Vec3" + " has been disposed and cannot be used!");
+        throw new Error("Vec3 has been disposed and cannot be used!");
       }
       const _this5 = _this4.zpp_inner;
       if (_this5._validate != null) {

--- a/packages/nape-js/src/native/constraint/ZPP_WeldJoint.ts
+++ b/packages/nape-js/src/native/constraint/ZPP_WeldJoint.ts
@@ -136,7 +136,7 @@ export class ZPP_WeldJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -167,21 +167,21 @@ export class ZPP_WeldJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -189,7 +189,7 @@ export class ZPP_WeldJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -239,7 +239,7 @@ export class ZPP_WeldJoint extends ZPP_Constraint {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -270,21 +270,21 @@ export class ZPP_WeldJoint extends ZPP_Constraint {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -292,7 +292,7 @@ export class ZPP_WeldJoint extends ZPP_Constraint {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -337,10 +337,10 @@ export class ZPP_WeldJoint extends ZPP_Constraint {
 
   override validate(): void {
     if (this.b1 == null || this.b2 == null) {
-      throw new Error("Error: AngleJoint cannot be simulated null bodies");
+      throw new Error("AngleJoint cannot be simulated null bodies");
     }
     if (this.b1 == this.b2) {
-      throw new Error("Error: WeldJoint cannot be simulated with body1 == body2");
+      throw new Error("WeldJoint cannot be simulated with body1 == body2");
     }
     if (this.b1.space != this.space || this.b2.space != this.space) {
       throw new Error(
@@ -348,7 +348,7 @@ export class ZPP_WeldJoint extends ZPP_Constraint {
       );
     }
     if (this.b1.type != 2 && this.b2.type != 2) {
-      throw new Error("Error: Constraints cannot have both bodies non-dynamic");
+      throw new Error("Constraints cannot have both bodies non-dynamic");
     }
   }
 

--- a/packages/nape-js/src/native/dynamics/ZPP_ColArbiter.ts
+++ b/packages/nape-js/src/native/dynamics/ZPP_ColArbiter.ts
@@ -203,7 +203,7 @@ export class ZPP_ColArbiter extends ZPP_Arbiter {
 
   normal_validate(): void {
     if (this.cleared) {
-      throw new Error("Error: Arbiter not currently in use");
+      throw new Error("Arbiter not currently in use");
     }
     this.wrap_normal.zpp_inner.x = this.nx;
     this.wrap_normal.zpp_inner.y = this.ny;
@@ -250,21 +250,21 @@ export class ZPP_ColArbiter extends ZPP_Arbiter {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x !== x || y !== y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -272,7 +272,7 @@ export class ZPP_ColArbiter extends ZPP_Arbiter {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {

--- a/packages/nape-js/src/native/dynamics/ZPP_Contact.ts
+++ b/packages/nape-js/src/native/dynamics/ZPP_Contact.ts
@@ -102,7 +102,7 @@ export class ZPP_Contact {
 
   position_validate(): void {
     if (this.inactiveme()) {
-      throw new Error("Error: Contact not currently in use");
+      throw new Error("Contact not currently in use");
     }
     this.wrap_position.zpp_inner.x = this.px;
     this.wrap_position.zpp_inner.y = this.py;
@@ -142,18 +142,18 @@ export class ZPP_Contact {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -161,7 +161,7 @@ export class ZPP_Contact {
       }
       if (ret.zpp_inner.x == 0) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {

--- a/packages/nape-js/src/native/dynamics/ZPP_FluidArbiter.ts
+++ b/packages/nape-js/src/native/dynamics/ZPP_FluidArbiter.ts
@@ -117,7 +117,7 @@ export class ZPP_FluidArbiter extends ZPP_Arbiter {
 
   position_validate(): void {
     if (!this.active) {
-      throw new Error("Error: Arbiter not currently in use");
+      throw new Error("Arbiter not currently in use");
     }
     this.wrap_position.zpp_inner.x = this.centroidx;
     this.wrap_position.zpp_inner.y = this.centroidy;
@@ -162,18 +162,18 @@ export class ZPP_FluidArbiter extends ZPP_Arbiter {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -181,7 +181,7 @@ export class ZPP_FluidArbiter extends ZPP_Arbiter {
       }
       if (ret.zpp_inner.x == 0) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {

--- a/packages/nape-js/src/native/dynamics/ZPP_SpaceArbiterList.ts
+++ b/packages/nape-js/src/native/dynamics/ZPP_SpaceArbiterList.ts
@@ -142,27 +142,27 @@ export class ZPP_SpaceArbiterList {
   // ========== Immutable overrides ==========
 
   push(_obj: any): void {
-    throw new Error("Error: ArbiterList is immutable");
+    throw new Error("ArbiterList is immutable");
   }
 
   pop(): any {
-    throw new Error("Error: ArbiterList is immutable");
+    throw new Error("ArbiterList is immutable");
   }
 
   unshift(_obj: any): void {
-    throw new Error("Error: ArbiterList is immutable");
+    throw new Error("ArbiterList is immutable");
   }
 
   shift(): any {
-    throw new Error("Error: ArbiterList is immutable");
+    throw new Error("ArbiterList is immutable");
   }
 
   remove(_obj: any): void {
-    throw new Error("Error: ArbiterList is immutable");
+    throw new Error("ArbiterList is immutable");
   }
 
   clear(): void {
-    throw new Error("Error: ArbiterList is immutable");
+    throw new Error("ArbiterList is immutable");
   }
 
   // ========== Indexed access ==========
@@ -170,7 +170,7 @@ export class ZPP_SpaceArbiterList {
   at(index: number): any {
     this.zpp_vm();
     if (index < 0 || index >= this.zpp_gl()) {
-      throw new Error("Error: Index out of bounds");
+      throw new Error("Index out of bounds");
     }
     let ret: any = null;
     let accum_length = 0;

--- a/packages/nape-js/src/native/geom/ZPP_AABB.ts
+++ b/packages/nape-js/src/native/geom/ZPP_AABB.ts
@@ -132,7 +132,7 @@ export class ZPP_AABB {
     const napeNs = ZPP_AABB._nape;
 
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
 
     let ret: any;
@@ -165,15 +165,15 @@ export class ZPP_AABB {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const inner = ret.zpp_inner;
       if (inner._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (inner._isimmutable != null) inner._isimmutable();
       if (x !== x || y !== y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       if (inner._validate != null) inner._validate();
       if (inner.x !== x || inner.y !== y) {

--- a/packages/nape-js/src/native/geom/ZPP_Collide.ts
+++ b/packages/nape-js/src/native/geom/ZPP_Collide.ts
@@ -1243,7 +1243,7 @@ export class ZPP_Collide {
                 if (_this.type == 1) {
                   const _this1 = _this.polygon;
                   if (_this1.lverts.next == null) {
-                    throw new Error("Error: An empty polygon has no meaningful localCOM");
+                    throw new Error("An empty polygon has no meaningful localCOM");
                   }
                   if (_this1.lverts.next.next == null) {
                     _this1.localCOMx = _this1.lverts.next.x;
@@ -1357,7 +1357,7 @@ export class ZPP_Collide {
                   if (_this3.type == 1) {
                     const _this4 = _this3.polygon;
                     if (_this4.lverts.next == null) {
-                      throw new Error("Error: An empty polygon has no meaningful localCOM");
+                      throw new Error("An empty polygon has no meaningful localCOM");
                     }
                     if (_this4.lverts.next.next == null) {
                       _this4.localCOMx = _this4.lverts.next.x;
@@ -2196,7 +2196,7 @@ export class ZPP_Collide {
                       if (_this6.type == 1) {
                         const _this7 = _this6.polygon;
                         if (_this7.lverts.next == null) {
-                          throw new Error("Error: An empty polygon has no meaningful localCOM");
+                          throw new Error("An empty polygon has no meaningful localCOM");
                         }
                         if (_this7.lverts.next.next == null) {
                           _this7.localCOMx = _this7.lverts.next.x;

--- a/packages/nape-js/src/native/geom/ZPP_ConvexRayResult.ts
+++ b/packages/nape-js/src/native/geom/ZPP_ConvexRayResult.ts
@@ -95,7 +95,7 @@ export class ZPP_ConvexRayResult {
 
   disposed(): void {
     if (this.next != null) {
-      throw new Error("Error: This object has been disposed of and cannot be used");
+      throw new Error("This object has been disposed of and cannot be used");
     }
   }
 
@@ -135,17 +135,17 @@ export class ZPP_ConvexRayResult {
 
     // Validate the Vec2 wrapper
     if (v != null && v.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const zppInner: ZPP_Vec2 = v.zpp_inner;
     if (zppInner._immutable) {
-      throw new Error("Error: Vec2 is immutable");
+      throw new Error("Vec2 is immutable");
     }
     if (zppInner._isimmutable != null) {
       zppInner._isimmutable();
     }
     if (zppInner._inuse) {
-      throw new Error("Error: This Vec2 is not disposable");
+      throw new Error("This Vec2 is not disposable");
     }
 
     // Disconnect wrapper ↔ inner

--- a/packages/nape-js/src/native/geom/ZPP_Cutter.ts
+++ b/packages/nape-js/src/native/geom/ZPP_Cutter.ts
@@ -45,7 +45,7 @@ export class ZPP_Cutter {
     const zpp_nape = napeNs.__zpp;
 
     if (_start != null && _start.zpp_disp) {
-      throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const _this = _start.zpp_inner;
     if (_this._validate != null) {
@@ -53,7 +53,7 @@ export class ZPP_Cutter {
     }
     const px = _start.zpp_inner.x;
     if (_start != null && _start.zpp_disp) {
-      throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const _this1 = _start.zpp_inner;
     if (_this1._validate != null) {
@@ -61,7 +61,7 @@ export class ZPP_Cutter {
     }
     const py = _start.zpp_inner.y;
     if (_end != null && _end.zpp_disp) {
-      throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const _this2 = _end.zpp_inner;
     if (_this2._validate != null) {
@@ -69,7 +69,7 @@ export class ZPP_Cutter {
     }
     const dx = _end.zpp_inner.x - px;
     if (_end != null && _end.zpp_disp) {
-      throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const _this3 = _end.zpp_inner;
     if (_this3._validate != null) {
@@ -861,17 +861,17 @@ export class ZPP_Cutter {
             o.wrap.zpp_inner._inuse = false;
             const _this4 = o.wrap;
             if (_this4 != null && _this4.zpp_disp) {
-              throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+              throw new Error("Vec2 has been disposed and cannot be used!");
             }
             const _this5 = _this4.zpp_inner;
             if (_this5._immutable) {
-              throw new Error("Error: Vec2 is immutable");
+              throw new Error("Vec2 is immutable");
             }
             if (_this5._isimmutable != null) {
               _this5._isimmutable();
             }
             if (_this4.zpp_inner._inuse) {
-              throw new Error("Error: This Vec2 is not disposable");
+              throw new Error("This Vec2 is not disposable");
             }
             const inner = _this4.zpp_inner;
             _this4.zpp_inner.outer = null;
@@ -911,17 +911,17 @@ export class ZPP_Cutter {
             o3.wrap.zpp_inner._inuse = false;
             const _this6 = o3.wrap;
             if (_this6 != null && _this6.zpp_disp) {
-              throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+              throw new Error("Vec2 has been disposed and cannot be used!");
             }
             const _this7 = _this6.zpp_inner;
             if (_this7._immutable) {
-              throw new Error("Error: Vec2 is immutable");
+              throw new Error("Vec2 is immutable");
             }
             if (_this7._isimmutable != null) {
               _this7._isimmutable();
             }
             if (_this6.zpp_inner._inuse) {
-              throw new Error("Error: This Vec2 is not disposable");
+              throw new Error("This Vec2 is not disposable");
             }
             const inner1 = _this6.zpp_inner;
             _this6.zpp_inner.outer = null;
@@ -966,17 +966,17 @@ export class ZPP_Cutter {
                 o6.wrap.zpp_inner._inuse = false;
                 const _this8 = o6.wrap;
                 if (_this8 != null && _this8.zpp_disp) {
-                  throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                  throw new Error("Vec2 has been disposed and cannot be used!");
                 }
                 const _this9 = _this8.zpp_inner;
                 if (_this9._immutable) {
-                  throw new Error("Error: Vec2 is immutable");
+                  throw new Error("Vec2 is immutable");
                 }
                 if (_this9._isimmutable != null) {
                   _this9._isimmutable();
                 }
                 if (_this8.zpp_inner._inuse) {
-                  throw new Error("Error: This Vec2 is not disposable");
+                  throw new Error("This Vec2 is not disposable");
                 }
                 const inner2 = _this8.zpp_inner;
                 _this8.zpp_inner.outer = null;
@@ -1016,17 +1016,17 @@ export class ZPP_Cutter {
                 o9.wrap.zpp_inner._inuse = false;
                 const _this10 = o9.wrap;
                 if (_this10 != null && _this10.zpp_disp) {
-                  throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                  throw new Error("Vec2 has been disposed and cannot be used!");
                 }
                 const _this11 = _this10.zpp_inner;
                 if (_this11._immutable) {
-                  throw new Error("Error: Vec2 is immutable");
+                  throw new Error("Vec2 is immutable");
                 }
                 if (_this11._isimmutable != null) {
                   _this11._isimmutable();
                 }
                 if (_this10.zpp_inner._inuse) {
-                  throw new Error("Error: This Vec2 is not disposable");
+                  throw new Error("This Vec2 is not disposable");
                 }
                 const inner3 = _this10.zpp_inner;
                 _this10.zpp_inner.outer = null;
@@ -1070,17 +1070,17 @@ export class ZPP_Cutter {
                 o12.wrap.zpp_inner._inuse = false;
                 const _this12 = o12.wrap;
                 if (_this12 != null && _this12.zpp_disp) {
-                  throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                  throw new Error("Vec2 has been disposed and cannot be used!");
                 }
                 const _this13 = _this12.zpp_inner;
                 if (_this13._immutable) {
-                  throw new Error("Error: Vec2 is immutable");
+                  throw new Error("Vec2 is immutable");
                 }
                 if (_this13._isimmutable != null) {
                   _this13._isimmutable();
                 }
                 if (_this12.zpp_inner._inuse) {
-                  throw new Error("Error: This Vec2 is not disposable");
+                  throw new Error("This Vec2 is not disposable");
                 }
                 const inner4 = _this12.zpp_inner;
                 _this12.zpp_inner.outer = null;
@@ -1118,17 +1118,17 @@ export class ZPP_Cutter {
                 o15.wrap.zpp_inner._inuse = false;
                 const _this14 = o15.wrap;
                 if (_this14 != null && _this14.zpp_disp) {
-                  throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                  throw new Error("Vec2 has been disposed and cannot be used!");
                 }
                 const _this15 = _this14.zpp_inner;
                 if (_this15._immutable) {
-                  throw new Error("Error: Vec2 is immutable");
+                  throw new Error("Vec2 is immutable");
                 }
                 if (_this15._isimmutable != null) {
                   _this15._isimmutable();
                 }
                 if (_this14.zpp_inner._inuse) {
-                  throw new Error("Error: This Vec2 is not disposable");
+                  throw new Error("This Vec2 is not disposable");
                 }
                 const inner5 = _this14.zpp_inner;
                 _this14.zpp_inner.outer = null;
@@ -1221,17 +1221,17 @@ export class ZPP_Cutter {
             o18.wrap.zpp_inner._inuse = false;
             const _this16 = o18.wrap;
             if (_this16 != null && _this16.zpp_disp) {
-              throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+              throw new Error("Vec2 has been disposed and cannot be used!");
             }
             const _this17 = _this16.zpp_inner;
             if (_this17._immutable) {
-              throw new Error("Error: Vec2 is immutable");
+              throw new Error("Vec2 is immutable");
             }
             if (_this17._isimmutable != null) {
               _this17._isimmutable();
             }
             if (_this16.zpp_inner._inuse) {
-              throw new Error("Error: This Vec2 is not disposable");
+              throw new Error("This Vec2 is not disposable");
             }
             const inner6 = _this16.zpp_inner;
             _this16.zpp_inner.outer = null;
@@ -1271,17 +1271,17 @@ export class ZPP_Cutter {
             o21.wrap.zpp_inner._inuse = false;
             const _this18 = o21.wrap;
             if (_this18 != null && _this18.zpp_disp) {
-              throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+              throw new Error("Vec2 has been disposed and cannot be used!");
             }
             const _this19 = _this18.zpp_inner;
             if (_this19._immutable) {
-              throw new Error("Error: Vec2 is immutable");
+              throw new Error("Vec2 is immutable");
             }
             if (_this19._isimmutable != null) {
               _this19._isimmutable();
             }
             if (_this18.zpp_inner._inuse) {
-              throw new Error("Error: This Vec2 is not disposable");
+              throw new Error("This Vec2 is not disposable");
             }
             const inner7 = _this18.zpp_inner;
             _this18.zpp_inner.outer = null;
@@ -1326,17 +1326,17 @@ export class ZPP_Cutter {
                 o24.wrap.zpp_inner._inuse = false;
                 const _this20 = o24.wrap;
                 if (_this20 != null && _this20.zpp_disp) {
-                  throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                  throw new Error("Vec2 has been disposed and cannot be used!");
                 }
                 const _this21 = _this20.zpp_inner;
                 if (_this21._immutable) {
-                  throw new Error("Error: Vec2 is immutable");
+                  throw new Error("Vec2 is immutable");
                 }
                 if (_this21._isimmutable != null) {
                   _this21._isimmutable();
                 }
                 if (_this20.zpp_inner._inuse) {
-                  throw new Error("Error: This Vec2 is not disposable");
+                  throw new Error("This Vec2 is not disposable");
                 }
                 const inner8 = _this20.zpp_inner;
                 _this20.zpp_inner.outer = null;
@@ -1376,17 +1376,17 @@ export class ZPP_Cutter {
                 o27.wrap.zpp_inner._inuse = false;
                 const _this22 = o27.wrap;
                 if (_this22 != null && _this22.zpp_disp) {
-                  throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                  throw new Error("Vec2 has been disposed and cannot be used!");
                 }
                 const _this23 = _this22.zpp_inner;
                 if (_this23._immutable) {
-                  throw new Error("Error: Vec2 is immutable");
+                  throw new Error("Vec2 is immutable");
                 }
                 if (_this23._isimmutable != null) {
                   _this23._isimmutable();
                 }
                 if (_this22.zpp_inner._inuse) {
-                  throw new Error("Error: This Vec2 is not disposable");
+                  throw new Error("This Vec2 is not disposable");
                 }
                 const inner9 = _this22.zpp_inner;
                 _this22.zpp_inner.outer = null;
@@ -1430,17 +1430,17 @@ export class ZPP_Cutter {
                 o30.wrap.zpp_inner._inuse = false;
                 const _this24 = o30.wrap;
                 if (_this24 != null && _this24.zpp_disp) {
-                  throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                  throw new Error("Vec2 has been disposed and cannot be used!");
                 }
                 const _this25 = _this24.zpp_inner;
                 if (_this25._immutable) {
-                  throw new Error("Error: Vec2 is immutable");
+                  throw new Error("Vec2 is immutable");
                 }
                 if (_this25._isimmutable != null) {
                   _this25._isimmutable();
                 }
                 if (_this24.zpp_inner._inuse) {
-                  throw new Error("Error: This Vec2 is not disposable");
+                  throw new Error("This Vec2 is not disposable");
                 }
                 const inner10 = _this24.zpp_inner;
                 _this24.zpp_inner.outer = null;
@@ -1478,17 +1478,17 @@ export class ZPP_Cutter {
                 o33.wrap.zpp_inner._inuse = false;
                 const _this26 = o33.wrap;
                 if (_this26 != null && _this26.zpp_disp) {
-                  throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                  throw new Error("Vec2 has been disposed and cannot be used!");
                 }
                 const _this27 = _this26.zpp_inner;
                 if (_this27._immutable) {
-                  throw new Error("Error: Vec2 is immutable");
+                  throw new Error("Vec2 is immutable");
                 }
                 if (_this27._isimmutable != null) {
                   _this27._isimmutable();
                 }
                 if (_this26.zpp_inner._inuse) {
-                  throw new Error("Error: This Vec2 is not disposable");
+                  throw new Error("This Vec2 is not disposable");
                 }
                 const inner11 = _this26.zpp_inner;
                 _this26.zpp_inner.outer = null;

--- a/packages/nape-js/src/native/geom/ZPP_Geom.ts
+++ b/packages/nape-js/src/native/geom/ZPP_Geom.ts
@@ -119,7 +119,7 @@ export class ZPP_Geom {
             }
           }
           if (_this6.lverts.next == null) {
-            throw new Error("Error: An empty polygon has no meaningful bounds");
+            throw new Error("An empty polygon has no meaningful bounds");
           }
           const p0 = _this6.gverts.next;
           _this6.aabb.minx = p0.x;
@@ -205,7 +205,7 @@ export class ZPP_Geom {
   /** @internal Compute polygon local COM from vertex ring. */
   private static _computePolygonLocalCOM(poly: any): void {
     if (poly.lverts.next == null) {
-      throw new Error("Error: An empty polygon has no meaningful localCOM");
+      throw new Error("An empty polygon has no meaningful localCOM");
     }
     if (poly.lverts.next.next == null) {
       poly.localCOMx = poly.lverts.next.x;

--- a/packages/nape-js/src/native/geom/ZPP_GeomVert.ts
+++ b/packages/nape-js/src/native/geom/ZPP_GeomVert.ts
@@ -46,17 +46,17 @@ export class ZPP_GeomVert {
       this.wrap.zpp_inner._inuse = false;
       const _this = this.wrap;
       if (_this != null && _this.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = _this.zpp_inner;
       if (_this1._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this1._isimmutable != null) {
         _this1._isimmutable();
       }
       if (_this.zpp_inner._inuse) {
-        throw new Error("Error: This Vec2 is not disposable");
+        throw new Error("This Vec2 is not disposable");
       }
       const inner = _this.zpp_inner;
       _this.zpp_inner.outer = null;
@@ -97,7 +97,7 @@ export class ZPP_GeomVert {
         x = 0;
       }
       if (x !== x || y !== y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let ret: any;
       if (ZPP_PubPool.poolVec2 == null) {
@@ -129,21 +129,21 @@ export class ZPP_GeomVert {
         ret.zpp_inner.outer = ret;
       } else {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this = ret.zpp_inner;
         if (_this._immutable) {
-          throw new Error("Error: Vec2 is immutable");
+          throw new Error("Vec2 is immutable");
         }
         if (_this._isimmutable != null) {
           _this._isimmutable();
         }
         if (x !== x || y !== y) {
-          throw new Error("Error: Vec2 components cannot be NaN");
+          throw new Error("Vec2 components cannot be NaN");
         }
         let tmp: boolean;
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this1 = ret.zpp_inner;
         if (_this1._validate != null) {
@@ -151,7 +151,7 @@ export class ZPP_GeomVert {
         }
         if (ret.zpp_inner.x === x) {
           if (ret != null && ret.zpp_disp) {
-            throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+            throw new Error("Vec2 has been disposed and cannot be used!");
           }
           const _this2 = ret.zpp_inner;
           if (_this2._validate != null) {

--- a/packages/nape-js/src/native/geom/ZPP_MarchingSquares.ts
+++ b/packages/nape-js/src/native/geom/ZPP_MarchingSquares.ts
@@ -67,17 +67,17 @@ export class ZPP_MarchingSquares {
       o.wrap.zpp_inner._inuse = false;
       const _this = o.wrap;
       if (_this != null && _this.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = _this.zpp_inner;
       if (_this1._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this1._isimmutable != null) {
         _this1._isimmutable();
       }
       if (_this.zpp_inner._inuse) {
-        throw new Error("Error: This Vec2 is not disposable");
+        throw new Error("This Vec2 is not disposable");
       }
       const inner = _this.zpp_inner;
       _this.zpp_inner.outer = null;
@@ -254,7 +254,7 @@ export class ZPP_MarchingSquares {
     ret: ZNPList<ZPP_GeomVert>,
   ): void {
     if (cell != null && cell.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     let _this = cell.zpp_inner;
     if (_this._validate != null) {
@@ -264,7 +264,7 @@ export class ZPP_MarchingSquares {
     let xn = xp | 0;
 
     if (cell != null && cell.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     _this = cell.zpp_inner;
     if (_this._validate != null) {
@@ -301,7 +301,7 @@ export class ZPP_MarchingSquares {
         yc = by0;
       } else if (y <= yn) {
         if (cell != null && cell.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = cell.zpp_inner;
         if (_this2._validate != null) {
@@ -318,7 +318,7 @@ export class ZPP_MarchingSquares {
           xc = bx0;
         } else if (x <= xn) {
           if (cell != null && cell.zpp_disp) {
-            throw new Error("Error: Vec2 has been disposed and cannot be used!");
+            throw new Error("Vec2 has been disposed and cannot be used!");
           }
           const _this3 = cell.zpp_inner;
           if (_this3._validate != null) {
@@ -354,7 +354,7 @@ export class ZPP_MarchingSquares {
         y1end = by1;
       } else {
         if (cell != null && cell.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this5 = cell.zpp_inner;
         if (_this5._validate != null) {
@@ -374,7 +374,7 @@ export class ZPP_MarchingSquares {
           x1end = bx1;
         } else {
           if (cell != null && cell.zpp_disp) {
-            throw new Error("Error: Vec2 has been disposed and cannot be used!");
+            throw new Error("Vec2 has been disposed and cannot be used!");
           }
           const _this6 = cell.zpp_inner;
           if (_this6._validate != null) {

--- a/packages/nape-js/src/native/geom/ZPP_Ray.ts
+++ b/packages/nape-js/src/native/geom/ZPP_Ray.ts
@@ -71,18 +71,18 @@ export class ZPP_Ray {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       let tmp: boolean;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -90,7 +90,7 @@ export class ZPP_Ray {
       }
       if (ret.zpp_inner.x == 0) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -144,18 +144,18 @@ export class ZPP_Ray {
       ret2.zpp_inner.outer = ret2;
     } else {
       if (ret2 != null && ret2.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this4 = ret2.zpp_inner;
       if (_this4._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this4._isimmutable != null) {
         _this4._isimmutable();
       }
       let tmp1: boolean;
       if (ret2 != null && ret2.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this5 = ret2.zpp_inner;
       if (_this5._validate != null) {
@@ -163,7 +163,7 @@ export class ZPP_Ray {
       }
       if (ret2.zpp_inner.x == 0) {
         if (ret2 != null && ret2.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this6 = ret2.zpp_inner;
         if (_this6._validate != null) {
@@ -221,7 +221,7 @@ export class ZPP_Ray {
       this.zip_dir = false;
       const nape = getNape();
       if (this.dirx * this.dirx + this.diry * this.diry < nape.Config.epsilon) {
-        throw new Error("Error: Ray::direction is degenerate");
+        throw new Error("Ray::direction is degenerate");
       }
       const d = this.dirx * this.dirx + this.diry * this.diry;
       const imag = 1.0 / Math.sqrt(d);
@@ -376,7 +376,7 @@ export class ZPP_Ray {
   private static _allocVec2(x: number, y: number): any {
     const nape = getNape();
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
 
     let ret: any;
@@ -409,17 +409,17 @@ export class ZPP_Ray {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let same: boolean;
       if (ret.zpp_inner._validate != null) {
@@ -458,7 +458,7 @@ export class ZPP_Ray {
           if (c.type == 1) {
             const _this = c.polygon;
             if (_this.lverts.next == null) {
-              throw new Error("Error: An empty polygon has no meaningful localCOM");
+              throw new Error("An empty polygon has no meaningful localCOM");
             }
             if (_this.lverts.next.next == null) {
               _this.localCOMx = _this.lverts.next.x;
@@ -558,10 +558,10 @@ export class ZPP_Ray {
     while (cx_ite != null) {
       const j = cx_ite.elt;
       if (res.zpp_inner.next != null) {
-        throw new Error("Error: This object has been disposed of and cannot be used");
+        throw new Error("This object has been disposed of and cannot be used");
       }
       if (j.zpp_inner.next != null) {
-        throw new Error("Error: This object has been disposed of and cannot be used");
+        throw new Error("This object has been disposed of and cannot be used");
       }
       if (res.zpp_inner.toiDistance < j.zpp_inner.toiDistance) {
         break;

--- a/packages/nape-js/src/native/geom/ZPP_Vec2.ts
+++ b/packages/nape-js/src/native/geom/ZPP_Vec2.ts
@@ -82,7 +82,7 @@ export class ZPP_Vec2 {
 
   immutable(): void {
     if (this._immutable) {
-      throw new Error("Error: Vec2 is immutable");
+      throw new Error("Vec2 is immutable");
     }
     if (this._isimmutable != null) this._isimmutable();
   }

--- a/packages/nape-js/src/native/phys/ZPP_Body.ts
+++ b/packages/nape-js/src/native/phys/ZPP_Body.ts
@@ -563,7 +563,7 @@ export class ZPP_Body {
   pos_invalidate(pos: ZPP_Vec2): void {
     this.immutable_midstep("Body::position");
     if (this.type === 1 && this.space != null) {
-      throw new Error("Error: Cannot move a static object once inside a Space");
+      throw new Error("Cannot move a static object once inside a Space");
     }
     if (!(this.posx === pos.x && this.posy === pos.y)) {
       this.posx = pos.x;
@@ -580,7 +580,7 @@ export class ZPP_Body {
 
   vel_invalidate(vel: ZPP_Vec2): void {
     if (this.type === 1) {
-      throw new Error("Error: Static body cannot have its velocity set.");
+      throw new Error("Static body cannot have its velocity set.");
     }
     this.velx = vel.x;
     this.vely = vel.y;
@@ -616,7 +616,7 @@ export class ZPP_Body {
 
   force_invalidate(force: ZPP_Vec2): void {
     if (this.type !== 2) {
-      throw new Error("Error: Non-dynamic body cannot have force applied.");
+      throw new Error("Non-dynamic body cannot have force applied.");
     }
     this.forcex = force.x;
     this.forcey = force.y;
@@ -639,7 +639,7 @@ export class ZPP_Body {
     const nape = ZPP_Body._nape;
 
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
 
     let ret: any;
@@ -672,17 +672,17 @@ export class ZPP_Body {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       // Only invalidate if changed
       let same: boolean;
@@ -959,7 +959,7 @@ export class ZPP_Body {
 
   validate_aabb(): void {
     if (this.shapes.head == null) {
-      throw new Error("Error: Body bounds only makes sense if it contains shapes");
+      throw new Error("Body bounds only makes sense if it contains shapes");
     }
     if (this.zip_aabb) {
       this.zip_aabb = false;
@@ -1039,7 +1039,7 @@ export class ZPP_Body {
       }
     }
     if (poly.lverts.next == null) {
-      throw new Error("Error: An empty polygon has no meaningful bounds");
+      throw new Error("An empty polygon has no meaningful bounds");
     }
     const p0 = poly.gverts.next;
     poly.aabb.minx = p0.x;
@@ -1059,7 +1059,7 @@ export class ZPP_Body {
 
   aabb_validate(): void {
     if (this.shapes.head == null) {
-      throw new Error("Error: bounds only makes sense when Body has shapes");
+      throw new Error("bounds only makes sense when Body has shapes");
     }
     this.validate_aabb();
   }
@@ -1077,7 +1077,7 @@ export class ZPP_Body {
 
   private _computePolygonLocalCOM(poly: any): void {
     if (poly.lverts.next == null) {
-      throw new Error("Error: An empty polygon has no meaningful localCOM");
+      throw new Error("An empty polygon has no meaningful localCOM");
     }
     if (poly.lverts.next.next == null) {
       poly.localCOMx = poly.lverts.next.x;
@@ -1195,14 +1195,14 @@ export class ZPP_Body {
 
   getlocalCOM(): void {
     if (this.shapes.head == null) {
-      throw new Error("Error: Body has no shapes so cannot compute its localCOM");
+      throw new Error("Body has no shapes so cannot compute its localCOM");
     }
     this.validate_localCOM();
   }
 
   getworldCOM(): void {
     if (this.shapes.head == null) {
-      throw new Error("Error: Body has no shapes so cannot compute its worldCOM");
+      throw new Error("Body has no shapes so cannot compute its worldCOM");
     }
     this.validate_worldCOM();
   }
@@ -1211,7 +1211,7 @@ export class ZPP_Body {
 
   __immutable_midstep(): void {
     if (this.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
   }
 
@@ -1219,10 +1219,10 @@ export class ZPP_Body {
 
   clear(): void {
     if (this.space != null) {
-      throw new Error("Error: Cannot clear a Body if it is currently being used by a Space!");
+      throw new Error("Cannot clear a Body if it is currently being used by a Space!");
     }
     if (this.constraints.head != null) {
-      throw new Error("Error: Cannot clear a Body if it is currently being used by a constraint!");
+      throw new Error("Cannot clear a Body if it is currently being used by a constraint!");
     }
     while (this.shapes.head != null) {
       const s = this.shapes.pop_unsafe();
@@ -1333,7 +1333,7 @@ export class ZPP_Body {
   shapes_modifiable(): void {
     this.immutable_midstep("Body::shapes");
     if (this.type === 1 && this.space != null) {
-      throw new Error("Error: Cannot modifiy shapes of static object once added to Space");
+      throw new Error("Cannot modifiy shapes of static object once added to Space");
     }
   }
 

--- a/packages/nape-js/src/native/phys/ZPP_Compound.ts
+++ b/packages/nape-js/src/native/phys/ZPP_Compound.ts
@@ -83,7 +83,7 @@ export class ZPP_Compound {
   // --- Mid-step guard (ZPP_Compound-specific) ---
   __imutable_midstep(name: string): void {
     if (this.space != null && this.space.midstep) {
-      throw new Error("Error: " + name + " cannot be set during space step()");
+      throw new Error(`${name} cannot be set during space step()`);
     }
   }
 

--- a/packages/nape-js/src/native/phys/ZPP_FluidProperties.ts
+++ b/packages/nape-js/src/native/phys/ZPP_FluidProperties.ts
@@ -116,7 +116,7 @@ export class ZPP_FluidProperties {
     const y = this.gravityy ?? 0;
 
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
 
     // Get or create a Vec2 from the public pool
@@ -152,17 +152,17 @@ export class ZPP_FluidProperties {
     } else {
       // Reuse existing inner Vec2
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const inner = ret.zpp_inner;
       if (inner._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (inner._isimmutable != null) {
         inner._isimmutable();
       }
       if (x !== x || y !== y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
 
       // Check if values actually changed

--- a/packages/nape-js/src/native/phys/ZPP_Interactor.ts
+++ b/packages/nape-js/src/native/phys/ZPP_Interactor.ts
@@ -317,7 +317,7 @@ export class ZPP_Interactor {
     if (this.ibody != null) {
       const _this = this.ibody;
       if (_this.space != null && _this.space.midstep) {
-        throw new Error("Error: " + n + " cannot be set during a space step()");
+        throw new Error(`${n} cannot be set during a space step()`);
       }
     } else if (this.ishape != null) {
       this.ishape.__immutable_midstep(n);

--- a/packages/nape-js/src/native/shape/ZPP_Circle.ts
+++ b/packages/nape-js/src/native/shape/ZPP_Circle.ts
@@ -127,7 +127,7 @@ export class ZPP_Circle {
     const x = this.localCOMx;
     const y = this.localCOMy;
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {

--- a/packages/nape-js/src/native/shape/ZPP_Edge.ts
+++ b/packages/nape-js/src/native/shape/ZPP_Edge.ts
@@ -91,7 +91,7 @@ export class ZPP_Edge {
 
   lnorm_validate(): void {
     if (this.polygon == null) {
-      throw new Error("Error: Edge not currently in use");
+      throw new Error("Edge not currently in use");
     }
     this.polygon.validate_laxi();
     this.wrap_lnorm.zpp_inner.x = this.lnormx;
@@ -100,7 +100,7 @@ export class ZPP_Edge {
 
   gnorm_validate(): void {
     if (this.polygon == null) {
-      throw new Error("Error: Edge not currently in use");
+      throw new Error("Edge not currently in use");
     }
     if (this.polygon.body == null) {
       throw new Error(
@@ -118,7 +118,7 @@ export class ZPP_Edge {
     const x = this.lnormx;
     const y = this.lnormy;
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -163,7 +163,7 @@ export class ZPP_Edge {
     const x = this.gnormx;
     const y = this.gnormy;
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {

--- a/packages/nape-js/src/native/shape/ZPP_Polygon.ts
+++ b/packages/nape-js/src/native/shape/ZPP_Polygon.ts
@@ -243,7 +243,7 @@ export class ZPP_Polygon {
   lverts_modifiable(): void {
     this.immutable_midstep("Polygon::localVerts");
     if (this.body != null && this.body.type === 1 && this.body.space != null) {
-      throw new Error("Error: Cannot modifiy shapes of static object once added to Space");
+      throw new Error("Cannot modifiy shapes of static object once added to Space");
     }
   }
 
@@ -794,7 +794,7 @@ export class ZPP_Polygon {
   __validate_aabb(): void {
     this._validateGverts();
     if (this.lverts.next == null) {
-      throw new Error("Error: An empty polygon has no meaningful bounds");
+      throw new Error("An empty polygon has no meaningful bounds");
     }
     const p0 = this.gverts.next;
     this.aabb.minx = p0.x;
@@ -921,7 +921,7 @@ export class ZPP_Polygon {
   __validate_angDrag(): void {
     const nape = ZPP_Polygon._nape;
     if (this.lverts.length < 3) {
-      throw new Error("Error: Polygon's with less than 3 vertices have no meaningful angDrag");
+      throw new Error("Polygon's with less than 3 vertices have no meaningful angDrag");
     }
     this.validate_area_inertia();
     this.validate_laxi();
@@ -1023,7 +1023,7 @@ export class ZPP_Polygon {
 
   __validate_localCOM(): void {
     if (this.lverts.next == null) {
-      throw new Error("Error: An empty polygon has no meaningful localCOM");
+      throw new Error("An empty polygon has no meaningful localCOM");
     }
     if (this.lverts.next.next == null) {
       this.localCOMx = this.lverts.next.x;
@@ -1077,7 +1077,7 @@ export class ZPP_Polygon {
 
   localCOM_validate(): void {
     if (this.lverts.next == null) {
-      throw new Error("Error: An empty polygon does not have any meaningful localCOM");
+      throw new Error("An empty polygon does not have any meaningful localCOM");
     }
     this.validate_localCOM();
   }
@@ -1101,7 +1101,7 @@ export class ZPP_Polygon {
     const x = this.localCOMx;
     const y = this.localCOMy;
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret: any;
     if (zpp.util.ZPP_PubPool.poolVec2 == null) {

--- a/packages/nape-js/src/native/shape/ZPP_Shape.ts
+++ b/packages/nape-js/src/native/shape/ZPP_Shape.ts
@@ -301,7 +301,7 @@ export class ZPP_Shape {
 
   getworldCOM(): void {
     if (this.body == null) {
-      throw new Error("Error: worldCOM only makes sense when Shape belongs to a Body");
+      throw new Error("worldCOM only makes sense when Shape belongs to a Body");
     }
     this.validate_worldCOM();
     this.wrap_worldCOM.zpp_inner.x = this.worldCOMx;
@@ -382,7 +382,7 @@ export class ZPP_Shape {
   // --- AABB validate callback (bound to aabb._validate) ---
   aabb_validate(): void {
     if (this.body == null) {
-      throw new Error("Error: bounds only makes sense when Shape belongs to a Body");
+      throw new Error("bounds only makes sense when Shape belongs to a Body");
     }
     this.validate_aabb();
   }
@@ -441,7 +441,7 @@ export class ZPP_Shape {
   // --- Midstep guard ---
   __immutable_midstep(name: string): void {
     if (this.body != null && this.body.space != null && this.body.space.midstep) {
-      throw new Error("Error: " + name + " cannot be set during a space step()");
+      throw new Error(`${name} cannot be set during a space step()`);
     }
   }
 

--- a/packages/nape-js/src/native/space/ZPP_Broadphase.ts
+++ b/packages/nape-js/src/native/space/ZPP_Broadphase.ts
@@ -77,7 +77,7 @@ export class ZPP_Broadphase {
                     if (_this.type == 1) {
                       const _this1 = _this.polygon;
                       if (_this1.lverts.next == null) {
-                        throw new Error("Error: An empty polygon has no meaningful localCOM");
+                        throw new Error("An empty polygon has no meaningful localCOM");
                       }
                       if (_this1.lverts.next.next == null) {
                         _this1.localCOMx = _this1.lverts.next.x;
@@ -180,7 +180,7 @@ export class ZPP_Broadphase {
                 }
               }
               if (_this3.lverts.next == null) {
-                throw new Error("Error: An empty polygon has no meaningful bounds");
+                throw new Error("An empty polygon has no meaningful bounds");
               }
               const p0 = _this3.gverts.next;
               _this3.aabb.minx = p0.x;
@@ -226,7 +226,7 @@ export class ZPP_Broadphase {
                       if (_this6.type == 1) {
                         const _this7 = _this6.polygon;
                         if (_this7.lverts.next == null) {
-                          throw new Error("Error: An empty polygon has no meaningful localCOM");
+                          throw new Error("An empty polygon has no meaningful localCOM");
                         }
                         if (_this7.lverts.next.next == null) {
                           _this7.localCOMx = _this7.lverts.next.x;
@@ -331,7 +331,7 @@ export class ZPP_Broadphase {
                   }
                 }
                 if (_this9.lverts.next == null) {
-                  throw new Error("Error: An empty polygon has no meaningful bounds");
+                  throw new Error("An empty polygon has no meaningful bounds");
                 }
                 const p01 = _this9.gverts.next;
                 _this9.aabb.minx = p01.x;
@@ -428,7 +428,7 @@ export class ZPP_Broadphase {
       }
       const _this1 = this.matrix;
       if (sx !== sx) {
-        throw new Error("Error: Mat23::a cannot be NaN");
+        throw new Error("Mat23::a cannot be NaN");
       }
       _this1.zpp_inner.a = sx;
       const _this2 = _this1.zpp_inner;
@@ -444,7 +444,7 @@ export class ZPP_Broadphase {
       }
       const b = _this4.zpp_inner.c;
       if (b !== b) {
-        throw new Error("Error: Mat23::b cannot be NaN");
+        throw new Error("Mat23::b cannot be NaN");
       }
       _this3.zpp_inner.b = b;
       const _this6 = _this3.zpp_inner;
@@ -453,7 +453,7 @@ export class ZPP_Broadphase {
       }
       const _this7 = this.matrix;
       if (sy !== sy) {
-        throw new Error("Error: Mat23::d cannot be NaN");
+        throw new Error("Mat23::d cannot be NaN");
       }
       _this7.zpp_inner.d = sy;
       const _this8 = _this7.zpp_inner;
@@ -463,7 +463,7 @@ export class ZPP_Broadphase {
       const _this9 = this.matrix;
       const tx = aabb.minx - sx * ab.minx;
       if (tx !== tx) {
-        throw new Error("Error: Mat23::tx cannot be NaN");
+        throw new Error("Mat23::tx cannot be NaN");
       }
       _this9.zpp_inner.tx = tx;
       const _this10 = _this9.zpp_inner;
@@ -473,7 +473,7 @@ export class ZPP_Broadphase {
       const _this11 = this.matrix;
       const ty = aabb.miny - sy * ab.miny;
       if (ty !== ty) {
-        throw new Error("Error: Mat23::ty cannot be NaN");
+        throw new Error("Mat23::ty cannot be NaN");
       }
       _this11.zpp_inner.ty = ty;
       const _this12 = _this11.zpp_inner;
@@ -496,7 +496,7 @@ export class ZPP_Broadphase {
                 if (_this14.type == 1) {
                   const _this15 = _this14.polygon;
                   if (_this15.lverts.next == null) {
-                    throw new Error("Error: An empty polygon has no meaningful localCOM");
+                    throw new Error("An empty polygon has no meaningful localCOM");
                   }
                   if (_this15.lverts.next.next == null) {
                     _this15.localCOMx = _this15.lverts.next.x;
@@ -599,7 +599,7 @@ export class ZPP_Broadphase {
             }
           }
           if (_this17.lverts.next == null) {
-            throw new Error("Error: An empty polygon has no meaningful bounds");
+            throw new Error("An empty polygon has no meaningful bounds");
           }
           const p0 = _this17.gverts.next;
           _this17.aabb.minx = p0.x;
@@ -746,7 +746,7 @@ export class ZPP_Broadphase {
         x1 = 0;
       }
       if (x1 !== x1 || y1 !== y1) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let ret: any;
       if (zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -777,21 +777,21 @@ export class ZPP_Broadphase {
         ret.zpp_inner.outer = ret;
       } else {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this1 = ret.zpp_inner;
         if (_this1._immutable) {
-          throw new Error("Error: Vec2 is immutable");
+          throw new Error("Vec2 is immutable");
         }
         if (_this1._isimmutable != null) {
           _this1._isimmutable();
         }
         if (x1 !== x1 || y1 !== y1) {
-          throw new Error("Error: Vec2 components cannot be NaN");
+          throw new Error("Vec2 components cannot be NaN");
         }
         let obj: boolean;
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -799,7 +799,7 @@ export class ZPP_Broadphase {
         }
         if (ret.zpp_inner.x == x1) {
           if (ret != null && ret.zpp_disp) {
-            throw new Error("Error: Vec2 has been disposed and cannot be used!");
+            throw new Error("Vec2 has been disposed and cannot be used!");
           }
           const _this3 = ret.zpp_inner;
           if (_this3._validate != null) {
@@ -834,7 +834,7 @@ export class ZPP_Broadphase {
       const _this5 = this.matrix;
       const _this6 = this.matrix;
       if (ss !== ss) {
-        throw new Error("Error: Mat23::d cannot be NaN");
+        throw new Error("Mat23::d cannot be NaN");
       }
       _this6.zpp_inner.d = ss;
       const _this7 = _this6.zpp_inner;
@@ -843,7 +843,7 @@ export class ZPP_Broadphase {
       }
       const a = _this6.zpp_inner.d;
       if (a !== a) {
-        throw new Error("Error: Mat23::a cannot be NaN");
+        throw new Error("Mat23::a cannot be NaN");
       }
       _this5.zpp_inner.a = a;
       const _this8 = _this5.zpp_inner;
@@ -859,7 +859,7 @@ export class ZPP_Broadphase {
       }
       const b = _this10.zpp_inner.c;
       if (b !== b) {
-        throw new Error("Error: Mat23::b cannot be NaN");
+        throw new Error("Mat23::b cannot be NaN");
       }
       _this9.zpp_inner.b = b;
       const _this12 = _this9.zpp_inner;
@@ -869,7 +869,7 @@ export class ZPP_Broadphase {
       const _this13 = this.matrix;
       const tx = x - ss * ci.localCOMx;
       if (tx !== tx) {
-        throw new Error("Error: Mat23::tx cannot be NaN");
+        throw new Error("Mat23::tx cannot be NaN");
       }
       _this13.zpp_inner.tx = tx;
       const _this14 = _this13.zpp_inner;
@@ -879,7 +879,7 @@ export class ZPP_Broadphase {
       const _this15 = this.matrix;
       const ty = y - ss * ci.localCOMy;
       if (ty !== ty) {
-        throw new Error("Error: Mat23::ty cannot be NaN");
+        throw new Error("Mat23::ty cannot be NaN");
       }
       _this15.zpp_inner.ty = ty;
       const _this16 = _this15.zpp_inner;
@@ -902,7 +902,7 @@ export class ZPP_Broadphase {
                 if (_this18.type == 1) {
                   const _this19 = _this18.polygon;
                   if (_this19.lverts.next == null) {
-                    throw new Error("Error: An empty polygon has no meaningful localCOM");
+                    throw new Error("An empty polygon has no meaningful localCOM");
                   }
                   if (_this19.lverts.next.next == null) {
                     _this19.localCOMx = _this19.lverts.next.x;
@@ -1005,7 +1005,7 @@ export class ZPP_Broadphase {
             }
           }
           if (_this21.lverts.next == null) {
-            throw new Error("Error: An empty polygon has no meaningful bounds");
+            throw new Error("An empty polygon has no meaningful bounds");
           }
           const p0 = _this21.gverts.next;
           _this21.aabb.minx = p0.x;
@@ -1148,7 +1148,7 @@ export class ZPP_Broadphase {
                 if (_this3.type == 1) {
                   const _this4 = _this3.polygon;
                   if (_this4.lverts.next == null) {
-                    throw new Error("Error: An empty polygon has no meaningful localCOM");
+                    throw new Error("An empty polygon has no meaningful localCOM");
                   }
                   if (_this4.lverts.next.next == null) {
                     _this4.localCOMx = _this4.lverts.next.x;
@@ -1251,7 +1251,7 @@ export class ZPP_Broadphase {
             }
           }
           if (_this6.lverts.next == null) {
-            throw new Error("Error: An empty polygon has no meaningful bounds");
+            throw new Error("An empty polygon has no meaningful bounds");
           }
           const p0 = _this6.gverts.next;
           _this6.aabb.minx = p0.x;
@@ -1286,7 +1286,7 @@ export class ZPP_Broadphase {
           if (s.type == 1) {
             const _this8 = s.polygon;
             if (_this8.lverts.next == null) {
-              throw new Error("Error: An empty polygon has no meaningful localCOM");
+              throw new Error("An empty polygon has no meaningful localCOM");
             }
             if (_this8.lverts.next.next == null) {
               _this8.localCOMx = _this8.lverts.next.x;

--- a/packages/nape-js/src/native/space/ZPP_DynAABBPhase.ts
+++ b/packages/nape-js/src/native/space/ZPP_DynAABBPhase.ts
@@ -225,7 +225,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
                     if (_this.type == 1) {
                       const _this1 = _this.polygon;
                       if (_this1.lverts.next == null) {
-                        throw new Error("Error: An empty polygon has no meaningful localCOM");
+                        throw new Error("An empty polygon has no meaningful localCOM");
                       }
                       if (_this1.lverts.next.next == null) {
                         _this1.localCOMx = _this1.lverts.next.x;
@@ -328,7 +328,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
                 }
               }
               if (_this3.lverts.next == null) {
-                throw new Error("Error: An empty polygon has no meaningful bounds");
+                throw new Error("An empty polygon has no meaningful bounds");
               }
               const p0 = _this3.gverts.next;
               _this3.aabb.minx = p0.x;
@@ -616,7 +616,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
                         if (_this9.type == 1) {
                           const _this10 = _this9.polygon;
                           if (_this10.lverts.next == null) {
-                            throw new Error("Error: An empty polygon has no meaningful localCOM");
+                            throw new Error("An empty polygon has no meaningful localCOM");
                           }
                           if (_this10.lverts.next.next == null) {
                             _this10.localCOMx = _this10.lverts.next.x;
@@ -723,7 +723,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
                     }
                   }
                   if (_this12.lverts.next == null) {
-                    throw new Error("Error: An empty polygon has no meaningful bounds");
+                    throw new Error("An empty polygon has no meaningful bounds");
                   }
                   const p0 = _this12.gverts.next;
                   _this12.aabb.minx = p0.x;
@@ -1272,7 +1272,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
                         if (_this44.type == 1) {
                           const _this45 = _this44.polygon;
                           if (_this45.lverts.next == null) {
-                            throw new Error("Error: An empty polygon has no meaningful localCOM");
+                            throw new Error("An empty polygon has no meaningful localCOM");
                           }
                           if (_this45.lverts.next.next == null) {
                             _this45.localCOMx = _this45.lverts.next.x;
@@ -1381,7 +1381,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
                     }
                   }
                   if (_this47.lverts.next == null) {
-                    throw new Error("Error: An empty polygon has no meaningful bounds");
+                    throw new Error("An empty polygon has no meaningful bounds");
                   }
                   const p01 = _this47.gverts.next;
                   _this47.aabb.minx = p01.x;
@@ -1934,7 +1934,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
                     if (_this9.type == 1) {
                       const _this10 = _this9.polygon;
                       if (_this10.lverts.next == null) {
-                        throw new Error("Error: An empty polygon has no meaningful localCOM");
+                        throw new Error("An empty polygon has no meaningful localCOM");
                       }
                       if (_this10.lverts.next.next == null) {
                         _this10.localCOMx = _this10.lverts.next.x;
@@ -2039,7 +2039,7 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
                 }
               }
               if (_this12.lverts.next == null) {
-                throw new Error("Error: An empty polygon has no meaningful bounds");
+                throw new Error("An empty polygon has no meaningful bounds");
               }
               const p0 = _this12.gverts.next;
               _this12.aabb.minx = p0.x;
@@ -4250,12 +4250,12 @@ export class ZPP_DynAABBPhase extends ZPP_Broadphase {
                 : null;
           if (result != null) {
             if (result.zpp_inner.next != null) {
-              throw new Error("Error: This object has been disposed of and cannot be used");
+              throw new Error("This object has been disposed of and cannot be used");
             }
             mint = result.zpp_inner.toiDistance;
             if (minres != null) {
               if (minres.zpp_inner.next != null) {
-                throw new Error("Error: This object has been disposed of and cannot be used");
+                throw new Error("This object has been disposed of and cannot be used");
               }
               minres.zpp_inner.free();
             }

--- a/packages/nape-js/src/native/space/ZPP_Space.ts
+++ b/packages/nape-js/src/native/space/ZPP_Space.ts
@@ -235,7 +235,7 @@ export class ZPP_Space {
       x = 0;
     }
     if (x != x || y != y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     let ret;
     if (ZPP_Space._zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -266,21 +266,21 @@ export class ZPP_Space {
       ret.zpp_inner.outer = ret;
     } else {
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this = ret.zpp_inner;
       if (_this._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this._isimmutable != null) {
         _this._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp;
       if (ret != null && ret.zpp_disp) {
-        throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this1 = ret.zpp_inner;
       if (_this1._validate != null) {
@@ -288,7 +288,7 @@ export class ZPP_Space {
       }
       if (ret.zpp_inner.x == x) {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this2 = ret.zpp_inner;
         if (_this2._validate != null) {
@@ -316,7 +316,7 @@ export class ZPP_Space {
 
   gravity_invalidate(x: any) {
     if (this.midstep) {
-      throw new Error("Error: Space::gravity cannot be set during space step");
+      throw new Error("Space::gravity cannot be set during space step");
     }
     this.gravityx = x.x;
     this.gravityy = x.y;
@@ -921,7 +921,7 @@ export class ZPP_Space {
 
   bodies_modifiable() {
     if (this.midstep) {
-      throw new Error("Error: Space::bodies cannot be set during space step()");
+      throw new Error("Space::bodies cannot be set during space step()");
     }
   }
 
@@ -948,7 +948,7 @@ export class ZPP_Space {
 
   compounds_modifiable() {
     if (this.midstep) {
-      throw new Error("Error: Space::compounds cannot be set during space step()");
+      throw new Error("Space::compounds cannot be set during space step()");
     }
   }
 
@@ -975,7 +975,7 @@ export class ZPP_Space {
 
   constraints_modifiable() {
     if (this.midstep) {
-      throw new Error("Error: Space::constraints cannot be set during space step()");
+      throw new Error("Space::constraints cannot be set during space step()");
     }
   }
 
@@ -997,7 +997,7 @@ export class ZPP_Space {
 
   listeners_modifiable() {
     if (this.midstep) {
-      throw new Error("Error: Space::listeners cannot be set during space step()");
+      throw new Error("Space::listeners cannot be set during space step()");
     }
   }
 
@@ -1650,7 +1650,7 @@ export class ZPP_Space {
   shapesInCircle(pos: any, rad: any, cont: any, filter: any, output: any) {
     const tmp = this.bphase;
     if (pos != null && pos.zpp_disp) {
-      throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const _this = pos.zpp_inner;
     if (_this._validate != null) {
@@ -1658,7 +1658,7 @@ export class ZPP_Space {
     }
     const tmp1 = pos.zpp_inner.x;
     if (pos != null && pos.zpp_disp) {
-      throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const _this1 = pos.zpp_inner;
     if (_this1._validate != null) {
@@ -1670,7 +1670,7 @@ export class ZPP_Space {
   bodiesInCircle(pos: any, rad: any, cont: any, filter: any, output: any) {
     const tmp = this.bphase;
     if (pos != null && pos.zpp_disp) {
-      throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const _this = pos.zpp_inner;
     if (_this._validate != null) {
@@ -1678,7 +1678,7 @@ export class ZPP_Space {
     }
     const tmp1 = pos.zpp_inner.x;
     if (pos != null && pos.zpp_disp) {
-      throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     const _this1 = pos.zpp_inner;
     if (_this1._validate != null) {
@@ -1730,7 +1730,7 @@ export class ZPP_Space {
             if (_this.type == 1) {
               const _this1 = _this.polygon;
               if (_this1.lverts.next == null) {
-                throw new Error("Error: An empty polygon has no meaningful localCOM");
+                throw new Error("An empty polygon has no meaningful localCOM");
               }
               if (_this1.lverts.next.next == null) {
                 _this1.localCOMx = _this1.lverts.next.x;
@@ -2151,7 +2151,7 @@ export class ZPP_Space {
         x4 = 0;
       }
       if (x4 != x4 || y4 != y4) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let ret;
       if (ZPP_Space._zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -2182,21 +2182,21 @@ export class ZPP_Space {
         ret.zpp_inner.outer = ret;
       } else {
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this9 = ret.zpp_inner;
         if (_this9._immutable) {
-          throw new Error("Error: Vec2 is immutable");
+          throw new Error("Vec2 is immutable");
         }
         if (_this9._isimmutable != null) {
           _this9._isimmutable();
         }
         if (x4 != x4 || y4 != y4) {
-          throw new Error("Error: Vec2 components cannot be NaN");
+          throw new Error("Vec2 components cannot be NaN");
         }
         let tmp1;
         if (ret != null && ret.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this10 = ret.zpp_inner;
         if (_this10._validate != null) {
@@ -2204,7 +2204,7 @@ export class ZPP_Space {
         }
         if (ret.zpp_inner.x == x4) {
           if (ret != null && ret.zpp_disp) {
-            throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+            throw new Error("Vec2 has been disposed and cannot be used!");
           }
           const _this11 = ret.zpp_inner;
           if (_this11._validate != null) {
@@ -2233,7 +2233,7 @@ export class ZPP_Space {
         x5 = 0;
       }
       if (x5 != x5 || y5 != y5) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let ret2;
       if (ZPP_Space._zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -2264,21 +2264,21 @@ export class ZPP_Space {
         ret2.zpp_inner.outer = ret2;
       } else {
         if (ret2 != null && ret2.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this13 = ret2.zpp_inner;
         if (_this13._immutable) {
-          throw new Error("Error: Vec2 is immutable");
+          throw new Error("Vec2 is immutable");
         }
         if (_this13._isimmutable != null) {
           _this13._isimmutable();
         }
         if (x5 != x5 || y5 != y5) {
-          throw new Error("Error: Vec2 components cannot be NaN");
+          throw new Error("Vec2 components cannot be NaN");
         }
         let tmp2;
         if (ret2 != null && ret2.zpp_disp) {
-          throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this14 = ret2.zpp_inner;
         if (_this14._validate != null) {
@@ -2286,7 +2286,7 @@ export class ZPP_Space {
         }
         if (ret2.zpp_inner.x == x5) {
           if (ret2 != null && ret2.zpp_disp) {
-            throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+            throw new Error("Vec2 has been disposed and cannot be used!");
           }
           const _this15 = ret2.zpp_inner;
           if (_this15._validate != null) {
@@ -2323,7 +2323,7 @@ export class ZPP_Space {
             if (_this.type == 1) {
               const _this1 = _this.polygon;
               if (_this1.lverts.next == null) {
-                throw new Error("Error: An empty polygon has no meaningful localCOM");
+                throw new Error("An empty polygon has no meaningful localCOM");
               }
               if (_this1.lverts.next.next == null) {
                 _this1.localCOMx = _this1.lverts.next.x;
@@ -2494,7 +2494,7 @@ export class ZPP_Space {
             if (_this.type == 1) {
               const _this1 = _this.polygon;
               if (_this1.lverts.next == null) {
-                throw new Error("Error: An empty polygon has no meaningful localCOM");
+                throw new Error("An empty polygon has no meaningful localCOM");
               }
               if (_this1.lverts.next.next == null) {
                 _this1.localCOMx = _this1.lverts.next.x;
@@ -2830,7 +2830,7 @@ export class ZPP_Space {
             x4 = 0;
           }
           if (x4 != x4 || y4 != y4) {
-            throw new Error("Error: Vec2 components cannot be NaN");
+            throw new Error("Vec2 components cannot be NaN");
           }
           let ret1;
           if (ZPP_Space._zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -2861,21 +2861,21 @@ export class ZPP_Space {
             ret1.zpp_inner.outer = ret1;
           } else {
             if (ret1 != null && ret1.zpp_disp) {
-              throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+              throw new Error("Vec2 has been disposed and cannot be used!");
             }
             const _this9 = ret1.zpp_inner;
             if (_this9._immutable) {
-              throw new Error("Error: Vec2 is immutable");
+              throw new Error("Vec2 is immutable");
             }
             if (_this9._isimmutable != null) {
               _this9._isimmutable();
             }
             if (x4 != x4 || y4 != y4) {
-              throw new Error("Error: Vec2 components cannot be NaN");
+              throw new Error("Vec2 components cannot be NaN");
             }
             let res;
             if (ret1 != null && ret1.zpp_disp) {
-              throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+              throw new Error("Vec2 has been disposed and cannot be used!");
             }
             const _this10 = ret1.zpp_inner;
             if (_this10._validate != null) {
@@ -2883,7 +2883,7 @@ export class ZPP_Space {
             }
             if (ret1.zpp_inner.x == x4) {
               if (ret1 != null && ret1.zpp_disp) {
-                throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                throw new Error("Vec2 has been disposed and cannot be used!");
               }
               const _this11 = ret1.zpp_inner;
               if (_this11._validate != null) {
@@ -2912,7 +2912,7 @@ export class ZPP_Space {
             x5 = 0;
           }
           if (x5 != x5 || y5 != y5) {
-            throw new Error("Error: Vec2 components cannot be NaN");
+            throw new Error("Vec2 components cannot be NaN");
           }
           let ret3;
           if (ZPP_Space._zpp.util.ZPP_PubPool.poolVec2 == null) {
@@ -2943,21 +2943,21 @@ export class ZPP_Space {
             ret3.zpp_inner.outer = ret3;
           } else {
             if (ret3 != null && ret3.zpp_disp) {
-              throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+              throw new Error("Vec2 has been disposed and cannot be used!");
             }
             const _this13 = ret3.zpp_inner;
             if (_this13._immutable) {
-              throw new Error("Error: Vec2 is immutable");
+              throw new Error("Vec2 is immutable");
             }
             if (_this13._isimmutable != null) {
               _this13._isimmutable();
             }
             if (x5 != x5 || y5 != y5) {
-              throw new Error("Error: Vec2 components cannot be NaN");
+              throw new Error("Vec2 components cannot be NaN");
             }
             let res1;
             if (ret3 != null && ret3.zpp_disp) {
-              throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+              throw new Error("Vec2 has been disposed and cannot be used!");
             }
             const _this14 = ret3.zpp_inner;
             if (_this14._validate != null) {
@@ -2965,7 +2965,7 @@ export class ZPP_Space {
             }
             if (ret3.zpp_inner.x == x5) {
               if (ret3 != null && ret3.zpp_disp) {
-                throw new Error("Error: " + "Vec2" + " has been disposed and cannot be used!");
+                throw new Error("Vec2 has been disposed and cannot be used!");
               }
               const _this15 = ret3.zpp_inner;
               if (_this15._validate != null) {
@@ -2991,10 +2991,10 @@ export class ZPP_Space {
           while (cx_ite5 != null) {
             const j = cx_ite5.elt;
             if (res2.zpp_inner.next != null) {
-              throw new Error("Error: This object has been disposed of and cannot be used");
+              throw new Error("This object has been disposed of and cannot be used");
             }
             if (j.zpp_inner.next != null) {
-              throw new Error("Error: This object has been disposed of and cannot be used");
+              throw new Error("This object has been disposed of and cannot be used");
             }
             if (res2.zpp_inner.toiDistance < j.zpp_inner.toiDistance) {
               break;
@@ -6206,7 +6206,7 @@ export class ZPP_Space {
   static_validation(body: any) {
     if (body.shapes.head != null) {
       if (body.shapes.head == null) {
-        throw new Error("Error: Body bounds only makes sense if it contains shapes");
+        throw new Error("Body bounds only makes sense if it contains shapes");
       }
       if (body.zip_aabb) {
         body.zip_aabb = false;
@@ -6230,7 +6230,7 @@ export class ZPP_Space {
                       if (_this.type == 1) {
                         const _this1 = _this.polygon;
                         if (_this1.lverts.next == null) {
-                          throw new Error("Error: An empty polygon has no meaningful localCOM");
+                          throw new Error("An empty polygon has no meaningful localCOM");
                         }
                         if (_this1.lverts.next.next == null) {
                           _this1.localCOMx = _this1.lverts.next.x;
@@ -6333,7 +6333,7 @@ export class ZPP_Space {
                   }
                 }
                 if (_this3.lverts.next == null) {
-                  throw new Error("Error: An empty polygon has no meaningful bounds");
+                  throw new Error("An empty polygon has no meaningful bounds");
                 }
                 const p0 = _this3.gverts.next;
                 _this3.aabb.minx = p0.x;
@@ -6618,7 +6618,7 @@ export class ZPP_Space {
       cur.validate_inertia();
       if (cur.shapes.head != null) {
         if (cur.shapes.head == null) {
-          throw new Error("Error: Body bounds only makes sense if it contains shapes");
+          throw new Error("Body bounds only makes sense if it contains shapes");
         }
         if (cur.zip_aabb) {
           cur.zip_aabb = false;
@@ -6642,7 +6642,7 @@ export class ZPP_Space {
                         if (_this5.type == 1) {
                           const _this6 = _this5.polygon;
                           if (_this6.lverts.next == null) {
-                            throw new Error("Error: An empty polygon has no meaningful localCOM");
+                            throw new Error("An empty polygon has no meaningful localCOM");
                           }
                           if (_this6.lverts.next.next == null) {
                             _this6.localCOMx = _this6.lverts.next.x;
@@ -6749,7 +6749,7 @@ export class ZPP_Space {
                     }
                   }
                   if (_this8.lverts.next == null) {
-                    throw new Error("Error: An empty polygon has no meaningful bounds");
+                    throw new Error("An empty polygon has no meaningful bounds");
                   }
                   const p0 = _this8.gverts.next;
                   _this8.aabb.minx = p0.x;
@@ -6947,7 +6947,7 @@ export class ZPP_Space {
       cur1.validate_inertia();
       if (cur1.shapes.head != null) {
         if (cur1.shapes.head == null) {
-          throw new Error("Error: Body bounds only makes sense if it contains shapes");
+          throw new Error("Body bounds only makes sense if it contains shapes");
         }
         if (cur1.zip_aabb) {
           cur1.zip_aabb = false;
@@ -6971,7 +6971,7 @@ export class ZPP_Space {
                         if (_this15.type == 1) {
                           const _this16 = _this15.polygon;
                           if (_this16.lverts.next == null) {
-                            throw new Error("Error: An empty polygon has no meaningful localCOM");
+                            throw new Error("An empty polygon has no meaningful localCOM");
                           }
                           if (_this16.lverts.next.next == null) {
                             _this16.localCOMx = _this16.lverts.next.x;
@@ -7080,7 +7080,7 @@ export class ZPP_Space {
                     }
                   }
                   if (_this18.lverts.next == null) {
-                    throw new Error("Error: An empty polygon has no meaningful bounds");
+                    throw new Error("An empty polygon has no meaningful bounds");
                   }
                   const p01 = _this18.gverts.next;
                   _this18.aabb.minx = p01.x;

--- a/packages/nape-js/src/native/space/ZPP_SpatialHashPhase.ts
+++ b/packages/nape-js/src/native/space/ZPP_SpatialHashPhase.ts
@@ -117,7 +117,7 @@ export class ZPP_SpatialHashPhase extends ZPP_Broadphase {
                   if (_this.type == 1) {
                     const _this1 = _this.polygon;
                     if (_this1.lverts.next == null) {
-                      throw new Error("Error: An empty polygon has no meaningful localCOM");
+                      throw new Error("An empty polygon has no meaningful localCOM");
                     }
                     if (_this1.lverts.next.next == null) {
                       _this1.localCOMx = _this1.lverts.next.x;
@@ -220,7 +220,7 @@ export class ZPP_SpatialHashPhase extends ZPP_Broadphase {
               }
             }
             if (_this3.lverts.next == null) {
-              throw new Error("Error: An empty polygon has no meaningful bounds");
+              throw new Error("An empty polygon has no meaningful bounds");
             }
             const p0 = _this3.gverts.next;
             _this3.aabb.minx = p0.x;
@@ -877,12 +877,12 @@ export class ZPP_SpatialHashPhase extends ZPP_Broadphase {
               : ray.polysect(shape.polygon, inner, mint);
           if (result != null) {
             if (result.zpp_inner.next != null) {
-              throw new Error("Error: This object has been disposed of and cannot be used");
+              throw new Error("This object has been disposed of and cannot be used");
             }
             mint = result.zpp_inner.toiDistance;
             if (minres != null) {
               if (minres.zpp_inner.next != null) {
-                throw new Error("Error: This object has been disposed of and cannot be used");
+                throw new Error("This object has been disposed of and cannot be used");
               }
               minres.zpp_inner.free();
             }

--- a/packages/nape-js/src/native/space/ZPP_SweepPhase.ts
+++ b/packages/nape-js/src/native/space/ZPP_SweepPhase.ts
@@ -88,7 +88,7 @@ export class ZPP_SweepPhase extends ZPP_Broadphase {
                   if (_this.type == 1) {
                     const _this1 = _this.polygon;
                     if (_this1.lverts.next == null) {
-                      throw new Error("Error: An empty polygon has no meaningful localCOM");
+                      throw new Error("An empty polygon has no meaningful localCOM");
                     }
                     if (_this1.lverts.next.next == null) {
                       _this1.localCOMx = _this1.lverts.next.x;
@@ -191,7 +191,7 @@ export class ZPP_SweepPhase extends ZPP_Broadphase {
               }
             }
             if (_this3.lverts.next == null) {
-              throw new Error("Error: An empty polygon has no meaningful bounds");
+              throw new Error("An empty polygon has no meaningful bounds");
             }
             const p0 = _this3.gverts.next;
             _this3.aabb.minx = p0.x;
@@ -872,12 +872,12 @@ export class ZPP_SweepPhase extends ZPP_Broadphase {
                 : ray.polysect(a.shape.polygon, inner, mint);
             if (result != null) {
               if (result.zpp_inner.next != null) {
-                throw new Error("Error: This object has been disposed of and cannot be used");
+                throw new Error("This object has been disposed of and cannot be used");
               }
               mint = result.zpp_inner.toiDistance;
               if (minres != null) {
                 if (minres.zpp_inner.next != null) {
-                  throw new Error("Error: This object has been disposed of and cannot be used");
+                  throw new Error("This object has been disposed of and cannot be used");
                 }
                 minres.zpp_inner.free();
               }
@@ -924,12 +924,12 @@ export class ZPP_SweepPhase extends ZPP_Broadphase {
                 : ray.polysect(a1.shape.polygon, inner, mint);
             if (result1 != null) {
               if (result1.zpp_inner.next != null) {
-                throw new Error("Error: This object has been disposed of and cannot be used");
+                throw new Error("This object has been disposed of and cannot be used");
               }
               mint = result1.zpp_inner.toiDistance;
               if (minres != null) {
                 if (minres.zpp_inner.next != null) {
-                  throw new Error("Error: This object has been disposed of and cannot be used");
+                  throw new Error("This object has been disposed of and cannot be used");
                 }
                 minres.zpp_inner.free();
               }
@@ -974,12 +974,12 @@ export class ZPP_SweepPhase extends ZPP_Broadphase {
                 : ray.polysect(a2.shape.polygon, inner, mint);
             if (result2 != null) {
               if (result2.zpp_inner.next != null) {
-                throw new Error("Error: This object has been disposed of and cannot be used");
+                throw new Error("This object has been disposed of and cannot be used");
               }
               mint = result2.zpp_inner.toiDistance;
               if (minres != null) {
                 if (minres.zpp_inner.next != null) {
-                  throw new Error("Error: This object has been disposed of and cannot be used");
+                  throw new Error("This object has been disposed of and cannot be used");
                 }
                 minres.zpp_inner.free();
               }

--- a/packages/nape-js/src/native/util/ZPP_MixVec2List.ts
+++ b/packages/nape-js/src/native/util/ZPP_MixVec2List.ts
@@ -127,7 +127,7 @@ Object.defineProperty((ZPP_MixVec2ListCtor as any).prototype, "length", {
 (ZPP_MixVec2ListCtor as any).prototype.at = function (this: any, index: number): any {
   this.zpp_vm();
   if (index < 0 || index >= this.zpp_gl()) {
-    throw new Error("Error: Index out of bounds");
+    throw new Error("Index out of bounds");
   }
   if (this.zpp_inner.reverse_flag) {
     index = this.zpp_gl() - 1 - index;
@@ -149,12 +149,12 @@ Object.defineProperty((ZPP_MixVec2ListCtor as any).prototype, "length", {
 
 (ZPP_MixVec2ListCtor as any).prototype.push = function (this: any, obj: any): boolean {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   this.zpp_vm();
   if (obj.zpp_inner._inuse) {
-    throw new Error("Error: Vec2 is already in use");
+    throw new Error("Vec2 is already in use");
   }
   const cont = this.zpp_inner.adder != null ? this.zpp_inner.adder(obj) : true;
   if (cont) {
@@ -178,12 +178,12 @@ Object.defineProperty((ZPP_MixVec2ListCtor as any).prototype, "length", {
 
 (ZPP_MixVec2ListCtor as any).prototype.unshift = function (this: any, obj: any): boolean {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   this.zpp_vm();
   if (obj.zpp_inner._inuse) {
-    throw new Error("Error: Vec2 is already in use");
+    throw new Error("Vec2 is already in use");
   }
   const cont = this.zpp_inner.adder != null ? this.zpp_inner.adder(obj) : true;
   if (cont) {
@@ -207,11 +207,11 @@ Object.defineProperty((ZPP_MixVec2ListCtor as any).prototype, "length", {
 
 (ZPP_MixVec2ListCtor as any).prototype.pop = function (this: any): any {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   if (this.empty()) {
-    throw new Error("Error: Cannot remove from empty list");
+    throw new Error("Cannot remove from empty list");
   }
   this.zpp_vm();
   let ret: any;
@@ -248,11 +248,11 @@ Object.defineProperty((ZPP_MixVec2ListCtor as any).prototype, "length", {
 
 (ZPP_MixVec2ListCtor as any).prototype.shift = function (this: any): any {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   if (this.empty()) {
-    throw new Error("Error: Cannot remove from empty list");
+    throw new Error("Cannot remove from empty list");
   }
   this.zpp_vm();
   let ret: any;
@@ -289,7 +289,7 @@ Object.defineProperty((ZPP_MixVec2ListCtor as any).prototype, "length", {
 
 (ZPP_MixVec2ListCtor as any).prototype.remove = function (this: any, obj: any): boolean {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   this.zpp_inner.modify_test();
   this.zpp_vm();
@@ -320,7 +320,7 @@ Object.defineProperty((ZPP_MixVec2ListCtor as any).prototype, "length", {
 
 (ZPP_MixVec2ListCtor as any).prototype.clear = function (this: any): void {
   if (this.zpp_inner.immutable) {
-    throw new Error("Error: Vec2List is immutable");
+    throw new Error("Vec2List is immutable");
   }
   if (this.zpp_inner.reverse_flag) {
     while (!this.empty()) this.pop();

--- a/packages/nape-js/src/phys/Body.ts
+++ b/packages/nape-js/src/phys/Body.ts
@@ -32,7 +32,7 @@ import type { GravMassMode } from "./GravMassMode";
 /** Read validated x from a Vec2 input. */
 function _readVec2X(v: Vec2): number {
   if (v.zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -42,7 +42,7 @@ function _readVec2X(v: Vec2): number {
 /** Read validated y from a Vec2 input. */
 function _readVec2Y(v: Vec2): number {
   if (v.zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
   const inner = v.zpp_inner;
   if (inner._validate != null) inner._validate();
@@ -52,7 +52,7 @@ function _readVec2Y(v: Vec2): number {
 /** Check a Vec2 is not disposed. */
 function _checkVec2Disposed(v: Vec2): void {
   if (v != null && v.zpp_disp) {
-    throw new Error("Error: Vec2 has been disposed and cannot be used!");
+    throw new Error("Vec2 has been disposed and cannot be used!");
   }
 }
 
@@ -76,7 +76,7 @@ function _setVec2Prop(
 ): Vec2 {
   _checkVec2Disposed(source);
   if (source == null) {
-    throw new Error("Error: Body::" + propName + " cannot be null");
+    throw new Error("Body::" + propName + " cannot be null");
   }
   if (wrapper == null && setupFn != null) {
     setupFn();
@@ -150,11 +150,11 @@ export class Body extends Interactor {
 
     zpp.immutable_midstep("Body::type");
     if (zpp.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (ZPP_Body.types[zpp.type] !== type1) {
       if (type1 == null) {
-        throw new Error("Error: Cannot use null BodyType");
+        throw new Error("Cannot use null BodyType");
       }
       const ntype = _bodyTypeToInt(type1, nape);
       if (ntype === 1 && zpp.space != null) {
@@ -216,11 +216,11 @@ export class Body extends Interactor {
     const zpp = this.zpp_inner;
     zpp.immutable_midstep("Body::type");
     if (zpp.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (ZPP_Body.types[zpp.type] !== value) {
       if (value == null) {
-        throw new Error("Error: Cannot use null BodyType");
+        throw new Error("Cannot use null BodyType");
       }
       const nape = getNape();
       const ntype = _bodyTypeToInt(value, nape);
@@ -286,14 +286,14 @@ export class Body extends Interactor {
     const zpp = this.zpp_inner;
     zpp.immutable_midstep("Body::rotation");
     if (zpp.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (zpp.type === 1 && zpp.space != null) {
-      throw new Error("Error: Static objects cannot be rotated once inside a Space");
+      throw new Error("Static objects cannot be rotated once inside a Space");
     }
     if (zpp.rot !== value) {
       if (value !== value) {
-        throw new Error("Error: Body::rotation cannot be NaN");
+        throw new Error("Body::rotation cannot be NaN");
       }
       zpp.rot = value;
       zpp.invalidate_rot();
@@ -332,14 +332,14 @@ export class Body extends Interactor {
   set angularVel(value: number) {
     const zpp = this.zpp_inner;
     if (zpp.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (zpp.angvel !== value) {
       if (value !== value) {
-        throw new Error("Error: Body::angularVel cannot be NaN");
+        throw new Error("Body::angularVel cannot be NaN");
       }
       if (zpp.type === 1) {
-        throw new Error("Error: A static object cannot be given a velocity");
+        throw new Error("A static object cannot be given a velocity");
       }
       zpp.angvel = value;
       zpp.wake();
@@ -373,11 +373,11 @@ export class Body extends Interactor {
   set kinAngVel(value: number) {
     const zpp = this.zpp_inner;
     if (zpp.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (zpp.kinangvel !== value) {
       if (value !== value) {
-        throw new Error("Error: Body::kinAngVel cannot be NaN");
+        throw new Error("Body::kinAngVel cannot be NaN");
       }
       zpp.kinangvel = value;
       zpp.wake();
@@ -435,13 +435,13 @@ export class Body extends Interactor {
   set torque(value: number) {
     const zpp = this.zpp_inner;
     if (zpp.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (zpp.type !== 2) {
-      throw new Error("Error: Non-dynamic body cannot have torque applied.");
+      throw new Error("Non-dynamic body cannot have torque applied.");
     }
     if (value !== value) {
-      throw new Error("Error: Body::torque cannot be NaN");
+      throw new Error("Body::torque cannot be NaN");
     }
     if (zpp.torque !== value) {
       zpp.torque = value;
@@ -459,7 +459,7 @@ export class Body extends Interactor {
    */
   get mass(): number {
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world has no mass");
+      throw new Error("Space::world has no mass");
     }
     this.zpp_inner.validate_mass();
     if (this.zpp_inner.massMode === 0 && this.zpp_inner.shapes.head == null) {
@@ -472,16 +472,16 @@ export class Body extends Interactor {
   set mass(value: number) {
     this.zpp_inner.immutable_midstep("Body::mass");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (value !== value) {
-      throw new Error("Error: Mass cannot be NaN");
+      throw new Error("Mass cannot be NaN");
     }
     if (value <= 0) {
-      throw new Error("Error: Mass must be strictly positive");
+      throw new Error("Mass must be strictly positive");
     }
     if (value >= Infinity) {
-      throw new Error("Error: Mass cannot be infinite, use allowMovement = false instead");
+      throw new Error("Mass cannot be infinite, use allowMovement = false instead");
     }
     this.zpp_inner.massMode = 1;
     this.zpp_inner.cmass = value;
@@ -494,7 +494,7 @@ export class Body extends Interactor {
    */
   get inertia(): number {
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world has no inertia");
+      throw new Error("Space::world has no inertia");
     }
     this.zpp_inner.validate_inertia();
     if (this.zpp_inner.inertiaMode === 0 && this.zpp_inner.shapes.head == null) {
@@ -507,16 +507,16 @@ export class Body extends Interactor {
   set inertia(value: number) {
     this.zpp_inner.immutable_midstep("Body::inertia");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (value !== value) {
-      throw new Error("Error: Inertia cannot be NaN");
+      throw new Error("Inertia cannot be NaN");
     }
     if (value <= 0) {
-      throw new Error("Error: Inertia must be strictly positive");
+      throw new Error("Inertia must be strictly positive");
     }
     if (value >= Infinity) {
-      throw new Error("Error: Inertia cannot be infinite, use allowRotation = false instead");
+      throw new Error("Inertia cannot be infinite, use allowRotation = false instead");
     }
     this.zpp_inner.inertiaMode = 1;
     this.zpp_inner.cinertia = value;
@@ -542,7 +542,7 @@ export class Body extends Interactor {
   /** Gravitational mass. Defaults to the same as `mass`. */
   get gravMass(): number {
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world has no gravMass");
+      throw new Error("Space::world has no gravMass");
     }
     this.zpp_inner.validate_gravMass();
     if (this.zpp_inner.shapes.head == null) {
@@ -557,10 +557,10 @@ export class Body extends Interactor {
   set gravMass(value: number) {
     this.zpp_inner.immutable_midstep("Body::gravMass");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (value !== value) {
-      throw new Error("Error: gravMass cannot be NaN");
+      throw new Error("gravMass cannot be NaN");
     }
     this.zpp_inner.gravMassMode = 1;
     this.zpp_inner.gravMass = value;
@@ -582,10 +582,10 @@ export class Body extends Interactor {
   set gravMassScale(value: number) {
     this.zpp_inner.immutable_midstep("Body::gravMassScale");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (value !== value) {
-      throw new Error("Error: gravMassScale cannot be NaN");
+      throw new Error("gravMassScale cannot be NaN");
     }
     this.zpp_inner.gravMassMode = 2;
     this.zpp_inner.gravMassScale = value;
@@ -672,7 +672,7 @@ export class Body extends Interactor {
     }
     this.zpp_inner.immutable_midstep("Body::space");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     const currentSpace = this.zpp_inner.space == null ? null : this.zpp_inner.space.outer;
     if (currentSpace !== space) {
@@ -719,7 +719,7 @@ export class Body extends Interactor {
    */
   get bounds(): AABB {
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world has no bounds");
+      throw new Error("Space::world has no bounds");
     }
     return AABB._wrap(this.zpp_inner.aabb.wrapper());
   }
@@ -738,7 +738,7 @@ export class Body extends Interactor {
    */
   get localCOM(): Vec2 {
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world has no localCOM");
+      throw new Error("Space::world has no localCOM");
     }
     if (this.zpp_inner.wrap_localCOM == null) {
       const ret = Vec2.get(this.zpp_inner.localCOMx, this.zpp_inner.localCOMy);
@@ -756,7 +756,7 @@ export class Body extends Interactor {
    */
   get worldCOM(): Vec2 {
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world has no worldCOM");
+      throw new Error("Space::world has no worldCOM");
     }
     if (this.zpp_inner.wrap_worldCOM == null) {
       const ret = Vec2.get(this.zpp_inner.worldCOMx, this.zpp_inner.worldCOMy);
@@ -783,10 +783,10 @@ export class Body extends Interactor {
     const nape = getNape();
     this.zpp_inner.immutable_midstep("Body::massMode");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (value == null) {
-      throw new Error("Error: cannot use null massMode");
+      throw new Error("cannot use null massMode");
     }
     const d = _ensureFlag("MassMode_DEFAULT", () => new nape.phys.MassMode());
     this.zpp_inner.massMode = value === d ? 0 : 1;
@@ -804,10 +804,10 @@ export class Body extends Interactor {
     const nape = getNape();
     this.zpp_inner.immutable_midstep("Body::inertiaMode");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (value == null) {
-      throw new Error("Error: Cannot use null InertiaMode");
+      throw new Error("Cannot use null InertiaMode");
     }
     const f = _ensureFlag("InertiaMode_FIXED", () => new nape.phys.InertiaMode());
     this.zpp_inner.inertiaMode = value === f ? 1 : 0;
@@ -826,10 +826,10 @@ export class Body extends Interactor {
     const nape = getNape();
     this.zpp_inner.immutable_midstep("Body::gravMassMode");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (value == null) {
-      throw new Error("Error: Cannot use null gravMassMode");
+      throw new Error("Cannot use null gravMassMode");
     }
     const s = _ensureFlag("GravMassMode_SCALED", () => new nape.phys.GravMassMode());
     if (value === s) {
@@ -852,7 +852,7 @@ export class Body extends Interactor {
    */
   copy(): Body {
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world cannot be copied");
+      throw new Error("Space::world cannot be copied");
     }
     return this.zpp_inner.copy();
   }
@@ -889,7 +889,7 @@ export class Body extends Interactor {
     }
     this.zpp_inner.immutable_midstep("Body::space");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (deltaTime === 0) {
       return this;
@@ -940,7 +940,7 @@ export class Body extends Interactor {
   localPointToWorld(point: Vec2, weak: boolean = false): Vec2 {
     _checkVec2Disposed(point);
     if (point == null) {
-      throw new Error("Error: Cannot transform null Vec2");
+      throw new Error("Cannot transform null Vec2");
     }
     this.zpp_inner.validate_axis();
     const px = _readVec2X(point);
@@ -960,7 +960,7 @@ export class Body extends Interactor {
   worldPointToLocal(point: Vec2, weak: boolean = false): Vec2 {
     _checkVec2Disposed(point);
     if (point == null) {
-      throw new Error("Error: Cannot transform null Vec2");
+      throw new Error("Cannot transform null Vec2");
     }
     this.zpp_inner.validate_axis();
     const px = _readVec2X(point) - this.zpp_inner.posx;
@@ -980,7 +980,7 @@ export class Body extends Interactor {
   localVectorToWorld(vector: Vec2, weak: boolean = false): Vec2 {
     _checkVec2Disposed(vector);
     if (vector == null) {
-      throw new Error("Error: Cannot transform null Vec2");
+      throw new Error("Cannot transform null Vec2");
     }
     this.zpp_inner.validate_axis();
     const vx = _readVec2X(vector);
@@ -1000,7 +1000,7 @@ export class Body extends Interactor {
   worldVectorToLocal(vector: Vec2, weak: boolean = false): Vec2 {
     _checkVec2Disposed(vector);
     if (vector == null) {
-      throw new Error("Error: Cannot transform null Vec2");
+      throw new Error("Cannot transform null Vec2");
     }
     this.zpp_inner.validate_axis();
     const vx = _readVec2X(vector);
@@ -1028,10 +1028,10 @@ export class Body extends Interactor {
     _checkVec2Disposed(impulse);
     if (pos != null) _checkVec2Disposed(pos);
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (impulse == null) {
-      throw new Error("Error: Cannot apply null impulse to Body");
+      throw new Error("Cannot apply null impulse to Body");
     }
     // If sleepable and body is sleeping, dispose weak Vec2s and return
     if (sleepable && this.isSleeping) {
@@ -1069,7 +1069,7 @@ export class Body extends Interactor {
    */
   applyAngularImpulse(impulse: number, sleepable: boolean = false): Body {
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (sleepable && this.isSleeping) {
       return this;
@@ -1114,14 +1114,14 @@ export class Body extends Interactor {
     // Set angular velocity
     const angularVel = (targetRotation - this.zpp_inner.rot) * idt;
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (this.zpp_inner.angvel !== angularVel) {
       if (angularVel !== angularVel) {
-        throw new Error("Error: Body::angularVel cannot be NaN");
+        throw new Error("Body::angularVel cannot be NaN");
       }
       if (this.zpp_inner.type === 1) {
-        throw new Error("Error: A static object cannot be given a velocity");
+        throw new Error("A static object cannot be given a velocity");
       }
       this.zpp_inner.angvel = angularVel;
       this.zpp_inner.wake();
@@ -1143,10 +1143,10 @@ export class Body extends Interactor {
     this.zpp_inner.immutable_midstep("Body::translateShapes()");
     _checkVec2Disposed(translation);
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (translation == null) {
-      throw new Error("Error: Cannot displace by null Vec2");
+      throw new Error("Cannot displace by null Vec2");
     }
     const weak = translation.zpp_inner.weak;
     translation.zpp_inner.weak = false;
@@ -1168,7 +1168,7 @@ export class Body extends Interactor {
   rotateShapes(angle: number): Body {
     this.zpp_inner.immutable_midstep("Body::rotateShapes()");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     let cx_ite = this.zpp_inner.shapes.head;
     while (cx_ite != null) {
@@ -1187,7 +1187,7 @@ export class Body extends Interactor {
   scaleShapes(scaleX: number, scaleY: number): Body {
     this.zpp_inner.immutable_midstep("Body::scaleShapes()");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     let cx_ite = this.zpp_inner.shapes.head;
     while (cx_ite != null) {
@@ -1205,7 +1205,7 @@ export class Body extends Interactor {
   transformShapes(matrix: Mat23): Body {
     this.zpp_inner.immutable_midstep("Body::transformShapes()");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     let cx_ite = this.zpp_inner.shapes.head;
     while (cx_ite != null) {
@@ -1223,10 +1223,10 @@ export class Body extends Interactor {
   align(): Body {
     this.zpp_inner.immutable_midstep("Body::align()");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     if (this.zpp_inner.shapes.head == null) {
-      throw new Error("Error: Cannot align empty Body");
+      throw new Error("Cannot align empty Body");
     }
     this.zpp_inner.validate_localCOM();
     const dx = Vec2.get(-this.zpp_inner.localCOMx, -this.zpp_inner.localCOMy);
@@ -1256,10 +1256,10 @@ export class Body extends Interactor {
   rotate(centre: Vec2, angle: number): Body {
     _checkVec2Disposed(centre);
     if (centre == null) {
-      throw new Error("Error: Cannot rotate about a null Vec2");
+      throw new Error("Cannot rotate about a null Vec2");
     }
     if (angle !== angle) {
-      throw new Error("Error: Cannot rotate by NaN radians");
+      throw new Error("Cannot rotate by NaN radians");
     }
     const weak = centre.zpp_inner.weak;
     centre.zpp_inner.weak = false;
@@ -1287,14 +1287,14 @@ export class Body extends Interactor {
       const zpp = this.zpp_inner;
       zpp.immutable_midstep("Body::rotation");
       if (zpp.world) {
-        throw new Error("Error: Space::world is immutable");
+        throw new Error("Space::world is immutable");
       }
       if (zpp.type === 1 && zpp.space != null) {
-        throw new Error("Error: Static objects cannot be rotated once inside a Space");
+        throw new Error("Static objects cannot be rotated once inside a Space");
       }
       if (zpp.rot !== newRot) {
         if (newRot !== newRot) {
-          throw new Error("Error: Body::rotation cannot be NaN");
+          throw new Error("Body::rotation cannot be NaN");
         }
         zpp.rot = newRot;
         zpp.invalidate_rot();
@@ -1314,14 +1314,14 @@ export class Body extends Interactor {
   setShapeMaterials(material: Material): Body {
     this.zpp_inner.immutable_midstep("Body::setShapeMaterials()");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     let cx_ite = this.zpp_inner.shapes.head;
     while (cx_ite != null) {
       const shape = cx_ite.elt.outer;
       shape.zpp_inner.immutable_midstep("Shape::material");
       if (material == null) {
-        throw new Error("Error: Cannot assign null as Shape material");
+        throw new Error("Cannot assign null as Shape material");
       }
       shape.zpp_inner.setMaterial(material.zpp_inner);
       shape.zpp_inner.material.wrapper();
@@ -1338,14 +1338,14 @@ export class Body extends Interactor {
   setShapeFilters(filter: InteractionFilter): Body {
     this.zpp_inner.immutable_midstep("Body::setShapeFilters()");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     let cx_ite = this.zpp_inner.shapes.head;
     while (cx_ite != null) {
       const shape = cx_ite.elt.outer;
       shape.zpp_inner.immutable_midstep("Shape::filter");
       if (filter == null) {
-        throw new Error("Error: Cannot assign null as Shape filter");
+        throw new Error("Cannot assign null as Shape filter");
       }
       shape.zpp_inner.setFilter(filter.zpp_inner);
       shape.zpp_inner.filter.wrapper();
@@ -1362,7 +1362,7 @@ export class Body extends Interactor {
   setShapeFluidProperties(fluidProperties: FluidProperties): Body {
     this.zpp_inner.immutable_midstep("Body::setShapeFluidProperties()");
     if (this.zpp_inner.world) {
-      throw new Error("Error: Space::world is immutable");
+      throw new Error("Space::world is immutable");
     }
     const nape = getNape();
     let cx_ite = this.zpp_inner.shapes.head;
@@ -1396,7 +1396,7 @@ export class Body extends Interactor {
   contains(point: Vec2): boolean {
     _checkVec2Disposed(point);
     if (point == null) {
-      throw new Error("Error: Cannot check containment of null point");
+      throw new Error("Cannot check containment of null point");
     }
     const wasWeak = point.zpp_inner.weak;
     point.zpp_inner.weak = false;

--- a/packages/nape-js/src/phys/BodyType.ts
+++ b/packages/nape-js/src/phys/BodyType.ts
@@ -13,7 +13,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class BodyType {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate BodyType derp!");
+      throw new Error("Cannot instantiate BodyType derp!");
     }
   }
 

--- a/packages/nape-js/src/phys/Compound.ts
+++ b/packages/nape-js/src/phys/Compound.ts
@@ -151,7 +151,7 @@ export class Compound extends Interactor {
   /** Recursively visit all bodies in this compound and its sub-compounds. */
   visitBodies(lambda: (body: Body) => void): void {
     if (lambda == null) {
-      throw new Error("Error: lambda cannot be null for Compound::visitBodies");
+      throw new Error("lambda cannot be null for Compound::visitBodies");
     }
     const bodies = this.zpp_inner.wrap_bodies;
     const bLen = bodies.length;
@@ -168,7 +168,7 @@ export class Compound extends Interactor {
   /** Recursively visit all constraints in this compound and its sub-compounds. */
   visitConstraints(lambda: (constraint: Constraint) => void): void {
     if (lambda == null) {
-      throw new Error("Error: lambda cannot be null for Compound::visitConstraints");
+      throw new Error("lambda cannot be null for Compound::visitConstraints");
     }
     const constraints = this.zpp_inner.wrap_constraints;
     const cLen = constraints.length;
@@ -185,7 +185,7 @@ export class Compound extends Interactor {
   /** Recursively visit all sub-compounds in this compound. */
   visitCompounds(lambda: (compound: Compound) => void): void {
     if (lambda == null) {
-      throw new Error("Error: lambda cannot be null for Compound::visitConstraints");
+      throw new Error("lambda cannot be null for Compound::visitConstraints");
     }
     const compounds = this.zpp_inner.wrap_compounds;
     const compLen = compounds.length;
@@ -205,7 +205,7 @@ export class Compound extends Interactor {
       const shapes = b.zpp_inner.wrap_shapes;
       if (shapes.zpp_inner.inner.head != null) {
         if (b.zpp_inner.world) {
-          throw new Error("Error: Space::world has no worldCOM");
+          throw new Error("Space::world has no worldCOM");
         }
         // Get worldCOM
         if (b.zpp_inner.wrap_worldCOM == null) {
@@ -215,7 +215,7 @@ export class Compound extends Interactor {
 
         // Get mass
         if (b.zpp_inner.world) {
-          throw new Error("Error: Space::world has no mass");
+          throw new Error("Space::world has no mass");
         }
         b.zpp_inner.validate_mass();
         if (b.zpp_inner.massMode == 0 && b.zpp_inner.shapes.head == null) {
@@ -231,7 +231,7 @@ export class Compound extends Interactor {
     });
 
     if (total === 0.0) {
-      throw new Error("Error: COM of an empty Compound is undefined silly");
+      throw new Error("COM of an empty Compound is undefined silly");
     }
     ret.muleq(1 / total);
     if (weak) {
@@ -243,10 +243,10 @@ export class Compound extends Interactor {
   /** Translate all bodies in this compound by the given vector. */
   translate(translation: Vec2): Compound {
     if (translation != null && (translation as any).zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (translation == null) {
-      throw new Error("Error: Cannot translate by null Vec2");
+      throw new Error("Cannot translate by null Vec2");
     }
     const weak = translation.zpp_inner.weak;
     translation.zpp_inner.weak = false;
@@ -266,13 +266,13 @@ export class Compound extends Interactor {
   /** Rotate all bodies in this compound around the given centre point. */
   rotate(centre: Vec2, angle: number): Compound {
     if (centre != null && (centre as any).zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (centre == null) {
-      throw new Error("Error: Cannot rotate about a null Vec2");
+      throw new Error("Cannot rotate about a null Vec2");
     }
     if (angle !== angle) {
-      throw new Error("Error: Cannot rotate by NaN radians");
+      throw new Error("Cannot rotate by NaN radians");
     }
     const weak = centre.zpp_inner.weak;
     centre.zpp_inner.weak = false;

--- a/packages/nape-js/src/phys/FluidProperties.ts
+++ b/packages/nape-js/src/phys/FluidProperties.ts
@@ -43,7 +43,7 @@ export class FluidProperties {
     // --- Validate and set density (internal storage = value / 1000) ---
     if (density != zpp.density * 1000) {
       if (density !== density) {
-        throw new Error("Error: FluidProperties::density cannot be NaN");
+        throw new Error("FluidProperties::density cannot be NaN");
       }
       zpp.density = density / 1000;
       zpp.invalidate();
@@ -52,10 +52,10 @@ export class FluidProperties {
     // --- Validate and set viscosity ---
     if (viscosity != zpp.viscosity) {
       if (viscosity !== viscosity) {
-        throw new Error("Error: FluidProperties::viscosity cannot be NaN");
+        throw new Error("FluidProperties::viscosity cannot be NaN");
       }
       if (viscosity < 0) {
-        throw new Error("Error: FluidProperties::viscosity (" + viscosity + ") must be >= 0");
+        throw new Error("FluidProperties::viscosity (" + viscosity + ") must be >= 0");
       }
       zpp.viscosity = viscosity / 1;
       zpp.invalidate();
@@ -95,7 +95,7 @@ export class FluidProperties {
   set density(value: number) {
     if (value != this.zpp_inner.density * 1000) {
       if (value !== value) {
-        throw new Error("Error: FluidProperties::density cannot be NaN");
+        throw new Error("FluidProperties::density cannot be NaN");
       }
       this.zpp_inner.density = value / 1000;
       this.zpp_inner.invalidate();
@@ -108,10 +108,10 @@ export class FluidProperties {
   set viscosity(value: number) {
     if (value != this.zpp_inner.viscosity) {
       if (value !== value) {
-        throw new Error("Error: FluidProperties::viscosity cannot be NaN");
+        throw new Error("FluidProperties::viscosity cannot be NaN");
       }
       if (value < 0) {
-        throw new Error("Error: FluidProperties::viscosity (" + value + ") must be >= 0");
+        throw new Error("FluidProperties::viscosity (" + value + ") must be >= 0");
       }
       this.zpp_inner.viscosity = value / 1;
       this.zpp_inner.invalidate();
@@ -131,17 +131,17 @@ export class FluidProperties {
         this.zpp_inner.wrap_gravity.zpp_inner._inuse = false;
         const _this = this.zpp_inner.wrap_gravity;
         if (_this != null && _this.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this1 = _this.zpp_inner;
         if (_this1._immutable) {
-          throw new Error("Error: Vec2 is immutable");
+          throw new Error("Vec2 is immutable");
         }
         if (_this1._isimmutable != null) {
           _this1._isimmutable();
         }
         if (_this.zpp_inner._inuse) {
-          throw new Error("Error: This Vec2 is not disposable");
+          throw new Error("This Vec2 is not disposable");
         }
         const inner = _this.zpp_inner;
         _this.zpp_inner.outer = null;
@@ -169,30 +169,30 @@ export class FluidProperties {
       }
     } else {
       if (gravity != null && gravity.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       if (this.zpp_inner.wrap_gravity == null) {
         this.zpp_inner.getgravity();
       }
       const _this2 = this.zpp_inner.wrap_gravity;
       if (_this2 != null && _this2.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       if (gravity != null && gravity.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this3 = _this2.zpp_inner;
       if (_this3._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this3._isimmutable != null) {
         _this3._isimmutable();
       }
       if (gravity == null) {
-        throw new Error("Error: Cannot assign null Vec2");
+        throw new Error("Cannot assign null Vec2");
       }
       if (gravity != null && gravity.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this4 = gravity.zpp_inner;
       if (_this4._validate != null) {
@@ -200,7 +200,7 @@ export class FluidProperties {
       }
       const x = gravity.zpp_inner.x;
       if (gravity != null && gravity.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this5 = gravity.zpp_inner;
       if (_this5._validate != null) {
@@ -208,21 +208,21 @@ export class FluidProperties {
       }
       const y = gravity.zpp_inner.y;
       if (_this2 != null && _this2.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this6 = _this2.zpp_inner;
       if (_this6._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this6._isimmutable != null) {
         _this6._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp;
       if (_this2 != null && _this2.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this7 = _this2.zpp_inner;
       if (_this7._validate != null) {
@@ -230,7 +230,7 @@ export class FluidProperties {
       }
       if (_this2.zpp_inner.x == x) {
         if (_this2 != null && _this2.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this8 = _this2.zpp_inner;
         if (_this8._validate != null) {
@@ -250,17 +250,17 @@ export class FluidProperties {
       }
       if (gravity.zpp_inner.weak) {
         if (gravity != null && gravity.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this10 = gravity.zpp_inner;
         if (_this10._immutable) {
-          throw new Error("Error: Vec2 is immutable");
+          throw new Error("Vec2 is immutable");
         }
         if (_this10._isimmutable != null) {
           _this10._isimmutable();
         }
         if (gravity.zpp_inner._inuse) {
-          throw new Error("Error: This Vec2 is not disposable");
+          throw new Error("This Vec2 is not disposable");
         }
         const inner1 = gravity.zpp_inner;
         gravity.zpp_inner.outer = null;
@@ -327,17 +327,17 @@ export class FluidProperties {
         ret.zpp_inner.wrap_gravity.zpp_inner._inuse = false;
         const _this = ret.zpp_inner.wrap_gravity;
         if (_this != null && _this.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this1 = _this.zpp_inner;
         if (_this1._immutable) {
-          throw new Error("Error: Vec2 is immutable");
+          throw new Error("Vec2 is immutable");
         }
         if (_this1._isimmutable != null) {
           _this1._isimmutable();
         }
         if (_this.zpp_inner._inuse) {
-          throw new Error("Error: This Vec2 is not disposable");
+          throw new Error("This Vec2 is not disposable");
         }
         const inner = _this.zpp_inner;
         _this.zpp_inner.outer = null;
@@ -366,30 +366,30 @@ export class FluidProperties {
     } else {
       // Copy gravity from source
       if (gravity != null && gravity.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       if (ret.zpp_inner.wrap_gravity == null) {
         ret.zpp_inner.getgravity();
       }
       const _this2 = ret.zpp_inner.wrap_gravity;
       if (_this2 != null && _this2.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       if (gravity != null && gravity.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this3 = _this2.zpp_inner;
       if (_this3._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this3._isimmutable != null) {
         _this3._isimmutable();
       }
       if (gravity == null) {
-        throw new Error("Error: Cannot assign null Vec2");
+        throw new Error("Cannot assign null Vec2");
       }
       if (gravity != null && gravity.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this4 = gravity.zpp_inner;
       if (_this4._validate != null) {
@@ -397,7 +397,7 @@ export class FluidProperties {
       }
       const x = gravity.zpp_inner.x;
       if (gravity != null && gravity.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this5 = gravity.zpp_inner;
       if (_this5._validate != null) {
@@ -405,21 +405,21 @@ export class FluidProperties {
       }
       const y = gravity.zpp_inner.y;
       if (_this2 != null && _this2.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this6 = _this2.zpp_inner;
       if (_this6._immutable) {
-        throw new Error("Error: Vec2 is immutable");
+        throw new Error("Vec2 is immutable");
       }
       if (_this6._isimmutable != null) {
         _this6._isimmutable();
       }
       if (x != x || y != y) {
-        throw new Error("Error: Vec2 components cannot be NaN");
+        throw new Error("Vec2 components cannot be NaN");
       }
       let tmp;
       if (_this2 != null && _this2.zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const _this7 = _this2.zpp_inner;
       if (_this7._validate != null) {
@@ -427,7 +427,7 @@ export class FluidProperties {
       }
       if (_this2.zpp_inner.x == x) {
         if (_this2 != null && _this2.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this8 = _this2.zpp_inner;
         if (_this8._validate != null) {
@@ -447,17 +447,17 @@ export class FluidProperties {
       }
       if (gravity.zpp_inner.weak) {
         if (gravity != null && gravity.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         const _this10 = gravity.zpp_inner;
         if (_this10._immutable) {
-          throw new Error("Error: Vec2 is immutable");
+          throw new Error("Vec2 is immutable");
         }
         if (_this10._isimmutable != null) {
           _this10._isimmutable();
         }
         if (gravity.zpp_inner._inuse) {
-          throw new Error("Error: This Vec2 is not disposable");
+          throw new Error("This Vec2 is not disposable");
         }
         const inner1 = gravity.zpp_inner;
         gravity.zpp_inner.outer = null;

--- a/packages/nape-js/src/phys/GravMassMode.ts
+++ b/packages/nape-js/src/phys/GravMassMode.ts
@@ -13,7 +13,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class GravMassMode {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate GravMassMode derp!");
+      throw new Error("Cannot instantiate GravMassMode derp!");
     }
   }
 

--- a/packages/nape-js/src/phys/InertiaMode.ts
+++ b/packages/nape-js/src/phys/InertiaMode.ts
@@ -12,7 +12,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class InertiaMode {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate InertiaMode derp!");
+      throw new Error("Cannot instantiate InertiaMode derp!");
     }
   }
 

--- a/packages/nape-js/src/phys/MassMode.ts
+++ b/packages/nape-js/src/phys/MassMode.ts
@@ -12,7 +12,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class MassMode {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate MassMode derp!");
+      throw new Error("Cannot instantiate MassMode derp!");
     }
   }
 

--- a/packages/nape-js/src/phys/Material.ts
+++ b/packages/nape-js/src/phys/Material.ts
@@ -49,7 +49,7 @@ export class Material {
 
     if (elasticity !== zpp.elasticity) {
       if (elasticity !== elasticity) {
-        throw new Error("Error: Material::elasticity cannot be NaN");
+        throw new Error("Material::elasticity cannot be NaN");
       }
       zpp.elasticity = elasticity;
       zpp.invalidate(ZPP_Material.WAKE | ZPP_Material.ARBITERS);
@@ -57,10 +57,10 @@ export class Material {
 
     if (dynamicFriction !== zpp.dynamicFriction) {
       if (dynamicFriction !== dynamicFriction) {
-        throw new Error("Error: Material::dynamicFriction cannot be NaN");
+        throw new Error("Material::dynamicFriction cannot be NaN");
       }
       if (dynamicFriction < 0) {
-        throw new Error("Error: Material::dynamicFriction cannot be negative");
+        throw new Error("Material::dynamicFriction cannot be negative");
       }
       zpp.dynamicFriction = dynamicFriction;
       zpp.invalidate(ZPP_Material.WAKE | ZPP_Material.ANGDRAG | ZPP_Material.ARBITERS);
@@ -68,10 +68,10 @@ export class Material {
 
     if (staticFriction !== zpp.staticFriction) {
       if (staticFriction !== staticFriction) {
-        throw new Error("Error: Material::staticFriction cannot be NaN");
+        throw new Error("Material::staticFriction cannot be NaN");
       }
       if (staticFriction < 0) {
-        throw new Error("Error: Material::staticFriction cannot be negative");
+        throw new Error("Material::staticFriction cannot be negative");
       }
       zpp.staticFriction = staticFriction;
       zpp.invalidate(ZPP_Material.WAKE | ZPP_Material.ARBITERS);
@@ -79,10 +79,10 @@ export class Material {
 
     if (density !== zpp.density * 1000) {
       if (density !== density) {
-        throw new Error("Error: Material::density cannot be NaN");
+        throw new Error("Material::density cannot be NaN");
       }
       if (density < 0) {
-        throw new Error("Error: Material::density must be positive");
+        throw new Error("Material::density must be positive");
       }
       zpp.density = density / 1000;
       zpp.invalidate(ZPP_Material.WAKE | ZPP_Material.PROPS);
@@ -90,10 +90,10 @@ export class Material {
 
     if (rollingFriction !== zpp.rollingFriction) {
       if (rollingFriction !== rollingFriction) {
-        throw new Error("Error: Material::rollingFriction cannot be NaN");
+        throw new Error("Material::rollingFriction cannot be NaN");
       }
       if (rollingFriction < 0) {
-        throw new Error("Error: Material::rollingFriction cannot be negative");
+        throw new Error("Material::rollingFriction cannot be negative");
       }
       zpp.rollingFriction = rollingFriction;
       zpp.invalidate(ZPP_Material.WAKE | ZPP_Material.ARBITERS);
@@ -133,7 +133,7 @@ export class Material {
   set elasticity(value: number) {
     if (value !== this.zpp_inner.elasticity) {
       if (value !== value) {
-        throw new Error("Error: Material::elasticity cannot be NaN");
+        throw new Error("Material::elasticity cannot be NaN");
       }
       this.zpp_inner.elasticity = value;
       this.zpp_inner.invalidate(ZPP_Material.WAKE | ZPP_Material.ARBITERS);
@@ -146,10 +146,10 @@ export class Material {
   set dynamicFriction(value: number) {
     if (value !== this.zpp_inner.dynamicFriction) {
       if (value !== value) {
-        throw new Error("Error: Material::dynamicFriction cannot be NaN");
+        throw new Error("Material::dynamicFriction cannot be NaN");
       }
       if (value < 0) {
-        throw new Error("Error: Material::dynamicFriction cannot be negative");
+        throw new Error("Material::dynamicFriction cannot be negative");
       }
       this.zpp_inner.dynamicFriction = value;
       this.zpp_inner.invalidate(ZPP_Material.WAKE | ZPP_Material.ANGDRAG | ZPP_Material.ARBITERS);
@@ -162,10 +162,10 @@ export class Material {
   set staticFriction(value: number) {
     if (value !== this.zpp_inner.staticFriction) {
       if (value !== value) {
-        throw new Error("Error: Material::staticFriction cannot be NaN");
+        throw new Error("Material::staticFriction cannot be NaN");
       }
       if (value < 0) {
-        throw new Error("Error: Material::staticFriction cannot be negative");
+        throw new Error("Material::staticFriction cannot be negative");
       }
       this.zpp_inner.staticFriction = value;
       this.zpp_inner.invalidate(ZPP_Material.WAKE | ZPP_Material.ARBITERS);
@@ -178,10 +178,10 @@ export class Material {
   set density(value: number) {
     if (value !== this.zpp_inner.density * 1000) {
       if (value !== value) {
-        throw new Error("Error: Material::density cannot be NaN");
+        throw new Error("Material::density cannot be NaN");
       }
       if (value < 0) {
-        throw new Error("Error: Material::density must be positive");
+        throw new Error("Material::density must be positive");
       }
       this.zpp_inner.density = value / 1000;
       this.zpp_inner.invalidate(ZPP_Material.WAKE | ZPP_Material.PROPS);
@@ -194,10 +194,10 @@ export class Material {
   set rollingFriction(value: number) {
     if (value !== this.zpp_inner.rollingFriction) {
       if (value !== value) {
-        throw new Error("Error: Material::rollingFriction cannot be NaN");
+        throw new Error("Material::rollingFriction cannot be NaN");
       }
       if (value < 0) {
-        throw new Error("Error: Material::rollingFriction cannot be negative");
+        throw new Error("Material::rollingFriction cannot be negative");
       }
       this.zpp_inner.rollingFriction = value;
       this.zpp_inner.invalidate(ZPP_Material.WAKE | ZPP_Material.ARBITERS);

--- a/packages/nape-js/src/shape/Capsule.ts
+++ b/packages/nape-js/src/shape/Capsule.ts
@@ -98,13 +98,13 @@ export class Capsule extends Shape {
 
     // Validate
     if (width !== width || height !== height) {
-      throw new Error("Error: Capsule dimensions cannot be NaN");
+      throw new Error("Capsule dimensions cannot be NaN");
     }
     if (height <= 0) {
-      throw new Error("Error: Capsule height (" + height + ") must be > 0");
+      throw new Error("Capsule height (" + height + ") must be > 0");
     }
     if (width < height) {
-      throw new Error("Error: Capsule width (" + width + ") must be >= height (" + height + ")");
+      throw new Error("Capsule width (" + width + ") must be >= height (" + height + ")");
     }
 
     const radius = height / 2;
@@ -135,7 +135,7 @@ export class Capsule extends Shape {
     let comY = 0;
     if (localCOM != null) {
       if ((localCOM as any).zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const inner = localCOM.zpp_inner;
       if (inner._validate != null) inner._validate();
@@ -255,10 +255,10 @@ export class Capsule extends Shape {
     }
     if (value !== this._radius) {
       if (value !== value) {
-        throw new Error("Error: Capsule::radius cannot be NaN");
+        throw new Error("Capsule::radius cannot be NaN");
       }
       if (value < nape.Config.epsilon) {
-        throw new Error("Error: Capsule::radius (" + value + ") must be > Config.epsilon");
+        throw new Error("Capsule::radius (" + value + ") must be > Config.epsilon");
       }
       this._radius = value;
       (zpp as any)._capsuleRadius = value;
@@ -280,10 +280,10 @@ export class Capsule extends Shape {
     }
     if (value !== this._halfLength) {
       if (value !== value) {
-        throw new Error("Error: Capsule::halfLength cannot be NaN");
+        throw new Error("Capsule::halfLength cannot be NaN");
       }
       if (value < 0) {
-        throw new Error("Error: Capsule::halfLength (" + value + ") must be >= 0");
+        throw new Error("Capsule::halfLength (" + value + ") must be >= 0");
       }
       this._halfLength = value;
       (zpp as any)._capsuleHalfLength = value;

--- a/packages/nape-js/src/shape/Circle.ts
+++ b/packages/nape-js/src/shape/Circle.ts
@@ -47,13 +47,13 @@ export class Circle extends Shape {
     // --- Validate and set radius ---
     if (radius !== zpp.radius) {
       if (radius !== radius) {
-        throw new Error("Error: Circle::radius cannot be NaN");
+        throw new Error("Circle::radius cannot be NaN");
       }
       if (radius < nape.Config.epsilon) {
-        throw new Error("Error: Circle::radius (" + radius + ") must be > Config.epsilon");
+        throw new Error("Circle::radius (" + radius + ") must be > Config.epsilon");
       }
       if (radius > ZPP_Const.FMAX) {
-        throw new Error("Error: Circle::radius (" + radius + ") must be < PR(Const).FMAX");
+        throw new Error("Circle::radius (" + radius + ") must be < PR(Const).FMAX");
       }
       zpp.radius = radius;
       zpp.invalidate_radius();
@@ -62,7 +62,7 @@ export class Circle extends Shape {
     // --- Handle localCOM ---
     if (localCOM != null) {
       if ((localCOM as any).zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const inner = localCOM.zpp_inner;
       if (inner._validate != null) inner._validate();
@@ -158,13 +158,13 @@ export class Circle extends Shape {
     }
     if (value !== zpp.radius) {
       if (value !== value) {
-        throw new Error("Error: Circle::radius cannot be NaN");
+        throw new Error("Circle::radius cannot be NaN");
       }
       if (value < nape.Config.epsilon) {
-        throw new Error("Error: Circle::radius (" + value + ") must be > Config.epsilon");
+        throw new Error("Circle::radius (" + value + ") must be > Config.epsilon");
       }
       if (value > ZPP_Const.FMAX) {
-        throw new Error("Error: Circle::radius (" + value + ") must be < PR(Const).FMAX");
+        throw new Error("Circle::radius (" + value + ") must be < PR(Const).FMAX");
       }
       zpp.radius = value;
       zpp.invalidate_radius();

--- a/packages/nape-js/src/shape/Edge.ts
+++ b/packages/nape-js/src/shape/Edge.ts
@@ -20,7 +20,7 @@ export class Edge {
 
   constructor() {
     if (!ZPP_Edge.internal) {
-      throw new Error("Error: Cannot instantiate an Edge derp!");
+      throw new Error("Cannot instantiate an Edge derp!");
     }
   }
 
@@ -49,7 +49,7 @@ export class Edge {
   get polygon(): Polygon {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     return zpp.polygon.outer_zn;
   }
@@ -58,7 +58,7 @@ export class Edge {
   get localNormal(): Vec2 {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     if (zpp.wrap_lnorm == null) {
       zpp.getlnorm();
@@ -70,7 +70,7 @@ export class Edge {
   get worldNormal(): Vec2 {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     if (zpp.wrap_gnorm == null) {
       zpp.getgnorm();
@@ -82,7 +82,7 @@ export class Edge {
   get length(): number {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     zpp.polygon.validate_laxi();
     return zpp.length;
@@ -92,7 +92,7 @@ export class Edge {
   get localProjection(): number {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     zpp.polygon.validate_laxi();
     return zpp.lprojection;
@@ -102,7 +102,7 @@ export class Edge {
   get worldProjection(): number {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     if (zpp.polygon.body == null) {
       throw new Error(
@@ -117,7 +117,7 @@ export class Edge {
   get localVertex1(): Vec2 {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     zpp.polygon.validate_laxi();
     return this._wrapVert(zpp.lp0);
@@ -127,7 +127,7 @@ export class Edge {
   get localVertex2(): Vec2 {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     zpp.polygon.validate_laxi();
     return this._wrapVert(zpp.lp1);
@@ -137,7 +137,7 @@ export class Edge {
   get worldVertex1(): Vec2 {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     zpp.polygon.validate_gaxi();
     return this._wrapVert(zpp.gp0);
@@ -147,7 +147,7 @@ export class Edge {
   get worldVertex2(): Vec2 {
     const zpp = this.zpp_inner;
     if (zpp.polygon == null) {
-      throw new Error("Error: Edge not current in use");
+      throw new Error("Edge not current in use");
     }
     zpp.polygon.validate_gaxi();
     return this._wrapVert(zpp.gp1);

--- a/packages/nape-js/src/shape/Polygon.ts
+++ b/packages/nape-js/src/shape/Polygon.ts
@@ -40,7 +40,7 @@ export class Polygon extends Shape {
     const nape = getNape();
 
     if (localVerts == null) {
-      throw new Error("Error: localVerts cannot be null");
+      throw new Error("localVerts cannot be null");
     }
 
     // --- Resolve overloaded parameters ---
@@ -78,13 +78,13 @@ export class Polygon extends Shape {
     if (Array.isArray(localVerts)) {
       for (const v of localVerts) {
         if (v == null) {
-          throw new Error("Error: Array<Vec2> contains null objects");
+          throw new Error("Array<Vec2> contains null objects");
         }
         if (!(v instanceof Vec2)) {
-          throw new Error("Error: Array<Vec2> contains non Vec2 objects");
+          throw new Error("Array<Vec2> contains non Vec2 objects");
         }
         if ((v as any).zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         if (zpp.wrap_lverts == null) zpp.getlverts();
         const inner = v.zpp_inner;
@@ -119,10 +119,10 @@ export class Polygon extends Shape {
         iter.zpp_critical = false;
         const v = iter.zpp_inner.at(iter.zpp_i++);
         if (v == null) {
-          throw new Error("Error: Vec2List contains null objects");
+          throw new Error("Vec2List contains null objects");
         }
         if (v.zpp_disp) {
-          throw new Error("Error: Vec2 has been disposed and cannot be used!");
+          throw new Error("Vec2 has been disposed and cannot be used!");
         }
         if (zpp.wrap_lverts == null) zpp.getlverts();
         const inner = v.zpp_inner;
@@ -171,7 +171,7 @@ export class Polygon extends Shape {
     // --- Handle localCOM ---
     if (localCOM != null) {
       if ((localCOM as any).zpp_disp) {
-        throw new Error("Error: Vec2 has been disposed and cannot be used!");
+        throw new Error("Vec2 has been disposed and cannot be used!");
       }
       const inner = localCOM.zpp_inner;
       if (inner._validate != null) inner._validate();
@@ -258,7 +258,7 @@ export class Polygon extends Shape {
    */
   static rect(x: number, y: number, width: number, height: number, weak: boolean = false): Vec2[] {
     if (x !== x || y !== y || width !== width || height !== height) {
-      throw new Error("Error: Polygon.rect cannot accept NaN arguments");
+      throw new Error("Polygon.rect cannot accept NaN arguments");
     }
     const v1 = new Vec2(x, y);
     v1.zpp_inner.weak = weak;
@@ -280,7 +280,7 @@ export class Polygon extends Shape {
    */
   static box(width: number, height: number = width, weak: boolean = false): Vec2[] {
     if (width !== width || height !== height) {
-      throw new Error("Error: Polygon.box cannot accept NaN arguments");
+      throw new Error("Polygon.box cannot accept NaN arguments");
     }
     return Polygon.rect(-width / 2, -height / 2, width, height, weak);
   }
@@ -302,7 +302,7 @@ export class Polygon extends Shape {
     weak: boolean = false,
   ): Vec2[] {
     if (xRadius !== xRadius || yRadius !== yRadius || angleOffset !== angleOffset) {
-      throw new Error("Error: Polygon.regular cannot accept NaN arguments");
+      throw new Error("Polygon.regular cannot accept NaN arguments");
     }
     const result: Vec2[] = [];
     const dangle = (Math.PI * 2) / edgeCount;

--- a/packages/nape-js/src/shape/Shape.ts
+++ b/packages/nape-js/src/shape/Shape.ts
@@ -198,7 +198,7 @@ export class Shape extends Interactor {
     const zpp = (this as any).zpp_inner;
     zpp.immutable_midstep("Body::localCOM");
     if ((value as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (zpp.body != null && zpp.body.space != null && zpp.body.type === 1) {
       throw new Error(
@@ -206,7 +206,7 @@ export class Shape extends Interactor {
       );
     }
     if (value == null) {
-      throw new Error("Error: Shape::localCOM cannot be null");
+      throw new Error("Shape::localCOM cannot be null");
     }
     // Ensure localCOM wrapper exists
     if (zpp.wrap_localCOM == null) {
@@ -253,7 +253,7 @@ export class Shape extends Interactor {
     const zpp = (this as any).zpp_inner;
     zpp.immutable_midstep("Shape::material");
     if (value == null) {
-      throw new Error("Error: Cannot assign null as Shape material");
+      throw new Error("Cannot assign null as Shape material");
     }
     zpp.setMaterial((value as any).zpp_inner);
   }
@@ -267,7 +267,7 @@ export class Shape extends Interactor {
     const zpp = (this as any).zpp_inner;
     zpp.immutable_midstep("Shape::filter");
     if (value == null) {
-      throw new Error("Error: Cannot assign null as Shape filter");
+      throw new Error("Cannot assign null as Shape filter");
     }
     zpp.setFilter((value as any).zpp_inner);
   }
@@ -373,7 +373,7 @@ export class Shape extends Interactor {
     const zpp = (this as any).zpp_inner;
     zpp.immutable_midstep("Shape::translate()");
     if ((translation as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (zpp.body != null && zpp.body.space != null && zpp.body.type === 1) {
       throw new Error(
@@ -381,7 +381,7 @@ export class Shape extends Interactor {
       );
     }
     if (translation == null) {
-      throw new Error("Error: Cannot displace Shape by null Vec2");
+      throw new Error("Cannot displace Shape by null Vec2");
     }
     if ((translation as any).lsq() > 0) {
       const inner = (translation as any).zpp_inner;
@@ -414,17 +414,17 @@ export class Shape extends Interactor {
       );
     }
     if (scaleX !== scaleX || scaleY !== scaleY) {
-      throw new Error("Error: Cannot scale Shape by NaN");
+      throw new Error("Cannot scale Shape by NaN");
     }
     if (scaleX === 0 || scaleY === 0) {
-      throw new Error("Error: Cannot Scale shape by a factor of 0");
+      throw new Error("Cannot Scale shape by a factor of 0");
     }
     if (zpp.type === 0) {
       const d = scaleX * scaleX - scaleY * scaleY;
       if (d * d < nape.Config.epsilon * nape.Config.epsilon) {
         zpp.circle.__scale(scaleX, scaleY);
       } else {
-        throw new Error("Error: Cannot perform a non equal scaling on a Circle");
+        throw new Error("Cannot perform a non equal scaling on a Circle");
       }
     } else if (zpp.type === 1) {
       zpp.polygon.__scale(scaleX, scaleY);
@@ -448,7 +448,7 @@ export class Shape extends Interactor {
       );
     }
     if (angle !== angle) {
-      throw new Error("Error: Cannot rotate Shape by NaN");
+      throw new Error("Cannot rotate Shape by NaN");
     }
     const dr = angle % (2 * Math.PI);
     if (dr !== 0.0) {
@@ -479,17 +479,17 @@ export class Shape extends Interactor {
       );
     }
     if (matrix == null) {
-      throw new Error("Error: Cannot transform Shape by null matrix");
+      throw new Error("Cannot transform Shape by null matrix");
     }
     const mat = matrix._inner ?? matrix;
     if ((mat as any).singular()) {
-      throw new Error("Error: Cannot transform Shape by a singular matrix");
+      throw new Error("Cannot transform Shape by a singular matrix");
     }
     if (zpp.type === 0) {
       if ((mat as any).equiorthogonal()) {
         zpp.circle.__transform(mat);
       } else {
-        throw new Error("Error: Cannot transform Circle by a non equiorthogonal matrix");
+        throw new Error("Cannot transform Circle by a non equiorthogonal matrix");
       }
     } else if (zpp.type === 1) {
       zpp.polygon.__transform(mat);
@@ -508,13 +508,13 @@ export class Shape extends Interactor {
   contains(point: Vec2): boolean {
     const zpp = (this as any).zpp_inner;
     if ((point as any)?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (point == null) {
       throw new Error("Cannot check null point for containment");
     }
     if ((zpp.body != null ? zpp.body.outer : null) == null) {
-      throw new Error("Error: Shape is not well defined without a Body");
+      throw new Error("Shape is not well defined without a Body");
     }
     ZPP_Geom.validateShape(zpp);
     const inner = (point as any).zpp_inner;
@@ -553,7 +553,7 @@ export class Shape extends Interactor {
     const x = zpp.worldCOMx;
     const y = zpp.worldCOMy;
     if (x !== x || y !== y) {
-      throw new Error("Error: Vec2 components cannot be NaN");
+      throw new Error("Vec2 components cannot be NaN");
     }
     // Get or create Vec2 from pool
     let ret: any;

--- a/packages/nape-js/src/shape/ShapeType.ts
+++ b/packages/nape-js/src/shape/ShapeType.ts
@@ -12,7 +12,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class ShapeType {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate ShapeType derp!");
+      throw new Error("Cannot instantiate ShapeType derp!");
     }
   }
 

--- a/packages/nape-js/src/shape/ValidationResult.ts
+++ b/packages/nape-js/src/shape/ValidationResult.ts
@@ -14,7 +14,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class ValidationResult {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate ValidationResult derp!");
+      throw new Error("Cannot instantiate ValidationResult derp!");
     }
   }
 

--- a/packages/nape-js/src/space/Broadphase.ts
+++ b/packages/nape-js/src/space/Broadphase.ts
@@ -12,7 +12,7 @@ import { ZPP_Flags } from "../native/util/ZPP_Flags";
 export class Broadphase {
   constructor() {
     if (!ZPP_Flags.internal) {
-      throw new Error("Error: Cannot instantiate Broadphase derp!");
+      throw new Error("Cannot instantiate Broadphase derp!");
     }
   }
 

--- a/packages/nape-js/src/space/Space.ts
+++ b/packages/nape-js/src/space/Space.ts
@@ -43,7 +43,7 @@ export class Space {
    */
   constructor(gravity?: Vec2, broadphase?: Broadphase) {
     if (gravity != null && gravity.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
 
     const gravityInner = gravity == null ? null : gravity.zpp_inner;
@@ -108,10 +108,10 @@ export class Space {
 
   set gravity(value: Vec2) {
     if (value?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (value == null) {
-      throw new Error("Error: Space::gravity cannot be null");
+      throw new Error("Space::gravity cannot be null");
     }
     if (this.zpp_inner.wrap_gravity == null) {
       this.zpp_inner.getgravity();
@@ -225,10 +225,10 @@ export class Space {
   }
   set subSteps(value: number) {
     if (value !== value) {
-      throw new Error("Error: Space::subSteps cannot be NaN");
+      throw new Error("Space::subSteps cannot be NaN");
     }
     if (value < 1) {
-      throw new Error("Error: Space::subSteps must be at least 1");
+      throw new Error("Space::subSteps must be at least 1");
     }
     this.zpp_inner.subSteps = Math.floor(value);
   }
@@ -242,7 +242,7 @@ export class Space {
   }
   set worldAngularDrag(value: number) {
     if (value !== value) {
-      throw new Error("Error: Space::worldAngularDrag cannot be NaN");
+      throw new Error("Space::worldAngularDrag cannot be NaN");
     }
     this.zpp_inner.global_ang_drag = value;
   }
@@ -256,7 +256,7 @@ export class Space {
   }
   set worldLinearDrag(value: number) {
     if (value !== value) {
-      throw new Error("Error: Space::worldLinearDrag cannot be NaN");
+      throw new Error("Space::worldLinearDrag cannot be NaN");
     }
     this.zpp_inner.global_lin_drag = value;
   }
@@ -330,16 +330,16 @@ export class Space {
    */
   step(deltaTime: number, velocityIterations: number = 10, positionIterations: number = 10): void {
     if (deltaTime !== deltaTime) {
-      throw new Error("Error: deltaTime cannot be NaN");
+      throw new Error("deltaTime cannot be NaN");
     }
     if (deltaTime <= 0) {
-      throw new Error("Error: deltaTime must be strictly positive");
+      throw new Error("deltaTime must be strictly positive");
     }
     if (velocityIterations <= 0) {
-      throw new Error("Error: must use atleast one velocity iteration");
+      throw new Error("must use atleast one velocity iteration");
     }
     if (positionIterations <= 0) {
-      throw new Error("Error: must use atleast one position iteration");
+      throw new Error("must use atleast one position iteration");
     }
     this.zpp_inner.step(deltaTime, velocityIterations, positionIterations);
   }
@@ -350,7 +350,7 @@ export class Space {
    */
   clear(): void {
     if (this.zpp_inner.midstep) {
-      throw new Error("Error: Space::clear() cannot be called during space step()");
+      throw new Error("Space::clear() cannot be called during space step()");
     }
     this.zpp_inner.clear();
   }
@@ -366,7 +366,7 @@ export class Space {
    */
   visitBodies(lambda: (body: Body) => void): void {
     if (lambda == null) {
-      throw new Error("Error: lambda cannot be null for Space::visitBodies");
+      throw new Error("lambda cannot be null for Space::visitBodies");
     }
     const nape = getNape();
     // Iterate bodies
@@ -425,7 +425,7 @@ export class Space {
    */
   visitConstraints(lambda: (constraint: Constraint) => void): void {
     if (lambda == null) {
-      throw new Error("Error: lambda cannot be null for Space::visitConstraints");
+      throw new Error("lambda cannot be null for Space::visitConstraints");
     }
     const nape = getNape();
     // Iterate constraints
@@ -484,7 +484,7 @@ export class Space {
    */
   visitCompounds(lambda: (compound: Compound) => void): void {
     if (lambda == null) {
-      throw new Error("Error: lambda cannot be null for Space::visitCompounds");
+      throw new Error("lambda cannot be null for Space::visitCompounds");
     }
     const nape = getNape();
     const compList = this.zpp_inner.wrap_compounds;
@@ -526,7 +526,7 @@ export class Space {
    */
   interactionType(shape1: Shape, shape2: Shape): InteractionType | null {
     if (shape1 == null || shape2 == null) {
-      throw new Error("Error: Cannot evaluate interaction type for null shapes");
+      throw new Error("Cannot evaluate interaction type for null shapes");
     }
     const s1 = (shape1 as any).zpp_inner;
     const s2 = (shape2 as any).zpp_inner;
@@ -534,7 +534,7 @@ export class Space {
       (s1.body != null ? s1.body.outer : null) == null ||
       (s2.body != null ? s2.body.outer : null) == null
     ) {
-      throw new Error("Error: Cannot evaluate interaction type for shapes not part of a Body");
+      throw new Error("Cannot evaluate interaction type for shapes not part of a Body");
     }
     const b1 = s1.body;
     const b2 = s2.body;
@@ -664,10 +664,10 @@ export class Space {
     output?: ShapeList | null,
   ): ShapeList {
     if (point?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (point == null) {
-      throw new Error("Error: Cannot evaluate shapes under a null point :)");
+      throw new Error("Cannot evaluate shapes under a null point :)");
     }
     const inner = point.zpp_inner;
     if (inner._validate != null) inner._validate();
@@ -694,10 +694,10 @@ export class Space {
     output?: BodyList | null,
   ): BodyList {
     if (point?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (point == null) {
-      throw new Error("Error: Cannot evaluate objects under a null point :)");
+      throw new Error("Cannot evaluate objects under a null point :)");
     }
     const inner = point.zpp_inner;
     if (inner._validate != null) inner._validate();
@@ -728,12 +728,12 @@ export class Space {
     output?: ShapeList | null,
   ): ShapeList {
     if (aabb == null) {
-      throw new Error("Error: Cannot evaluate shapes in a null AABB :)");
+      throw new Error("Cannot evaluate shapes in a null AABB :)");
     }
     const zi = aabb.zpp_inner;
     if (zi._validate != null) zi._validate();
     if (zi.maxx - zi.minx == 0 || zi.maxy - zi.miny == 0) {
-      throw new Error("Error: Cannot evaluate shapes in degenerate AABB :/");
+      throw new Error("Cannot evaluate shapes in degenerate AABB :/");
     }
     const filterInner = filter == null ? null : ((filter as any).zpp_inner ?? filter);
     return this.zpp_inner.shapesInAABB(aabb, strict, containment, filterInner, output);
@@ -757,12 +757,12 @@ export class Space {
     output?: BodyList | null,
   ): BodyList {
     if (aabb == null) {
-      throw new Error("Error: Cannot evaluate objects in a null AABB :)");
+      throw new Error("Cannot evaluate objects in a null AABB :)");
     }
     const zi = aabb.zpp_inner;
     if (zi._validate != null) zi._validate();
     if (zi.maxx - zi.minx == 0 || zi.maxy - zi.miny == 0) {
-      throw new Error("Error: Cannot evaluate objects in degenerate AABB :/");
+      throw new Error("Cannot evaluate objects in degenerate AABB :/");
     }
     const filterInner = filter == null ? null : ((filter as any).zpp_inner ?? filter);
     return this.zpp_inner.bodiesInAABB(aabb, strict, containment, filterInner, output);
@@ -786,16 +786,16 @@ export class Space {
     output?: ShapeList | null,
   ): ShapeList {
     if (position?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (position == null) {
-      throw new Error("Error: Cannot evaluate shapes at null circle :)");
+      throw new Error("Cannot evaluate shapes at null circle :)");
     }
     if (radius !== radius) {
-      throw new Error("Error: Circle radius cannot be NaN");
+      throw new Error("Circle radius cannot be NaN");
     }
     if (radius <= 0) {
-      throw new Error("Error: Circle radius must be strictly positive");
+      throw new Error("Circle radius must be strictly positive");
     }
     const filterInner = filter == null ? null : ((filter as any).zpp_inner ?? filter);
     const ret = this.zpp_inner.shapesInCircle(position, radius, containment, filterInner, output);
@@ -821,16 +821,16 @@ export class Space {
     output?: BodyList | null,
   ): BodyList {
     if (position?.zpp_disp) {
-      throw new Error("Error: Vec2 has been disposed and cannot be used!");
+      throw new Error("Vec2 has been disposed and cannot be used!");
     }
     if (position == null) {
-      throw new Error("Error: Cannot evaluate objects at null circle :)");
+      throw new Error("Cannot evaluate objects at null circle :)");
     }
     if (radius !== radius) {
-      throw new Error("Error: Circle radius cannot be NaN");
+      throw new Error("Circle radius cannot be NaN");
     }
     if (radius <= 0) {
-      throw new Error("Error: Circle radius must be strictly positive");
+      throw new Error("Circle radius must be strictly positive");
     }
     const filterInner = filter == null ? null : ((filter as any).zpp_inner ?? filter);
     const ret = this.zpp_inner.bodiesInCircle(position, radius, containment, filterInner, output);
@@ -854,11 +854,11 @@ export class Space {
     output?: ShapeList | null,
   ): ShapeList {
     if (shape == null) {
-      throw new Error("Error: Cannot evaluate shapes in a null shapes :)");
+      throw new Error("Cannot evaluate shapes in a null shapes :)");
     }
     const szpp = (shape as any).zpp_inner;
     if ((szpp.body != null ? szpp.body.outer : null) == null) {
-      throw new Error("Error: Query shape needs to be inside a Body to be well defined :)");
+      throw new Error("Query shape needs to be inside a Body to be well defined :)");
     }
     if (szpp.type == 1) {
       const res = szpp.polygon.valid();
@@ -868,7 +868,7 @@ export class Space {
         ZPP_Flags.internal = false;
       }
       if (res != ZPP_Flags.ValidationResult_VALID) {
-        throw new Error("Error: Polygon query shape is invalid : " + res.toString());
+        throw new Error("Polygon query shape is invalid : " + res.toString());
       }
     }
     const filterInner = filter == null ? null : ((filter as any).zpp_inner ?? filter);
@@ -891,11 +891,11 @@ export class Space {
     output?: BodyList | null,
   ): BodyList {
     if (shape == null) {
-      throw new Error("Error: Cannot evaluate bodies in a null shapes :)");
+      throw new Error("Cannot evaluate bodies in a null shapes :)");
     }
     const szpp = (shape as any).zpp_inner;
     if ((szpp.body != null ? szpp.body.outer : null) == null) {
-      throw new Error("Error: Query shape needs to be inside a Body to be well defined :)");
+      throw new Error("Query shape needs to be inside a Body to be well defined :)");
     }
     if (szpp.type == 1) {
       const res = szpp.polygon.valid();
@@ -905,7 +905,7 @@ export class Space {
         ZPP_Flags.internal = false;
       }
       if (res != ZPP_Flags.ValidationResult_VALID) {
-        throw new Error("Error: Polygon query shape is invalid : " + res.toString());
+        throw new Error("Polygon query shape is invalid : " + res.toString());
       }
     }
     const filterInner = filter == null ? null : ((filter as any).zpp_inner ?? filter);
@@ -927,7 +927,7 @@ export class Space {
     output?: ShapeList | null,
   ): ShapeList {
     if (body == null) {
-      throw new Error("Error: Cannot evaluate shapes in null body");
+      throw new Error("Cannot evaluate shapes in null body");
     }
     const nape = getNape();
     const ret = output == null ? new nape.shape.ShapeList() : output;
@@ -968,7 +968,7 @@ export class Space {
    */
   bodiesInBody(body: Body, filter?: InteractionFilter | null, output?: BodyList | null): BodyList {
     if (body == null) {
-      throw new Error("Error: Cannot evaluate shapes in null body");
+      throw new Error("Cannot evaluate shapes in null body");
     }
     const nape = getNape();
     const ret = output == null ? new nape.phys.BodyList() : output;
@@ -1014,14 +1014,14 @@ export class Space {
     filter?: InteractionFilter | null,
   ): ConvexResult | null {
     if (shape == null) {
-      throw new Error("Error: Cannot cast null shape :)");
+      throw new Error("Cannot cast null shape :)");
     }
     const szpp = (shape as any).zpp_inner;
     if ((szpp.body != null ? szpp.body.outer : null) == null) {
-      throw new Error("Error: Shape must belong to a body to be cast.");
+      throw new Error("Shape must belong to a body to be cast.");
     }
     if (deltaTime < 0 || deltaTime !== deltaTime) {
-      throw new Error("Error: deltaTime must be positive");
+      throw new Error("deltaTime must be positive");
     }
     return this.zpp_inner.convexCast(szpp, deltaTime, filter, liveSweep);
   }
@@ -1044,14 +1044,14 @@ export class Space {
     output?: ConvexResultList | null,
   ): ConvexResultList {
     if (shape == null) {
-      throw new Error("Error: Cannot cast null shape :)");
+      throw new Error("Cannot cast null shape :)");
     }
     const szpp = (shape as any).zpp_inner;
     if ((szpp.body != null ? szpp.body.outer : null) == null) {
-      throw new Error("Error: Shape must belong to a body to be cast.");
+      throw new Error("Shape must belong to a body to be cast.");
     }
     if (deltaTime < 0 || deltaTime !== deltaTime) {
-      throw new Error("Error: deltaTime must be positive");
+      throw new Error("deltaTime must be positive");
     }
     return this.zpp_inner.convexMultiCast(szpp, deltaTime, filter, liveSweep, output);
   }
@@ -1066,7 +1066,7 @@ export class Space {
    */
   rayCast(ray: Ray, inner: boolean = false, filter?: InteractionFilter | null): RayResult | null {
     if (ray == null) {
-      throw new Error("Error: Cannot cast null ray :)");
+      throw new Error("Cannot cast null ray :)");
     }
     return this.zpp_inner.rayCast(ray, inner, filter);
   }
@@ -1087,7 +1087,7 @@ export class Space {
     output?: RayResultList | null,
   ): RayResultList {
     if (ray == null) {
-      throw new Error("Error: Cannot cast null ray :)");
+      throw new Error("Cannot cast null ray :)");
     }
     return this.zpp_inner.rayMultiCast(ray, inner, filter, output);
   }
@@ -1114,7 +1114,7 @@ export class Space {
    */
   debugDraw(drawer: DebugDraw, flags: number = DebugDrawFlags.ALL): void {
     if (drawer == null) {
-      throw new Error("Error: drawer cannot be null for Space::debugDraw");
+      throw new Error("drawer cannot be null for Space::debugDraw");
     }
 
     const drawShapes = (flags & DebugDrawFlags.SHAPES) !== 0;

--- a/packages/nape-js/src/util/NapeListFactory.ts
+++ b/packages/nape-js/src/util/NapeListFactory.ts
@@ -109,7 +109,7 @@ export function createListClasses(spec: ListSpec): {
     this.zpp_i = 0;
     this.zpp_inner = null;
     if (!getZPPListClass().internal) {
-      throw new Error("Error: Cannot instantiate " + typeName + "Iterator derp!");
+      throw new Error("Cannot instantiate " + typeName + "Iterator derp!");
     }
   }
 
@@ -174,7 +174,7 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.fromArray = function (array: Any[]): Any {
     if (array == null) {
-      throw new Error("Error: Cannot convert null Array to Nape list");
+      throw new Error("Cannot convert null Array to Nape list");
     }
     const ret = new (TypedList as Any)();
     for (let i = 0; i < array.length; i++) {
@@ -220,7 +220,7 @@ export function createListClasses(spec: ListSpec): {
   TypedList.prototype.at = function (this: Any, index: number): Any {
     this.zpp_inner.valmod();
     if (index < 0 || index >= _getLength(this)) {
-      throw new Error("Error: Index out of bounds");
+      throw new Error("Index out of bounds");
     }
     if (this.zpp_inner.reverse_flag) {
       index = _getLength(this) - 1 - index;
@@ -239,7 +239,7 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.prototype.push = function (this: Any, obj: Any): boolean {
     if (this.zpp_inner.immutable) {
-      throw new Error("Error: " + typeName + "List is immutable");
+      throw new Error(`${typeName}List is immutable`);
     }
     this.zpp_inner.modify_test();
     this.zpp_inner.valmod();
@@ -269,7 +269,7 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.prototype.unshift = function (this: Any, obj: Any): boolean {
     if (this.zpp_inner.immutable) {
-      throw new Error("Error: " + typeName + "List is immutable");
+      throw new Error(`${typeName}List is immutable`);
     }
     this.zpp_inner.modify_test();
     this.zpp_inner.valmod();
@@ -299,11 +299,11 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.prototype.pop = function (this: Any): Any {
     if (this.zpp_inner.immutable) {
-      throw new Error("Error: " + typeName + "List is immutable");
+      throw new Error(`${typeName}List is immutable`);
     }
     this.zpp_inner.modify_test();
     if (this.zpp_inner.inner.head == null) {
-      throw new Error("Error: Cannot remove from empty list");
+      throw new Error("Cannot remove from empty list");
     }
     this.zpp_inner.valmod();
     let ret: Any;
@@ -341,11 +341,11 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.prototype.shift = function (this: Any): Any {
     if (this.zpp_inner.immutable) {
-      throw new Error("Error: " + typeName + "List is immutable");
+      throw new Error(`${typeName}List is immutable`);
     }
     this.zpp_inner.modify_test();
     if (this.zpp_inner.inner.head == null) {
-      throw new Error("Error: Cannot remove from empty list");
+      throw new Error("Cannot remove from empty list");
     }
     this.zpp_inner.valmod();
     let ret: Any;
@@ -391,7 +391,7 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.prototype.remove = function (this: Any, obj: Any): boolean {
     if (this.zpp_inner.immutable) {
-      throw new Error("Error: " + typeName + "List is immutable");
+      throw new Error(`${typeName}List is immutable`);
     }
     this.zpp_inner.modify_test();
     this.zpp_inner.valmod();
@@ -420,7 +420,7 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.prototype.clear = function (this: Any): void {
     if (this.zpp_inner.immutable) {
-      throw new Error("Error: " + typeName + "List is immutable");
+      throw new Error(`${typeName}List is immutable`);
     }
     if (this.zpp_inner.reverse_flag) {
       while (this.zpp_inner.inner.head != null) this.pop();
@@ -445,7 +445,7 @@ export function createListClasses(spec: ListSpec): {
     while (it.hasNext()) {
       const i = it.next();
       if (deep) {
-        throw new Error("Error: " + typeName + " is not a copyable type");
+        throw new Error(`${typeName} is not a copyable type`);
       }
       ret.push(i);
     }
@@ -454,7 +454,7 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.prototype.merge = function (this: Any, xs: Any): void {
     if (xs == null) {
-      throw new Error("Error: Cannot merge with null list");
+      throw new Error("Cannot merge with null list");
     }
     const it = TypedIterator.get(xs);
     while (it.hasNext()) {
@@ -484,7 +484,7 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.prototype.foreach = function (this: Any, lambda: Any): Any {
     if (lambda == null) {
-      throw new Error("Error: Cannot execute null on list elements");
+      throw new Error("Cannot execute null on list elements");
     }
     this.zpp_inner.valmod();
     const it = TypedIterator.get(this);
@@ -504,7 +504,7 @@ export function createListClasses(spec: ListSpec): {
 
   TypedList.prototype.filter = function (this: Any, lambda: Any): Any {
     if (lambda == null) {
-      throw new Error("Error: Cannot select elements of list with null");
+      throw new Error("Cannot select elements of list with null");
     }
     let i = 0;
     while (i < _getLength(this)) {

--- a/packages/nape-js/tests/native/callbacks/ZPP_OptionType.test.ts
+++ b/packages/nape-js/tests/native/callbacks/ZPP_OptionType.test.ts
@@ -304,7 +304,7 @@ describe("ZPP_OptionType", () => {
   describe("append", () => {
     it("should throw for null val", () => {
       const ot = new ZPP_OptionType();
-      expect(() => ot.append(ot.includes, null)).toThrow("Error: Cannot append null");
+      expect(() => ot.append(ot.includes, null)).toThrow("Cannot append null");
     });
 
     it("should handle CbType instance", () => {
@@ -319,7 +319,7 @@ describe("ZPP_OptionType", () => {
     it("should throw for invalid types", () => {
       const ot = new ZPP_OptionType();
       expect(() => ot.append(ot.includes, 42)).toThrow(
-        "Error: Cannot append non-CbType or CbType list value",
+        "Cannot append non-CbType or CbType list value",
       );
     });
 
@@ -338,7 +338,7 @@ describe("ZPP_OptionType", () => {
     it("should throw for array with non-CbType elements", () => {
       const ot = new ZPP_OptionType();
       expect(() => ot.append(ot.includes, [42])).toThrow(
-        "Error: Cannot append non-CbType or CbType list value",
+        "Cannot append non-CbType or CbType list value",
       );
     });
 

--- a/packages/nape-js/tests/native/constraint/ZPP_Constraint.test.ts
+++ b/packages/nape-js/tests/native/constraint/ZPP_Constraint.test.ts
@@ -147,7 +147,7 @@ describe("ZPP_Constraint", () => {
       const c = new ZPP_Constraint();
       c.space = { midstep: true };
       expect(() => c.immutable_midstep("frequency")).toThrow(
-        "Error: Constraint::frequency cannot be set during space step()",
+        "Constraint::frequency cannot be set during space step()",
       );
     });
 

--- a/packages/nape-js/tests/native/geom/ZPP_AABB.test.ts
+++ b/packages/nape-js/tests/native/geom/ZPP_AABB.test.ts
@@ -717,7 +717,7 @@ describe("ZPP_AABB", () => {
       // NaN min values trigger the NaN check at line 133-134
       a.minx = NaN;
       a.miny = 0;
-      expect(() => a.getmin()).toThrow("Error: Vec2 components cannot be NaN");
+      expect(() => a.getmin()).toThrow("Vec2 components cannot be NaN");
     });
 
     it("should reuse pooled Vec2 and advance the pool chain", () => {
@@ -974,7 +974,7 @@ describe("ZPP_AABB", () => {
       };
 
       const a = ZPP_AABB.get(1, 2, 5, 6);
-      expect(() => a.getmin()).toThrow("Error: Vec2 is immutable");
+      expect(() => a.getmin()).toThrow("Vec2 is immutable");
     });
 
     it("should throw when existing inner is disposed (via new Vec2 path)", () => {
@@ -1008,7 +1008,7 @@ describe("ZPP_AABB", () => {
       };
 
       const a = ZPP_AABB.get(1, 2, 5, 6);
-      expect(() => a.getmin()).toThrow("Error: Vec2 has been disposed and cannot be used!");
+      expect(() => a.getmin()).toThrow("Vec2 has been disposed and cannot be used!");
     });
   });
 });

--- a/packages/nape-js/tests/native/geom/ZPP_Vec2.test.ts
+++ b/packages/nape-js/tests/native/geom/ZPP_Vec2.test.ts
@@ -104,7 +104,7 @@ describe("ZPP_Vec2", () => {
     it("should throw when _immutable is true", () => {
       const v = new ZPP_Vec2();
       v._immutable = true;
-      expect(() => v.immutable()).toThrow("Error: Vec2 is immutable");
+      expect(() => v.immutable()).toThrow("Vec2 is immutable");
     });
 
     it("should call _isimmutable when set and not immutable", () => {

--- a/packages/nape-js/tests/native/phys/ZPP_FluidProperties.test.ts
+++ b/packages/nape-js/tests/native/phys/ZPP_FluidProperties.test.ts
@@ -235,7 +235,7 @@ describe("ZPP_FluidProperties", () => {
       const fp = new ZPP_FluidProperties();
       fp.gravityx = NaN;
       fp.gravityy = 0;
-      expect(() => fp.getgravity()).toThrow("Error: Vec2 components cannot be NaN");
+      expect(() => fp.getgravity()).toThrow("Vec2 components cannot be NaN");
     });
 
     it("should create new inner Vec2 when both pool and inner pool are empty", () => {
@@ -455,7 +455,7 @@ describe("ZPP_FluidProperties", () => {
       };
 
       const fp = new ZPP_FluidProperties();
-      expect(() => fp.getgravity()).toThrow("Error: Vec2 has been disposed and cannot be used!");
+      expect(() => fp.getgravity()).toThrow("Vec2 has been disposed and cannot be used!");
     });
 
     it("should throw when existing inner is immutable (via new Vec2 path)", () => {
@@ -481,7 +481,7 @@ describe("ZPP_FluidProperties", () => {
       };
 
       const fp = new ZPP_FluidProperties();
-      expect(() => fp.getgravity()).toThrow("Error: Vec2 is immutable");
+      expect(() => fp.getgravity()).toThrow("Vec2 is immutable");
     });
   });
 });

--- a/packages/nape-js/tests/native/shape/ZPP_Edge.test.ts
+++ b/packages/nape-js/tests/native/shape/ZPP_Edge.test.ts
@@ -133,7 +133,7 @@ describe("ZPP_Edge", () => {
     it("should throw if polygon is null", () => {
       const e = new ZPP_Edge();
       e.polygon = null;
-      expect(() => e.lnorm_validate()).toThrow("Error: Edge not currently in use");
+      expect(() => e.lnorm_validate()).toThrow("Edge not currently in use");
     });
 
     it("should call polygon.validate_laxi and update wrap_lnorm", () => {
@@ -160,14 +160,14 @@ describe("ZPP_Edge", () => {
     it("should throw if polygon is null", () => {
       const e = new ZPP_Edge();
       e.polygon = null;
-      expect(() => e.gnorm_validate()).toThrow("Error: Edge not currently in use");
+      expect(() => e.gnorm_validate()).toThrow("Edge not currently in use");
     });
 
     it("should throw if polygon.body is null", () => {
       const e = new ZPP_Edge();
       e.polygon = { body: null };
       expect(() => e.gnorm_validate()).toThrow(
-        "Error: Edge worldNormal only makes sense if the parent Polygon is contained within a rigid body",
+        "Edge worldNormal only makes sense if the parent Polygon is contained within a rigid body",
       );
     });
 
@@ -228,7 +228,7 @@ describe("ZPP_Edge", () => {
       const e = new ZPP_Edge();
       e.lnormx = NaN;
       e.lnormy = 0;
-      expect(() => e.getlnorm()).toThrow("Error: Vec2 components cannot be NaN");
+      expect(() => e.getlnorm()).toThrow("Vec2 components cannot be NaN");
     });
   });
 
@@ -237,7 +237,7 @@ describe("ZPP_Edge", () => {
       const e = new ZPP_Edge();
       e.gnormx = 0;
       e.gnormy = NaN;
-      expect(() => e.getgnorm()).toThrow("Error: Vec2 components cannot be NaN");
+      expect(() => e.getgnorm()).toThrow("Vec2 components cannot be NaN");
     });
   });
 });


### PR DESCRIPTION
## Summary

  The `Error` constructor and browser/Node consoles already prefix output
  with `"Error: "`. Including it in the message string caused double-prefixed
  output (e.g. `Error: Error: Cannot evaluate impulse on null body`) and made
  log output harder to grep.

  - Stripped `"Error: "` prefix from all `throw new Error()` calls — 1,117 instances across 106 files
  - Fixed missed template-literal instance in `src/geom/Geom.ts`
  - Updated 16 test assertions to match the cleaned message strings
  - Extracted `IMPULSE_ERROR_NULL_BODY` constant in `Constraint.ts` for the 9 constraint impulse-evaluators that shared the same literal

  ## Acceptance

  - `git grep 'Error("Error: '` → 0 matches
  - All 5761 + 71 tests pass
  - `npm run lint` + `npm run format:check` clean