### PR TITLE
ci: switch Codecov upload to App-based auth (drop token)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
           files: ./packages/nape-js/coverage/lcov.info
           flags: nape-js
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload nape-pixi coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -49,7 +48,6 @@ jobs:
           files: ./packages/nape-pixi/coverage/lcov.info
           flags: nape-pixi
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage reports as artifact
         if: always()


### PR DESCRIPTION
## Summary

- The Codecov GitHub App is now installed on this repo, so the explicit `token: ${{ secrets.CODECOV_TOKEN }}` parameter is no longer needed on `codecov/codecov-action@v5`. The app authenticates uploads directly.
- Drop the `token:` line from both upload steps (`nape-js` and `nape-pixi` coverage uploads).
- The `CODECOV_TOKEN` repo secret stays in place as a fallback — re-adding the `token:` line restores the previous behavior if the App ever has issues.

## Test plan

- [ ] Push to a branch and confirm the Codecov action still uploads both coverage reports successfully via the App
- [ ] Confirm the Codecov PR comment still appears with the coverage diff
- [ ] Verify both `nape-js` and `nape-pixi` flags appear in the Codecov dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)