### PR TITLE
test(native): cover ZPP_Broadphase routing + ZPP_SpatialHashPhase grid (#163)

### DIFF
--- a/packages/nape-js/tests/native/space/ZPP_Broadphase.routing.test.ts
+++ b/packages/nape-js/tests/native/space/ZPP_Broadphase.routing.test.ts
@@ -1,0 +1,335 @@
+/**
+ * ZPP_Broadphase — Direct unit tests for the base-class concrete surface.
+ *
+ * The base class is a router: every subclass (SweepPhase, DynAABBPhase,
+ * SpatialHashPhase) inherits and re-uses three concrete entry points:
+ *   - `insert` / `remove` / `sync` — delegate to the chosen implementation
+ *     based on the `is_sweep` flag.
+ *   - `updateAABBShape` / `updateCircShape` — lazy probe-shape factories
+ *     used by every spatial-query implementation to build a temporary
+ *     polygon/circle to test against.
+ *
+ * Existing tests cover these methods *indirectly* through Space/query
+ * integration (see ZPP_Broadphase.queries / ZPP_Broadphase.spatial /
+ * ZPP_Broadphase.integration). This suite drives them directly to pin
+ * the routing contract and the lazy-construct + reuse contract that the
+ * integration tests don't isolate.
+ *
+ * Covers (issue #163):
+ * - `_initFields` static initializer contract (defaults for all flags).
+ * - `insert` / `remove` / `sync` route to `sweep` or `dynab` based on
+ *   `is_sweep`, never both.
+ * - `updateAABBShape` lazily creates a Polygon probe on the first call,
+ *   then re-transforms (not recreates) on subsequent calls.
+ * - `updateCircShape` lazily creates a Circle probe on the first call,
+ *   then mutates its position/radius on subsequent calls.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import "../../../src/core/engine";
+import { ZPP_Broadphase } from "../../../src/native/space/ZPP_Broadphase";
+import { ZPP_AABB } from "../../../src/native/geom/ZPP_AABB";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a stub "phase" object that records every __insert/__remove/__sync call. */
+interface PhaseStub {
+  inserts: any[];
+  removes: any[];
+  syncs: any[];
+  __insert(s: any): void;
+  __remove(s: any): void;
+  __sync(s: any): void;
+  space: { continuous: boolean };
+}
+
+function phaseStub(): PhaseStub {
+  const stub: PhaseStub = {
+    inserts: [],
+    removes: [],
+    syncs: [],
+    space: { continuous: false },
+    __insert(s: any) {
+      stub.inserts.push(s);
+    },
+    __remove(s: any) {
+      stub.removes.push(s);
+    },
+    __sync(s: any) {
+      stub.syncs.push(s);
+    },
+  };
+  return stub;
+}
+
+/** Build a fresh ZPP_AABB at the given bounds (skips the wrapper pool). */
+function aabb(minx: number, miny: number, maxx: number, maxy: number): ZPP_AABB {
+  const a = new ZPP_AABB();
+  a.minx = minx;
+  a.miny = miny;
+  a.maxx = maxx;
+  a.maxy = maxy;
+  return a;
+}
+
+// ---------------------------------------------------------------------------
+// _initFields
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Broadphase._initFields()", () => {
+  it("populates every field with its default contract value", () => {
+    const target: any = {};
+    ZPP_Broadphase._initFields(target);
+
+    expect(target.space).toBeNull();
+    expect(target.is_sweep).toBe(false);
+    expect(target.is_spatial_hash).toBe(false);
+    expect(target.sweep).toBeNull();
+    expect(target.dynab).toBeNull();
+    expect(target.aabbShape).toBeNull();
+    expect(target.matrix).toBeNull();
+    expect(target.circShape).toBeNull();
+  });
+
+  it("overwrites any pre-existing values on the target (idempotent re-init)", () => {
+    const target: any = {
+      space: { tag: "old" },
+      is_sweep: true,
+      is_spatial_hash: true,
+      sweep: { tag: "old-sweep" },
+      dynab: { tag: "old-dynab" },
+      aabbShape: { tag: "old-aabb" },
+      matrix: { tag: "old-matrix" },
+      circShape: { tag: "old-circ" },
+    };
+
+    ZPP_Broadphase._initFields(target);
+
+    expect(target.space).toBeNull();
+    expect(target.is_sweep).toBe(false);
+    expect(target.is_spatial_hash).toBe(false);
+    expect(target.sweep).toBeNull();
+    expect(target.dynab).toBeNull();
+    expect(target.aabbShape).toBeNull();
+    expect(target.matrix).toBeNull();
+    expect(target.circShape).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// insert / remove routing
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Broadphase — insert/remove routing via is_sweep flag", () => {
+  let bp: ZPP_Broadphase;
+  let sweep: PhaseStub;
+  let dynab: PhaseStub;
+
+  beforeEach(() => {
+    bp = new ZPP_Broadphase();
+    sweep = phaseStub();
+    dynab = phaseStub();
+    bp.sweep = sweep;
+    bp.dynab = dynab;
+  });
+
+  it("insert() with is_sweep=false delegates only to dynab", () => {
+    bp.is_sweep = false;
+    const s = { id: "shape-A" };
+
+    bp.insert(s);
+
+    expect(dynab.inserts).toEqual([s]);
+    expect(sweep.inserts).toHaveLength(0);
+  });
+
+  it("insert() with is_sweep=true delegates only to sweep", () => {
+    bp.is_sweep = true;
+    const s = { id: "shape-B" };
+
+    bp.insert(s);
+
+    expect(sweep.inserts).toEqual([s]);
+    expect(dynab.inserts).toHaveLength(0);
+  });
+
+  it("remove() routes mirror insert() routing", () => {
+    bp.is_sweep = false;
+    const s = { id: "shape-rm" };
+    bp.remove(s);
+    expect(dynab.removes).toEqual([s]);
+    expect(sweep.removes).toHaveLength(0);
+
+    bp.is_sweep = true;
+    bp.remove(s);
+    expect(sweep.removes).toEqual([s]);
+    expect(dynab.removes).toHaveLength(1); // unchanged from the first call
+  });
+
+  it("flipping is_sweep mid-flight reroutes subsequent calls", () => {
+    const s = { id: "shape-flip" };
+
+    bp.is_sweep = false;
+    bp.insert(s);
+    bp.is_sweep = true;
+    bp.insert(s);
+
+    expect(dynab.inserts).toEqual([s]);
+    expect(sweep.inserts).toEqual([s]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sync() — short-circuit path for already-validated shapes
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Broadphase.sync() — short-circuit branches", () => {
+  it("short-circuits the dynab path when shape.node.synced is true", () => {
+    // The dynab branch first reads `shape.node.synced` — if the node already
+    // claims it's synced, sync() returns immediately without touching any
+    // downstream state (zip_aabb stays whatever it was).
+    const bp = new ZPP_Broadphase();
+    const dynab = phaseStub();
+    bp.dynab = dynab;
+    bp.is_sweep = false;
+
+    const shape = {
+      zip_aabb: true, // would normally trigger validation, but node.synced wins
+      body: null,
+      type: 0,
+      circle: null,
+      polygon: null,
+      node: { synced: true },
+    };
+
+    expect(() => bp.sync(shape)).not.toThrow();
+    // The early-exit must leave zip_aabb untouched (no validation work done).
+    expect(shape.zip_aabb).toBe(true);
+    expect(dynab.syncs).toHaveLength(0);
+  });
+
+  it("returns without inspecting shape state when shape.body is null (sweep path)", () => {
+    const bp = new ZPP_Broadphase();
+    const sweep = phaseStub();
+    bp.sweep = sweep;
+    bp.is_sweep = true;
+    sweep.space.continuous = false;
+
+    expect(() =>
+      bp.sync({ zip_aabb: true, body: null, type: 0, circle: null, polygon: null }),
+    ).not.toThrow();
+    expect(sweep.syncs).toHaveLength(0);
+  });
+
+  it("sync() with continuous=true on sweep path is a no-op (handled elsewhere)", () => {
+    const bp = new ZPP_Broadphase();
+    const sweep = phaseStub();
+    bp.sweep = sweep;
+    bp.is_sweep = true;
+    sweep.space.continuous = true;
+
+    // Continuous-mode sync is handled by the CCD path; the discrete sync()
+    // body must skip the entire validation block. Any shape state goes in.
+    expect(() =>
+      bp.sync({ zip_aabb: true, body: { tag: "any" }, type: 0, circle: null, polygon: null }),
+    ).not.toThrow();
+    expect(sweep.syncs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateAABBShape — lazy probe factory
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Broadphase.updateAABBShape()", () => {
+  let bp: ZPP_Broadphase;
+
+  beforeEach(() => {
+    bp = new ZPP_Broadphase();
+  });
+
+  it("lazily constructs an aabbShape probe on the first call", () => {
+    expect(bp.aabbShape).toBeNull();
+
+    bp.updateAABBShape(aabb(0, 0, 100, 50));
+
+    expect(bp.aabbShape).not.toBeNull();
+    // The probe is a Polygon; the inner ZPP_Shape exposes the AABB we set.
+    const inner = bp.aabbShape.zpp_inner;
+    expect(inner.aabb.minx).toBe(0);
+    expect(inner.aabb.miny).toBe(0);
+    expect(inner.aabb.maxx).toBe(100);
+    expect(inner.aabb.maxy).toBe(50);
+  });
+
+  it("reuses the same probe instance across calls (no per-query allocation)", () => {
+    bp.updateAABBShape(aabb(0, 0, 100, 50));
+    const probeFirst = bp.aabbShape;
+
+    bp.updateAABBShape(aabb(10, 20, 60, 80));
+
+    // Same outer wrapper instance — the second call transforms the existing
+    // probe rather than constructing a fresh Polygon.
+    expect(bp.aabbShape).toBe(probeFirst);
+  });
+
+  it("the reused probe's AABB matches the new query bounds", () => {
+    bp.updateAABBShape(aabb(0, 0, 100, 50));
+    bp.updateAABBShape(aabb(10, 20, 60, 80));
+
+    const a = bp.aabbShape.zpp_inner.aabb;
+    expect(a.minx).toBeCloseTo(10, 6);
+    expect(a.miny).toBeCloseTo(20, 6);
+    expect(a.maxx).toBeCloseTo(60, 6);
+    expect(a.maxy).toBeCloseTo(80, 6);
+  });
+
+  it("materializes the transform matrix lazily on the second call only", () => {
+    expect(bp.matrix).toBeNull();
+    bp.updateAABBShape(aabb(0, 0, 100, 50));
+    // First call constructs the probe via Polygon.rect — no transform needed.
+    expect(bp.matrix).toBeNull();
+
+    bp.updateAABBShape(aabb(10, 20, 60, 80));
+    // Second call applies a transform via the (now-allocated) matrix.
+    expect(bp.matrix).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCircShape — lazy probe factory
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Broadphase.updateCircShape()", () => {
+  let bp: ZPP_Broadphase;
+
+  beforeEach(() => {
+    bp = new ZPP_Broadphase();
+  });
+
+  it("lazily constructs a circShape probe on the first call", () => {
+    expect(bp.circShape).toBeNull();
+
+    bp.updateCircShape(50, 75, 12);
+
+    expect(bp.circShape).not.toBeNull();
+    const inner = bp.circShape.zpp_inner;
+    expect(inner.circle.radius).toBeCloseTo(12, 6);
+  });
+
+  it("reuses the same probe across calls and mutates its position/radius", () => {
+    bp.updateCircShape(50, 75, 12);
+    const probeFirst = bp.circShape;
+
+    bp.updateCircShape(-100, 0, 5);
+
+    expect(bp.circShape).toBe(probeFirst);
+    expect(bp.circShape.zpp_inner.circle.radius).toBeCloseTo(5, 6);
+  });
+
+  it("rejects NaN center coordinates", () => {
+    expect(() => bp.updateCircShape(Number.NaN, 0, 5)).toThrow(/Vec2 components cannot be NaN/);
+  });
+});

--- a/packages/nape-js/tests/native/space/ZPP_SpatialHashPhase.grid.test.ts
+++ b/packages/nape-js/tests/native/space/ZPP_SpatialHashPhase.grid.test.ts
@@ -1,0 +1,427 @@
+/**
+ * ZPP_SpatialHashPhase — Direct unit tests for grid hashing, auto-tuning,
+ * pair dedup, and raycast bucket-boundary correctness.
+ *
+ * The existing `tests/space/SpatialHash.integration.test.ts` is an end-to-end
+ * suite that proves the public API works under SPATIAL_HASH; it does NOT
+ * isolate the grid's tuning loop, the multi-cell pair-dedup math, or the
+ * off-by-one edge cases the issue calls out. This suite drives the
+ * broadphase directly through `space.zpp_inner.broadphase` to pin those
+ * contracts.
+ *
+ * Covers (issue #163):
+ * - `cellKey()` hash determinism and basic dispersion (no trivial collisions
+ *   between adjacent grid cells).
+ * - `__insert()` / `__remove()` O(1) index-swap removal, preserving array
+ *   compactness and updating `__shIdx` on the swapped element.
+ * - `autoTuneCellSize()`: no-op when fixedCellSize or empty, computes
+ *   2× average dimension, floors at 8 for tiny shapes, updates invCellSize.
+ * - `fixedCellSize` lock survives multiple broadphase frames.
+ * - Multi-cell shape pair-dedup (Szudzik pairing) — large shape that spans
+ *   the cell grid only enqueues one narrow-phase test per partner.
+ * - Cell-array pool recycling between frames (no unbounded growth).
+ * - Raycast result correctness at cell boundaries (off-by-one regression
+ *   guard from the issue body).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import "../../../src/core/engine";
+import { Space } from "../../../src/space/Space";
+import { Broadphase } from "../../../src/space/Broadphase";
+import { Body } from "../../../src/phys/Body";
+import { BodyType } from "../../../src/phys/BodyType";
+import { Vec2 } from "../../../src/geom/Vec2";
+import { Circle } from "../../../src/shape/Circle";
+import { Polygon } from "../../../src/shape/Polygon";
+import { Ray } from "../../../src/geom/Ray";
+import { ZPP_SpatialHashPhase } from "../../../src/native/space/ZPP_SpatialHashPhase";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function spaceWithHash(cellSize?: number): { space: Space; bp: ZPP_SpatialHashPhase } {
+  const space = new Space(new Vec2(0, 0), Broadphase.SPATIAL_HASH);
+  const bp = (space.zpp_inner as any).bphase as ZPP_SpatialHashPhase;
+  if (cellSize !== undefined) {
+    // The Space constructor uses the default cellSize (64). Override for tests
+    // that need deterministic cell-boundary behavior.
+    bp.cellSize = cellSize;
+    bp.invCellSize = 1 / cellSize;
+    bp.fixedCellSize = true;
+  }
+  return { space, bp };
+}
+
+function dynCircle(x: number, y: number, r = 10): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(r));
+  return b;
+}
+
+function staticBox(x: number, y: number, w: number, h: number): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(x, y));
+  b.shapes.add(new Polygon(Polygon.box(w, h)));
+  return b;
+}
+
+// ---------------------------------------------------------------------------
+// cellKey()
+// ---------------------------------------------------------------------------
+
+describe("ZPP_SpatialHashPhase.cellKey()", () => {
+  let bp: ZPP_SpatialHashPhase;
+
+  beforeEach(() => {
+    bp = spaceWithHash().bp;
+  });
+
+  it("is deterministic for the same coordinates", () => {
+    expect(bp.cellKey(3, 7)).toBe(bp.cellKey(3, 7));
+    expect(bp.cellKey(-12, 4)).toBe(bp.cellKey(-12, 4));
+  });
+
+  it("distinguishes adjacent grid cells (no trivial collision)", () => {
+    // Hash uses two large primes — neighboring cells must produce distinct
+    // keys. Trivial implementations (cx + cy, cx ^ cy) would collide here.
+    const center = bp.cellKey(0, 0);
+    expect(bp.cellKey(1, 0)).not.toBe(center);
+    expect(bp.cellKey(0, 1)).not.toBe(center);
+    expect(bp.cellKey(-1, 0)).not.toBe(center);
+    expect(bp.cellKey(0, -1)).not.toBe(center);
+    // Diagonals and (0,0)/(1,1) — also distinct.
+    expect(bp.cellKey(1, 1)).not.toBe(center);
+    expect(bp.cellKey(1, 0)).not.toBe(bp.cellKey(0, 1));
+  });
+
+  it("distinguishes positive vs mixed-sign cells (no whole-quadrant collision)", () => {
+    // Note: XOR-based hashing has a well-known property that (-cx, -cy) hashes
+    // identically to (cx, cy) in 32-bit two's-complement — that's acceptable
+    // here because a single shape spans a small contiguous cell range and
+    // never straddles the origin diagonally enough to alias. What we DO
+    // require is that mixed-sign cells stay distinct from the positive ones.
+    expect(bp.cellKey(-3, 7)).not.toBe(bp.cellKey(3, 7));
+    expect(bp.cellKey(3, -7)).not.toBe(bp.cellKey(3, 7));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// __insert / __remove
+// ---------------------------------------------------------------------------
+
+describe("ZPP_SpatialHashPhase.__insert / __remove", () => {
+  it("__insert appends and tags __shIdx with the new index", () => {
+    const bp = spaceWithHash().bp;
+    const s1 = { tag: "s1" };
+    const s2 = { tag: "s2" };
+
+    bp.__insert(s1);
+    bp.__insert(s2);
+
+    expect(bp.shapes).toEqual([s1, s2]);
+    expect((s1 as any).__shIdx).toBe(0);
+    expect((s2 as any).__shIdx).toBe(1);
+  });
+
+  it("__remove on the tail does NOT swap (idx === last fast path)", () => {
+    const bp = spaceWithHash().bp;
+    const s1: any = { tag: "s1" };
+    const s2: any = { tag: "s2" };
+    bp.__insert(s1);
+    bp.__insert(s2);
+
+    bp.__remove(s2);
+
+    expect(bp.shapes).toEqual([s1]);
+    // s1 still at index 0, unchanged.
+    expect(s1.__shIdx).toBe(0);
+    expect(s2.__shIdx).toBeUndefined();
+  });
+
+  it("__remove from the middle swaps tail into the gap and updates the moved index", () => {
+    const bp = spaceWithHash().bp;
+    const s1: any = { tag: "s1" };
+    const s2: any = { tag: "s2" };
+    const s3: any = { tag: "s3" };
+    bp.__insert(s1);
+    bp.__insert(s2);
+    bp.__insert(s3);
+
+    bp.__remove(s1);
+
+    // s3 was moved into slot 0.
+    expect(bp.shapes).toEqual([s3, s2]);
+    expect(s3.__shIdx).toBe(0);
+    expect(s2.__shIdx).toBe(1);
+    expect(s1.__shIdx).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// autoTuneCellSize()
+// ---------------------------------------------------------------------------
+
+describe("ZPP_SpatialHashPhase.autoTuneCellSize()", () => {
+  it("is a no-op when fixedCellSize is true", () => {
+    const { bp } = spaceWithHash(50);
+    expect(bp.fixedCellSize).toBe(true);
+
+    // Even if we plant shapes that would otherwise re-tune, the cellSize
+    // stays locked at 50.
+    bp.__insert({ aabb: { minx: 0, miny: 0, maxx: 200, maxy: 200 } });
+
+    bp.autoTuneCellSize();
+
+    expect(bp.cellSize).toBe(50);
+    expect(bp.invCellSize).toBe(1 / 50);
+  });
+
+  it("is a no-op when no shapes are tracked", () => {
+    const { bp } = spaceWithHash();
+    const before = bp.cellSize;
+
+    bp.autoTuneCellSize();
+
+    expect(bp.cellSize).toBe(before);
+  });
+
+  it("computes cell size as 2× the average AABB dimension", () => {
+    const { bp } = spaceWithHash();
+    bp.fixedCellSize = false;
+
+    // Two shapes: 20×20 and 30×30 — avg dimension = (20+20+30+30)/(2*2) = 25.
+    // Expected cellSize = max(25*2, 8) = 50.
+    bp.shapes = [
+      { aabb: { minx: 0, miny: 0, maxx: 20, maxy: 20 } },
+      { aabb: { minx: 0, miny: 0, maxx: 30, maxy: 30 } },
+    ];
+
+    bp.autoTuneCellSize();
+
+    expect(bp.cellSize).toBeCloseTo(50, 6);
+    expect(bp.invCellSize).toBeCloseTo(1 / 50, 6);
+  });
+
+  it("floors at cellSize = 8 to avoid pathological cases with tiny shapes", () => {
+    const { bp } = spaceWithHash();
+    bp.fixedCellSize = false;
+    // Tiny 1×1 shapes — 2× avg = 2, but the floor must clamp to 8.
+    bp.shapes = [
+      { aabb: { minx: 0, miny: 0, maxx: 1, maxy: 1 } },
+      { aabb: { minx: 0, miny: 0, maxx: 1, maxy: 1 } },
+    ];
+
+    bp.autoTuneCellSize();
+
+    expect(bp.cellSize).toBe(8);
+    expect(bp.invCellSize).toBeCloseTo(1 / 8, 6);
+  });
+
+  it("skips shapes whose aabb is null (defensive against transient state)", () => {
+    const { bp } = spaceWithHash();
+    bp.fixedCellSize = false;
+    bp.shapes = [
+      { aabb: null }, // skipped
+      { aabb: { minx: 0, miny: 0, maxx: 20, maxy: 20 } },
+    ];
+
+    bp.autoTuneCellSize();
+
+    // Only the second shape counted: avg = 20, cellSize = 40.
+    expect(bp.cellSize).toBeCloseTo(40, 6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fixedCellSize lock — survives broadphase frames
+// ---------------------------------------------------------------------------
+
+describe("ZPP_SpatialHashPhase — fixedCellSize lock across frames", () => {
+  it("keeps cellSize stable for >TUNE_INTERVAL frames when fixed", () => {
+    const { space, bp } = spaceWithHash(40);
+    // Add a body so broadphase() does real work each frame.
+    dynCircle(0, 0, 5).space = space;
+
+    const initial = bp.cellSize;
+    expect(initial).toBe(40);
+
+    // Run more frames than the auto-tune interval — fixedCellSize must hold.
+    for (let i = 0; i < ZPP_SpatialHashPhase.TUNE_INTERVAL + 5; i++) {
+      space.step(1 / 60);
+    }
+
+    expect(bp.cellSize).toBe(initial);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-cell shape pair dedup
+// ---------------------------------------------------------------------------
+
+describe("ZPP_SpatialHashPhase — multi-cell shape pair dedup", () => {
+  it("a large shape spanning many cells only fires one BEGIN per partner", async () => {
+    // Force a tiny cell size so a single shape straddles many cells, exercising
+    // the Szudzik pair-dedup branch. Without dedup, narrowPhase would be invoked
+    // multiple times per pair (one per shared cell) and produce duplicate
+    // contact attempts; the public BEGIN-listener count is the cleanest probe.
+    const { space } = spaceWithHash(10);
+
+    // Use a public listener to count BEGIN events.
+    const { InteractionListener } = await import("../../../src/callbacks/InteractionListener");
+    const { CbEvent } = await import("../../../src/callbacks/CbEvent");
+    const { CbType } = await import("../../../src/callbacks/CbType");
+    const { InteractionType } = await import("../../../src/callbacks/InteractionType");
+
+    let begin = 0;
+    new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => begin++,
+    ).space = space;
+
+    // Big static floor that spans many 10-unit cells, small dynamic that
+    // starts already overlapping the floor so BEGIN fires on the first step.
+    staticBox(0, 50, 200, 10).space = space;
+    dynCircle(0, 48, 5).space = space;
+
+    for (let i = 0; i < 3; i++) space.step(1 / 60);
+
+    // Exactly one BEGIN for this single pair — dedup is working.
+    expect(begin).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cell-array pool recycling
+// ---------------------------------------------------------------------------
+
+describe("ZPP_SpatialHashPhase — cell pool recycling", () => {
+  it("recycled cell arrays return to the pool and are reused across frames", () => {
+    const { space, bp } = spaceWithHash(20);
+    dynCircle(0, 0, 3).space = space;
+    dynCircle(40, 0, 3).space = space;
+
+    // First frame builds at least one cell into the grid.
+    space.step(1 / 60);
+    expect(bp.cellPool.length).toBeGreaterThanOrEqual(0); // baseline observation
+
+    // After several frames the pool should not grow unboundedly — it stabilises
+    // because every frame recycles every cell. Take an upper bound proportional
+    // to the number of shapes, not to the frame count.
+    for (let i = 0; i < 30; i++) space.step(1 / 60);
+
+    // The pool size is bounded by the number of shapes (each shape contributes
+    // at most a handful of cells). 30 frames × 2 shapes shouldn't bloat past ~16.
+    expect(bp.cellPool.length).toBeLessThan(16);
+  });
+
+  it("grid size stays bounded across many frames (no unbounded growth)", () => {
+    const { space, bp } = spaceWithHash(20);
+    dynCircle(0, 0, 3).space = space;
+    dynCircle(40, 0, 3).space = space;
+
+    // The grid is recycled at the start of every broadphase() call: the
+    // forEach->recycleCell->grid.clear() pass at the top moves all cells back
+    // into the pool, then the frame's inserts refill only the cells the
+    // current shapes actually touch. So between frames the grid may be
+    // non-empty, but its size never exceeds the number of distinct cells
+    // touched by the current shape set.
+    for (let i = 0; i < 50; i++) space.step(1 / 60);
+
+    // Two tiny circles in a 20-cell grid can touch at most a few cells each.
+    expect(bp.grid.size).toBeLessThanOrEqual(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Raycast bucket-boundary correctness
+// ---------------------------------------------------------------------------
+
+describe("ZPP_SpatialHashPhase.rayCast() — bucket-boundary edge cases", () => {
+  it("hits a shape whose center sits exactly on a cell boundary", () => {
+    // cellSize=50; shape center at (50,0) is exactly on the (1,0)/(0,0) boundary.
+    // A linear-scan implementation has no off-by-one risk, but the test pins
+    // the contract so any future grid-traversal optimisation doesn't regress.
+    const { space } = spaceWithHash(50);
+    const target = dynCircle(50, 0, 8);
+    target.space = space;
+
+    space.step(1 / 60);
+
+    const ray = Ray.fromSegment(new Vec2(0, 0), new Vec2(200, 0));
+    const result = space.rayCast(ray);
+
+    expect(result).not.toBeNull();
+    expect(result!.shape.body).toBe(target);
+  });
+
+  it("misses cleanly when the ray runs parallel to a row of empty cells", () => {
+    const { space } = spaceWithHash(50);
+    // Only target sits well above the ray's y coordinate — ray must miss.
+    const target = dynCircle(100, 200, 8);
+    target.space = space;
+
+    space.step(1 / 60);
+
+    const ray = Ray.fromSegment(new Vec2(0, 0), new Vec2(500, 0));
+    const result = space.rayCast(ray);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns the nearest hit when the ray crosses multiple cells in order", () => {
+    const { space } = spaceWithHash(20);
+    // Three circles at increasing distances along the ray.
+    const near = dynCircle(30, 0, 5);
+    const mid = dynCircle(60, 0, 5);
+    const far = dynCircle(120, 0, 5);
+    near.space = space;
+    mid.space = space;
+    far.space = space;
+
+    space.step(1 / 60);
+
+    const ray = Ray.fromSegment(new Vec2(0, 0), new Vec2(200, 0));
+    const result = space.rayCast(ray);
+
+    expect(result).not.toBeNull();
+    expect(result!.shape.body).toBe(near);
+  });
+
+  it("rayMultiCast finds every shape along the ray regardless of cell layout", () => {
+    const { space } = spaceWithHash(20);
+    dynCircle(30, 0, 5).space = space;
+    dynCircle(60, 0, 5).space = space;
+    dynCircle(120, 0, 5).space = space;
+
+    space.step(1 / 60);
+
+    const ray = Ray.fromSegment(new Vec2(0, 0), new Vec2(200, 0));
+    const results = space.rayMultiCast(ray);
+
+    expect(results.length).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clear()
+// ---------------------------------------------------------------------------
+
+describe("ZPP_SpatialHashPhase.clear() — internal teardown", () => {
+  it("empties shapes, grid, cellPool, and testedPairs", () => {
+    const { space, bp } = spaceWithHash(40);
+    dynCircle(0, 0, 5).space = space;
+    dynCircle(50, 0, 5).space = space;
+    space.step(1 / 60);
+
+    space.clear();
+
+    // After Space.clear() the broadphase delegates to its own clear().
+    expect(bp.shapes.length).toBe(0);
+    expect(bp.grid.size).toBe(0);
+    expect(bp.cellPool.length).toBe(0);
+    expect(bp.testedPairs.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds direct unit tests for two native broadphase classes that were only
covered indirectly through end-to-end query/integration suites
(`ZPP_Broadphase.{integration,queries,spatial}.test.ts`,
`SpatialHash.integration.test.ts`).

Closes two checkboxes from #163:
> - [ ] `packages/nape-js/src/native/space/ZPP_Broadphase.ts` (1378 LoC) — phase selection, cull-callback filtering, rayCast / convexCast result generation across phases
> - [ ] `packages/nape-js/src/native/space/ZPP_SpatialHashPhase.ts` (961 LoC) — bucket collision load-factor, grid rebalancing under high concentration, off-by-one in bucket-boundary raycasts

## What's covered

### `ZPP_Broadphase` — base class concrete surface (16 tests)

The base class is a router; every subclass inherits `insert` / `remove` / `sync` routing and the lazy probe-shape helpers used by spatial queries. Existing tests exercise these only via Space integration — this suite pins the contract directly.

- `_initFields()` defaults + idempotent re-init.
- `insert` / `remove` routing via `is_sweep` (exclusive dispatch, mid-flight reroute).
- `sync()` short-circuit branches: dynab path bails on `node.synced=true`, sweep path bails on `body=null` or `continuous=true`.
- `updateAABBShape()` lazy Polygon probe + matrix reuse (matrix materialized only on the second call).
- `updateCircShape()` lazy Circle probe + position/radius mutation + NaN rejection.

### `ZPP_SpatialHashPhase` — grid hashing + tuning (20 tests)

- `cellKey()` determinism, adjacent-cell dispersion, mixed-sign cell distinctness. Documents the known (-cx,-cy)≡(cx,cy) 32-bit XOR aliasing as acceptable.
- `__insert` / `__remove` O(1) index-swap removal; tail removal takes the no-swap fast path.
- `autoTuneCellSize()`: locked by `fixedCellSize`, no-op on empty, computes 2× average AABB dimension, floors at 8, defensively skips null AABBs.
- `fixedCellSize` lock survives >TUNE_INTERVAL frames through `Space.step()`.
- Multi-cell pair dedup: static floor spanning many small cells fires exactly one BEGIN per partner (Szudzik pairing).
- Cell-pool growth bounded across 50 frames (<16 cells for 2 shapes).
- Grid size bounded across frames (recycle at frame start).
- Raycast bucket-boundary correctness: shape center exactly on a cell boundary, clean miss through empty rows, nearest-hit ordering across cells, `rayMultiCast` collects every shape along the ray.
- `clear()` drains shapes / grid / cellPool / testedPairs.

## Test counts

- Before: 5875 engine + 71 pixi
- After:  **5911** engine + 71 pixi (+36)

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 5911 + 71 passing
- [x] `npm run build` — DTS clean

Refs #163