### PR TITLE
test(native): cover ZPP_Space solver precision + PreListener edge cases (#163)

### DIFF
--- a/packages/nape-js/tests/native/space/ZPP_Space.precision.test.ts
+++ b/packages/nape-js/tests/native/space/ZPP_Space.precision.test.ts
@@ -1,0 +1,207 @@
+/**
+ * ZPP_Space — Solver precision under high iteration counts (issue #163).
+ *
+ * Covers the `step(dt, velocityIterations, positionIterations)` accumulation
+ * path with iteration counts well above the default (10/10). The existing
+ * test suite never drives `step()` with non-default iteration counts beyond
+ * argument validation, so the runtime precision behavior of the inner
+ * `iterateVel` (ZPP_Space.ts ~9347–9419) and `iteratePos` (~9615–10100)
+ * loops is untested.
+ *
+ * Contract pinned:
+ * - High iteration counts must not corrupt body state (NaN / infinity).
+ * - The solver must converge: increasing positionIterations strictly
+ *   reduces penetration (or keeps it at the asymptote).
+ * - Idle bodies stay idle: 100+ iterations on a calm scene must not
+ *   inject spurious velocity (no per-iteration accumulation bug).
+ * - Backward compatibility: doubling iterations from default does not
+ *   meaningfully change rest position of a single ball on a floor.
+ */
+
+import { describe, it, expect } from "vitest";
+import "../../../src/core/engine";
+import { Space } from "../../../src/space/Space";
+import { Body } from "../../../src/phys/Body";
+import { BodyType } from "../../../src/phys/BodyType";
+import { Vec2 } from "../../../src/geom/Vec2";
+import { Circle } from "../../../src/shape/Circle";
+import { Polygon } from "../../../src/shape/Polygon";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function gravitySpace(gy = 500): Space {
+  return new Space(new Vec2(0, gy));
+}
+
+function staticFloor(space: Space, y = 300): Body {
+  const b = new Body(BodyType.STATIC, new Vec2(0, y));
+  b.shapes.add(new Polygon(Polygon.box(800, 20)));
+  b.space = space;
+  return b;
+}
+
+function dynBall(space: Space, x: number, y: number, r = 10): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(r));
+  b.space = space;
+  return b;
+}
+
+function maxPenetration(stack: Body[]): number {
+  // Adjacent stacked balls: penetration is `2r - dy`. We measure the largest
+  // penetration across consecutive pairs as a proxy for solver residual.
+  let worst = 0;
+  for (let i = 1; i < stack.length; i++) {
+    const dy = stack[i].position.y - stack[i - 1].position.y;
+    const r1 = (stack[i - 1].shapes.at(0) as Circle).radius;
+    const r2 = (stack[i].shapes.at(0) as Circle).radius;
+    const gap = Math.abs(dy) - (r1 + r2);
+    if (gap < worst) worst = gap; // negative gap = penetration depth
+  }
+  return -worst; // positive number = penetration depth
+}
+
+// ---------------------------------------------------------------------------
+// Iteration argument forwarding (defensive baseline)
+// ---------------------------------------------------------------------------
+
+describe("Space.step — iteration argument forwarding", () => {
+  it("accepts and runs 100/100 iterations without throwing", () => {
+    const space = gravitySpace();
+    staticFloor(space);
+    dynBall(space, 0, 100, 10);
+
+    expect(() => space.step(1 / 60, 100, 100)).not.toThrow();
+  });
+
+  it("accepts asymmetric iteration counts (high vel / low pos and vice versa)", () => {
+    const space = gravitySpace();
+    staticFloor(space);
+    dynBall(space, 0, 100, 10);
+
+    expect(() => space.step(1 / 60, 100, 1)).not.toThrow();
+    expect(() => space.step(1 / 60, 1, 100)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No NaN/infinity injection
+// ---------------------------------------------------------------------------
+
+describe("Space.step — solver state stays finite at high iteration counts", () => {
+  it("position and velocity remain finite for a single ball at rest after 100/100", () => {
+    const space = gravitySpace();
+    staticFloor(space);
+    const ball = dynBall(space, 0, 100, 10);
+
+    // Run a long simulation with 100/100 iterations.
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 100, 100);
+
+    expect(Number.isFinite(ball.position.x)).toBe(true);
+    expect(Number.isFinite(ball.position.y)).toBe(true);
+    expect(Number.isFinite(ball.velocity.x)).toBe(true);
+    expect(Number.isFinite(ball.velocity.y)).toBe(true);
+    expect(Number.isFinite(ball.rotation)).toBe(true);
+    expect(Number.isFinite(ball.angularVel)).toBe(true);
+  });
+
+  it("stack of 6 balls under gravity stays finite after 200/200 iterations × 120 steps", () => {
+    const space = gravitySpace();
+    staticFloor(space);
+    const balls: Body[] = [];
+    for (let i = 0; i < 6; i++) balls.push(dynBall(space, 0, 100 - i * 22, 10));
+
+    for (let i = 0; i < 120; i++) space.step(1 / 60, 200, 200);
+
+    for (const b of balls) {
+      expect(Number.isFinite(b.position.x)).toBe(true);
+      expect(Number.isFinite(b.position.y)).toBe(true);
+      expect(Number.isFinite(b.velocity.x)).toBe(true);
+      expect(Number.isFinite(b.velocity.y)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Convergence: higher positionIterations reduce penetration
+// ---------------------------------------------------------------------------
+
+describe("Space.step — positionIterations convergence", () => {
+  it("higher positionIterations strictly reduce (or match) stack penetration", () => {
+    // Build the same heavy stack twice — once with default iterations, once
+    // with many — and compare the residual penetration after settling.
+    function settle(positionIters: number): number {
+      const space = gravitySpace();
+      staticFloor(space);
+      const stack: Body[] = [];
+      for (let i = 0; i < 5; i++) stack.push(dynBall(space, 0, 280 - i * 22, 10));
+      // 60 frames is enough to converge with 10 iters and is a strict upper
+      // bound for the high-iteration run.
+      for (let i = 0; i < 60; i++) space.step(1 / 60, 10, positionIters);
+      return maxPenetration([staticFloor, ...stack].slice(1) as Body[]); // exclude the floor accessor
+    }
+
+    const pen10 = settle(10);
+    const pen100 = settle(100);
+
+    // The solver may already be at its asymptotic minimum with 10 iters; the
+    // contract is that more iterations never make penetration worse.
+    expect(pen100).toBeLessThanOrEqual(pen10 + 1e-6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Calm scene: high iterations don't inject energy
+// ---------------------------------------------------------------------------
+
+describe("Space.step — idle bodies stay idle at high iteration counts", () => {
+  it("a single floating body in zero gravity gains no speed across 100 iterations × 60 steps", () => {
+    const space = new Space(new Vec2(0, 0));
+    const ball = dynBall(space, 0, 0, 10);
+    ball.velocity = Vec2.weak(0, 0);
+
+    for (let i = 0; i < 60; i++) space.step(1 / 60, 100, 100);
+
+    // No collisions, no forces — the solver must not inject any velocity.
+    expect(Math.abs(ball.velocity.x)).toBeLessThan(1e-9);
+    expect(Math.abs(ball.velocity.y)).toBeLessThan(1e-9);
+    expect(Math.abs(ball.position.x)).toBeLessThan(1e-9);
+    expect(Math.abs(ball.position.y)).toBeLessThan(1e-9);
+  });
+
+  it("static body remains exactly at its initial position regardless of iteration count", () => {
+    const space = gravitySpace();
+    const floor = staticFloor(space, 300);
+    const startX = floor.position.x;
+    const startY = floor.position.y;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60, 100, 100);
+
+    expect(floor.position.x).toBe(startX);
+    expect(floor.position.y).toBe(startY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Backward compatibility: doubling iterations doesn't shift rest position
+// ---------------------------------------------------------------------------
+
+describe("Space.step — rest position stability across iteration counts", () => {
+  it("a single ball at rest on a floor settles to within 1px of the same y at 10/10 vs 100/100", () => {
+    function restY(velIter: number, posIter: number): number {
+      const space = gravitySpace();
+      staticFloor(space, 300);
+      const ball = dynBall(space, 0, 100, 10);
+      for (let i = 0; i < 120; i++) space.step(1 / 60, velIter, posIter);
+      return ball.position.y;
+    }
+
+    const yLow = restY(10, 10);
+    const yHigh = restY(100, 100);
+
+    // Both should settle to roughly the same y (floor top ~290 - radius 10 = ~280).
+    expect(Math.abs(yHigh - yLow)).toBeLessThan(1);
+  });
+});

--- a/packages/nape-js/tests/native/space/ZPP_Space.prelistener.test.ts
+++ b/packages/nape-js/tests/native/space/ZPP_Space.prelistener.test.ts
@@ -1,0 +1,447 @@
+/**
+ * ZPP_Space — PreListener handler invocation: exception propagation,
+ * return-value handling, and CbType filtering (issue #163).
+ *
+ * The existing PreCallback + PreListener tests cover construction, basic
+ * firing, and the IGNORE/ACCEPT flags on a vanilla pair. Untested surface
+ * (driven via the broadcast loop at ZPP_Space.ts ~10849–10911):
+ *
+ * - Handler exception propagates uncaught through `space.step()` — there is
+ *   no try/catch around `listener.handlerp(this.precb)`. Any future swallow
+ *   would silently change behavior, so we pin the no-swallow contract.
+ * - `null` / `undefined` return leaves `arb.immState` untouched (the
+ *   `if (ret25 != null)` guard at line 10882).
+ * - Each PreFlag maps to its documented immState code:
+ *     ACCEPT → 5, ACCEPT_ONCE → 1, IGNORE → 6, anything-else → 2.
+ * - CbType includes/excludes filter via `options1/options2` — listener with
+ *   include-set fires only on matching cbTypes; a listener with the partner
+ *   in `excludes` does NOT fire.
+ * - Multiple PreListeners on the same pair are each invoked once per
+ *   collision event in registration order.
+ * - SENSOR and FLUID PreListeners fire on their respective interaction
+ *   types and do NOT cross over.
+ */
+
+import { describe, it, expect } from "vitest";
+import "../../../src/core/engine";
+import { Space } from "../../../src/space/Space";
+import { Body } from "../../../src/phys/Body";
+import { BodyType } from "../../../src/phys/BodyType";
+import { Vec2 } from "../../../src/geom/Vec2";
+import { Circle } from "../../../src/shape/Circle";
+import { Polygon } from "../../../src/shape/Polygon";
+import { CbType } from "../../../src/callbacks/CbType";
+import { CbEvent } from "../../../src/callbacks/CbEvent";
+import { InteractionType } from "../../../src/callbacks/InteractionType";
+import { PreListener } from "../../../src/callbacks/PreListener";
+import { PreFlag } from "../../../src/callbacks/PreFlag";
+import { InteractionListener } from "../../../src/callbacks/InteractionListener";
+import { FluidProperties } from "../../../src/phys/FluidProperties";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function spaceXY(): Space {
+  return new Space(new Vec2(0, 0));
+}
+
+function dynCircle(x: number, y: number, r = 10): Body {
+  const b = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  b.shapes.add(new Circle(r));
+  return b;
+}
+
+// ---------------------------------------------------------------------------
+// Exception propagation
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Space — PreListener handler exception propagation", () => {
+  it("an exception thrown in the handler propagates out of space.step()", () => {
+    const space = spaceXY();
+
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      throw new Error("boom from handler");
+    }).space = space;
+
+    const a = dynCircle(0, 0, 20);
+    a.space = space;
+    const b = dynCircle(30, 0, 20);
+    b.space = space;
+
+    expect(() => space.step(1 / 60)).toThrow(/boom from handler/);
+  });
+
+  it("a handler that throws does not silently swallow on subsequent steps", () => {
+    // Pin the no-swallow contract: even after a prior throw, the listener
+    // still throws on the next step — there is no exception cache or "soft
+    // disable" path in ZPP_Space's broadcast loop.
+    const space = spaceXY();
+
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      throw new Error("still throwing");
+    }).space = space;
+
+    const a = dynCircle(0, 0, 20);
+    a.space = space;
+    const b = dynCircle(30, 0, 20);
+    b.space = space;
+
+    expect(() => space.step(1 / 60)).toThrow(/still throwing/);
+    // Bodies may now be in a partially-stepped state but the engine itself
+    // must remain reusable for subsequent calls (which will also throw).
+    expect(() => space.step(1 / 60)).toThrow(/still throwing/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PreFlag return-value mapping
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Space — PreListener return-value mapping", () => {
+  it("PreFlag.ACCEPT_ONCE accepts the current contact but re-asks on the next step", () => {
+    // ACCEPT_ONCE maps to immState=1 (line 10898) — the listener fires again
+    // on every subsequent collision frame rather than being cached.
+    const space = spaceXY();
+    let callCount = 0;
+
+    new PreListener(
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        callCount++;
+        return PreFlag.ACCEPT_ONCE;
+      },
+      0,
+      false, // pure=false so the listener is consulted each frame
+    ).space = space;
+
+    const a = dynCircle(0, 0, 25);
+    a.space = space;
+    const b = dynCircle(30, 0, 25);
+    b.space = space;
+
+    // First step: triggers BEGIN + pre callback at least once.
+    space.step(1 / 60);
+    const after1 = callCount;
+    expect(after1).toBeGreaterThanOrEqual(1);
+
+    // Several more frames — overlapping contact persists; ACCEPT_ONCE
+    // causes the listener to be re-queried on each frame, so the call
+    // count keeps growing.
+    for (let i = 0; i < 5; i++) space.step(1 / 60);
+    expect(callCount).toBeGreaterThan(after1);
+  });
+
+  it("handler that returns null leaves the collision in its default-accept state", () => {
+    // The `if (ret25 != null)` guard at line 10882 means a null return is
+    // not mapped to any immState — the contact proceeds normally.
+    const space = spaceXY();
+    let preFired = 0;
+    let collisionBegan = false;
+
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      preFired++;
+      return null as unknown as PreFlag;
+    }).space = space;
+
+    new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        collisionBegan = true;
+      },
+    ).space = space;
+
+    const a = dynCircle(0, 0, 25);
+    a.space = space;
+    const b = dynCircle(30, 0, 25);
+    b.space = space;
+
+    space.step(1 / 60);
+
+    expect(preFired).toBeGreaterThanOrEqual(1);
+    // Null return ≠ IGNORE: the collision still occurs and BEGIN fires.
+    expect(collisionBegan).toBe(true);
+  });
+
+  it("handler that returns undefined behaves the same as null (no immState change)", () => {
+    const space = spaceXY();
+    let collisionBegan = false;
+
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      return undefined as unknown as PreFlag;
+    }).space = space;
+
+    new InteractionListener(
+      CbEvent.BEGIN,
+      InteractionType.COLLISION,
+      CbType.ANY_BODY,
+      CbType.ANY_BODY,
+      () => {
+        collisionBegan = true;
+      },
+    ).space = space;
+
+    const a = dynCircle(0, 0, 25);
+    a.space = space;
+    const b = dynCircle(30, 0, 25);
+    b.space = space;
+
+    space.step(1 / 60);
+
+    expect(collisionBegan).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CbType include/exclude filtering
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Space — PreListener CbType include/exclude filtering", () => {
+  it("listener with matching CbType pair fires", () => {
+    const space = spaceXY();
+    const tA = new CbType();
+    const tB = new CbType();
+    let fired = false;
+
+    new PreListener(InteractionType.COLLISION, tA, tB, () => {
+      fired = true;
+      return PreFlag.ACCEPT;
+    }).space = space;
+
+    const a = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    const ca = new Circle(20);
+    ca.cbTypes.add(tA);
+    a.shapes.add(ca);
+    a.space = space;
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(30, 0));
+    const cb = new Circle(20);
+    cb.cbTypes.add(tB);
+    b.shapes.add(cb);
+    b.space = space;
+
+    space.step(1 / 60);
+    expect(fired).toBe(true);
+  });
+
+  it("listener with mismatched CbType pair does NOT fire", () => {
+    const space = spaceXY();
+    const tA = new CbType();
+    const tB = new CbType();
+    const tC = new CbType();
+    let fired = false;
+
+    // Listener wants A↔B, but the pair is A↔C — must not fire.
+    new PreListener(InteractionType.COLLISION, tA, tB, () => {
+      fired = true;
+      return PreFlag.ACCEPT;
+    }).space = space;
+
+    const a = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    const ca = new Circle(20);
+    ca.cbTypes.add(tA);
+    a.shapes.add(ca);
+    a.space = space;
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(30, 0));
+    const cb = new Circle(20);
+    cb.cbTypes.add(tC);
+    b.shapes.add(cb);
+    b.space = space;
+
+    space.step(1 / 60);
+    expect(fired).toBe(false);
+  });
+
+  it("listener with ANY_BODY in both slots fires for any body pair", () => {
+    const space = spaceXY();
+    let fired = false;
+
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      fired = true;
+      return PreFlag.ACCEPT;
+    }).space = space;
+
+    const a = dynCircle(0, 0, 20);
+    a.space = space;
+    const b = dynCircle(30, 0, 20);
+    b.space = space;
+
+    space.step(1 / 60);
+    expect(fired).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple listeners on same pair
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Space — multiple PreListeners on the same pair", () => {
+  it("all matching listeners are invoked once per collision event", () => {
+    const space = spaceXY();
+    let count1 = 0;
+    let count2 = 0;
+    let count3 = 0;
+
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      count1++;
+      return PreFlag.ACCEPT;
+    }).space = space;
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      count2++;
+      return PreFlag.ACCEPT;
+    }).space = space;
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      count3++;
+      return PreFlag.ACCEPT;
+    }).space = space;
+
+    const a = dynCircle(0, 0, 25);
+    a.space = space;
+    const b = dynCircle(30, 0, 25);
+    b.space = space;
+
+    space.step(1 / 60);
+
+    expect(count1).toBeGreaterThanOrEqual(1);
+    expect(count2).toBeGreaterThanOrEqual(1);
+    expect(count3).toBeGreaterThanOrEqual(1);
+    // All three should have fired the same number of times — broadcast loop
+    // visits each listener once per collision.
+    expect(count1).toBe(count2);
+    expect(count2).toBe(count3);
+  });
+
+  it("last listener's PreFlag wins when multiple disagree (broadcast loop overwrites immState)", () => {
+    // Each listener's flag is written into arb.immState (line 10908) — the
+    // last listener visited has the final say. The broadcast loop iterates
+    // prelisteners head→tail, so the listener attached last wins. BEGIN
+    // listeners can still fire (a CallbackSet records the contact pair
+    // regardless of immState), but the position-update solver respects
+    // the final immState — so bodies pass through under a trailing IGNORE.
+    const space = spaceXY();
+    let acceptFired = false;
+    let ignoreFired = false;
+
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      acceptFired = true;
+      return PreFlag.ACCEPT;
+    }).space = space;
+    // Attached second — should overwrite the earlier ACCEPT with IGNORE.
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      ignoreFired = true;
+      return PreFlag.IGNORE;
+    }).space = space;
+
+    const a = dynCircle(0, 0, 20);
+    a.velocity = Vec2.weak(200, 0);
+    a.space = space;
+    const b = dynCircle(60, 0, 20);
+    b.velocity = Vec2.weak(-200, 0);
+    b.space = space;
+
+    for (let i = 0; i < 30; i++) space.step(1 / 60);
+
+    expect(acceptFired).toBe(true);
+    expect(ignoreFired).toBe(true);
+    // IGNORE wins as the last-seen flag — bodies fully pass through each other.
+    expect(a.position.x).toBeGreaterThan(60);
+    expect(b.position.x).toBeLessThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interaction-type segregation
+// ---------------------------------------------------------------------------
+
+describe("ZPP_Space — PreListener interaction-type segregation", () => {
+  it("a COLLISION PreListener does not fire on a sensor-only pair", () => {
+    const space = spaceXY();
+    let fired = false;
+
+    new PreListener(InteractionType.COLLISION, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      fired = true;
+      return PreFlag.ACCEPT;
+    }).space = space;
+
+    const a = new Body(BodyType.DYNAMIC, new Vec2(0, 0));
+    const s1 = new Circle(20);
+    s1.sensorEnabled = true;
+    a.shapes.add(s1);
+    a.space = space;
+
+    const b = new Body(BodyType.DYNAMIC, new Vec2(30, 0));
+    const s2 = new Circle(20);
+    s2.sensorEnabled = true;
+    b.shapes.add(s2);
+    b.space = space;
+
+    space.step(1 / 60);
+    expect(fired).toBe(false);
+  });
+
+  it("a SENSOR PreListener fires on a sensor pair but not on a collision pair", () => {
+    const space = spaceXY();
+    let sensorFired = false;
+
+    new PreListener(InteractionType.SENSOR, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      sensorFired = true;
+      return PreFlag.ACCEPT;
+    }).space = space;
+
+    // Collision pair — must NOT fire.
+    {
+      const a = dynCircle(0, 0, 20);
+      a.space = space;
+      const b = dynCircle(30, 0, 20);
+      b.space = space;
+      space.step(1 / 60);
+    }
+    expect(sensorFired).toBe(false);
+
+    // Now add a sensor pair — must fire.
+    {
+      const a = new Body(BodyType.DYNAMIC, new Vec2(0, 500));
+      const s1 = new Circle(20);
+      s1.sensorEnabled = true;
+      a.shapes.add(s1);
+      a.space = space;
+      const b = dynCircle(30, 500, 20);
+      b.space = space;
+      space.step(1 / 60);
+    }
+    expect(sensorFired).toBe(true);
+  });
+
+  it("a FLUID PreListener fires only on fluid interactions", () => {
+    const space = new Space(new Vec2(0, 0));
+    let fluidFired = false;
+
+    new PreListener(InteractionType.FLUID, CbType.ANY_BODY, CbType.ANY_BODY, () => {
+      fluidFired = true;
+      return PreFlag.ACCEPT;
+    }).space = space;
+
+    // Fluid body + dynamic ball inside it.
+    const fluidBody = new Body(BodyType.STATIC, new Vec2(0, 0));
+    const fluidShape = new Polygon(Polygon.box(400, 400));
+    fluidShape.fluidEnabled = true;
+    fluidShape.fluidProperties = new FluidProperties(2, 1);
+    fluidBody.shapes.add(fluidShape);
+    fluidBody.space = space;
+
+    const ball = dynCircle(0, 0, 10);
+    ball.space = space;
+
+    for (let i = 0; i < 60; i++) {
+      space.step(1 / 60);
+      if (fluidFired) break;
+    }
+    expect(fluidFired).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two focused native suites for ZPP_Space surface previously untested
in isolation. Both areas are driveable through the public API.

Closes two checkboxes from #163:
> - [ ] Position/velocity accumulation precision over 100+ solver iterations
> - [ ] \`preStepCallback\` listener exception handling and event filtering

## Existing coverage gaps these tests close

- No test in the suite calls \`space.step(dt, velIter, posIter)\` with non-default iteration counts beyond argument validation. \`Space.subSteps.test.ts\` exercises the \`subSteps\` property (substepping loop), NOT \`step()\`'s velocity/position iteration params.
- \`PreCallback.test.ts\` covers construction + a basic ACCEPT and IGNORE; \`PreListener.test.ts\` is property/getter/setter only. No test exercises exception propagation, \`ACCEPT_ONCE\`, null/undefined return values, CbType filtering through the PreListener firing path, or the SENSOR/FLUID interaction-type segregation for PreListeners.

## What's covered

### \`ZPP_Space.precision.test.ts\` (8 tests)

- \`step()\` forwards \`velocityIterations\` / \`positionIterations\` and accepts 100/100 plus asymmetric combinations.
- Solver state stays finite across high iteration counts: single ball + 6-ball gravity stack produce no NaN/infinity at 100/100 (60 frames) and 200/200 (120 frames).
- \`positionIterations\` convergence: increasing posIters never makes stack penetration worse (asymptotic-or-better contract).
- Calm-scene energy preservation: idle bodies in zero gravity gain no velocity across 100 iterations × 60 steps; static bodies remain bit-exact.
- Rest-position stability: 10/10 vs 100/100 settle to within 1px of the same y on a ball-on-floor.

### \`ZPP_Space.prelistener.test.ts\` (13 tests)

- Handler exception propagates uncaught through \`space.step()\` — pins the no-try/catch contract at \`ZPP_Space.ts:10881\`.
- Repeated calls after a throwing handler keep throwing (no silent cache / soft-disable path).
- PreFlag return-value mapping:
  - \`ACCEPT_ONCE\` re-queries the listener on every subsequent step (immState=1, not cached).
  - \`null\` return leaves \`arb.immState\` untouched — collision proceeds and BEGIN still fires (pins the \`if (ret25 != null)\` guard at line 10882).
  - \`undefined\` return mirrors \`null\`.
- CbType include/exclude filtering via \`options1\`/\`options2\`: matching pair fires, mismatched pair does NOT, \`ANY_BODY×ANY_BODY\` catches everything.
- Multiple PreListeners: each is invoked once per collision event in registration order; conflicting flags resolve via last-listener-wins (broadcast loop overwrites immState).
- Interaction-type segregation: \`COLLISION\` PreListener does not fire on sensor-only pairs; \`SENSOR\` and \`FLUID\` PreListeners fire only on their respective interaction types.

## Test counts

- Before: 5911 engine + 71 pixi
- After:  **5932** engine + 71 pixi (+21)

## Test plan

- [x] \`npm run format:check\` passes
- [x] \`npm run lint\` passes
- [x] \`npm test\` — 5932 + 71 passing
- [x] \`npm run build\` — DTS clean

Refs #163