### PR TITLE
Feat/cordfall demo

### DIFF
--- a/docs/demo-categories.js
+++ b/docs/demo-categories.js
@@ -24,6 +24,7 @@ export const GAME_DEMO_IDS = new Set([
   "portals",
   "arena-defense",
   "floppy-fists",
+  "cordfall",
 ]);
 
 export const CATEGORIES = [

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -145,8 +145,6 @@ let _cutX0        = 0;  // visual start (original click position)
 let _cutY0        = 0;
 let _cutX1        = 0;  // visual end (current drag position)
 let _cutY1        = 0;
-let _cutPrevX     = 0;  // previous drag position for per-frame intersection test
-let _cutPrevY     = 0;
 
 // ── Geometry helpers ─────────────────────────────────────────────────────
 
@@ -496,21 +494,19 @@ export default {
     }
   },
 
-  drag(x, y, space) {
+  drag(x, y) {
     if (_state !== "playing") return;
     if (!_cutting) {
       _cutting = true;
-      _cutX0 = x; _cutY0 = y;   // visual start — fixed for this stroke
-      _cutPrevX = x; _cutPrevY = y;
+      _cutX0 = x; _cutY0 = y;
     }
-    _cutX1 = x; _cutY1 = y;     // visual end — tracks current position
-    // Intersect prev→current segment so fast swipes still register
-    const px = _cutPrevX, py = _cutPrevY;
-    _cutPrevX = x; _cutPrevY = y;
-    applyCut(space, px, py, x, y);
+    _cutX1 = x; _cutY1 = y;
   },
 
   release(space) {
+    if (_cutting) {
+      applyCut(space, _cutX0, _cutY0, _cutX1, _cutY1);
+    }
     _cutting = false;
   },
 

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -141,10 +141,12 @@ let _screenH      = 600;
 
 // Cut stroke state
 let _cutting      = false;
-let _cutX0        = 0;
+let _cutX0        = 0;  // visual start (original click position)
 let _cutY0        = 0;
-let _cutX1        = 0;
+let _cutX1        = 0;  // visual end (current drag position)
 let _cutY1        = 0;
+let _cutPrevX     = 0;  // previous drag position for per-frame intersection test
+let _cutPrevY     = 0;
 
 // ── Geometry helpers ─────────────────────────────────────────────────────
 
@@ -285,15 +287,12 @@ function ropeEndpoints(jEntry) {
 }
 
 // ── Cut logic ─────────────────────────────────────────────────────────────
-function applyCut(space) {
+function applyCut(space, x0, y0, x1, y1) {
   for (const jEntry of _joints) {
     if (!jEntry.joint.space) continue;
     const ep = ropeEndpoints(jEntry);
     if (!ep) continue;
-    if (segmentsIntersect(
-      _cutX0, _cutY0, _cutX1, _cutY1,
-      ep.ax, ep.ay, ep.bx, ep.by,
-    )) {
+    if (segmentsIntersect(x0, y0, x1, y1, ep.ax, ep.ay, ep.bx, ep.by)) {
       jEntry.joint.space = null;
       _ropesCut++;
     }
@@ -501,13 +500,14 @@ export default {
     if (_state !== "playing") return;
     if (!_cutting) {
       _cutting = true;
-      _cutX0 = x; _cutY0 = y;
+      _cutX0 = x; _cutY0 = y;   // visual start — fixed for this stroke
+      _cutPrevX = x; _cutPrevY = y;
     }
-    _cutX1 = x; _cutY1 = y;
-    // Test on every drag frame so fast swipes still register
-    applyCut(space);
-    // Start new segment from current position for next frame
-    _cutX0 = x; _cutY0 = y;
+    _cutX1 = x; _cutY1 = y;     // visual end — tracks current position
+    // Intersect prev→current segment so fast swipes still register
+    const px = _cutPrevX, py = _cutPrevY;
+    _cutPrevX = x; _cutPrevY = y;
+    applyCut(space, px, py, x, y);
   },
 
   release(space) {

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -316,9 +316,6 @@ function drawHUD(ctx, W, H) {
   ctx.restore();
 
   if (_state === "won") {
-    const stars = computeStars();
-    const starStr = "★".repeat(stars) + "☆".repeat(3 - stars);
-
     // Dark overlay
     ctx.save();
     ctx.fillStyle = "rgba(0,0,0,0.55)";
@@ -327,18 +324,10 @@ function drawHUD(ctx, W, H) {
     ctx.textAlign = "center";
     ctx.fillStyle = "#7ee787";
     ctx.font = "bold 32px system-ui, sans-serif";
-    ctx.fillText("Level Complete!", W / 2, H / 2 - 48);
-
-    ctx.fillStyle = "#ffa657";
-    ctx.font = "28px system-ui, sans-serif";
-    ctx.fillText(starStr, W / 2, H / 2 - 10);
-
-    ctx.fillStyle = "rgba(180,200,255,0.8)";
-    ctx.font = "14px monospace";
-    ctx.fillText(`Ropes cut: ${_ropesCut} / ${_startRopes}`, W / 2, H / 2 + 22);
+    ctx.fillText("Level Complete!", W / 2, H / 2 - 28);
 
     // Button
-    const bw = 160, bh = 36, bx = W / 2 - bw / 2, by = H / 2 + 42;
+    const bw = 160, bh = 36, bx = W / 2 - bw / 2, by = H / 2 + 10;
     ctx.fillStyle = "#238636";
     ctx.beginPath();
     ctx.roundRect(bx, by, bw, bh, 6);
@@ -429,7 +418,7 @@ function hitNextButton(x, y, W, H) {
   const bw = _state === "won" ? 160 : 140;
   const bh = 36;
   const bx = W / 2 - bw / 2;
-  const by = H / 2 + (_state === "won" ? 42 : 10);
+  const by = H / 2 + 10;
   return x >= bx && x <= bx + bw && y >= by && y <= by + bh;
 }
 

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -469,8 +469,9 @@ export default {
       }
     }
 
-    // Payload fell off-screen → treat as level fail
-    if (_payload.position.y > _screenH + 60 || _payload.position.x < -60 || _payload.position.x > _screenW + 60) {
+    // Payload fell off-screen with no ropes left → level fail
+    const hasRope = _joints.some((j) => j.joint.space != null);
+    if (!hasRope && (_payload.position.y > _screenH + 60 || _payload.position.x < -60 || _payload.position.x > _screenW + 60)) {
       _state = "lost";
     }
 

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -1,5 +1,5 @@
 /**
- * Cordfall — cut the ropes and guide the payload safely down.
+ * Cordfall — cut the ropes, guide the payload to the goal.
  *
  * Mechanics:
  *  - A small circular payload hangs from DistanceJoints anchored to static pivots.
@@ -7,7 +7,9 @@
  *    the cut segment is removed (`joint.space = null`).
  *  - Spike sensors cause level failure.
  *  - Bubble helpers apply upward force to the payload when touching.
+ *  - Goal sensor triggers level completion.
  *  - 5 levels with a "next level" button on completion.
+ *  - Optional star rating based on ropes cut (fewer = better).
  *
  * Engine features showcased:
  *  - DistanceJoint + runtime joint removal
@@ -22,11 +24,13 @@ import {
 // ── Palette ───────────────────────────────────────────────────────────────
 const C_PAYLOAD  = 1;  // blue
 const C_ANCHOR   = 0;  // red   (static pivot discs)
+const C_GOAL     = 3;  // purple
 const C_SPIKE    = 4;  // orange
 const C_BUBBLE   = 2;  // green
 
 // ── CbTypes ──────────────────────────────────────────────────────────────
 const cbPayload = new CbType();
+const cbGoal    = new CbType();
 const cbSpike   = new CbType();
 const cbBubble  = new CbType();
 
@@ -39,6 +43,7 @@ const cbBubble  = new CbType();
 //    ropes   : [{ai, slack}]    – ai = anchor index; slack added to rest length
 //    spikes  : [{x,y,w,h}]      – spike sensor rectangles
 //    bubbles : [{x,y,r}]        – bubble sensor circles
+//    goal    : {x,y,r}          – goal sensor circle
 
 const LEVELS = [
   // ── Level 1 — single rope, no hazards ──────────────────────────────
@@ -48,6 +53,7 @@ const LEVELS = [
     ropes:   [{ ai: 0, slack: 10 }],
     spikes:  [],
     bubbles: [],
+    goal:    { x: W / 2, y: H * 0.80 },
   }),
 
   // ── Level 2 — two ropes, one spike ──────────────────────────────────
@@ -60,6 +66,7 @@ const LEVELS = [
     ropes:   [{ ai: 0, slack: 5 }, { ai: 1, slack: 5 }],
     spikes:  [{ x: W / 2 - 10, y: H * 0.62, w: 20, h: 16 }],
     bubbles: [],
+    goal:    { x: W * 0.75, y: H * 0.80 },
   }),
 
   // ── Level 3 — two ropes, bubble helper, spike on right ──────────────
@@ -72,6 +79,7 @@ const LEVELS = [
     ropes:   [{ ai: 0, slack: 0 }, { ai: 1, slack: 0 }],
     spikes:  [{ x: W * 0.70 - 10, y: H * 0.55, w: 20, h: 16 }],
     bubbles: [{ x: W * 0.28, y: H * 0.65, r: 28 }],
+    goal:    { x: W * 0.25, y: H * 0.80 },
   }),
 
   // ── Level 4 — three ropes, two spikes, bubble in middle ──────────────
@@ -88,6 +96,7 @@ const LEVELS = [
       { x: W * 0.68 - 10, y: H * 0.58, w: 20, h: 16 },
     ],
     bubbles: [{ x: W / 2, y: H * 0.68, r: 30 }],
+    goal:    { x: W / 2, y: H * 0.85 },
   }),
 
   // ── Level 5 — four ropes, spike gauntlet, two bubbles ────────────────
@@ -112,17 +121,21 @@ const LEVELS = [
       { x: W * 0.20, y: H * 0.72, r: 28 },
       { x: W * 0.80, y: H * 0.72, r: 28 },
     ],
+    goal: { x: W / 2, y: H * 0.87 },
   }),
 ];
 
 // ── Module-level state ────────────────────────────────────────────────────
 let _levelIdx     = 0;
 let _state        = "playing";  // "playing" | "won" | "lost"
+let _ropesCut     = 0;
+let _startRopes   = 0;
 
 let _payload      = null;
-let _joints       = [];         // { joint, anchor }
+let _joints       = [];         // { joint, ax, ay, bx, by } — world-space endpoints cached
 let _anchors      = [];         // static pivot bodies
-let _bubbles      = [];         // bubble sensor bodies
+let _bubbles      = [];         // { body, r }
+let _goalBody     = null;
 let _screenW      = 600;
 let _screenH      = 600;
 
@@ -146,14 +159,25 @@ function segmentsIntersect(ax, ay, bx, by, cx, cy, dx, dy) {
   return t >= 0 && t <= 1 && u >= 0 && u <= 1;
 }
 
+/** Distance from point (px,py) to segment (ax,ay)–(bx,by). */
+function pointSegDist(px, py, ax, ay, bx, by) {
+  const dx = bx - ax, dy = by - ay;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) return Math.hypot(px - ax, py - ay);
+  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / lenSq));
+  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy));
+}
+
 // ── Level builder ─────────────────────────────────────────────────────────
 function buildLevel(space, W, H) {
-  _state    = "playing";
-  _joints   = [];
-  _anchors  = [];
-  _bubbles  = [];
-  _payload  = null;
-  _cutting  = false;
+  _state      = "playing";
+  _ropesCut   = 0;
+  _joints     = [];
+  _anchors    = [];
+  _bubbles    = [];
+  _payload    = null;
+  _goalBody   = null;
+  _cutting    = false;
 
   const def = LEVELS[_levelIdx](W, H);
 
@@ -191,6 +215,7 @@ function buildLevel(space, W, H) {
     joint.space  = space;
     _joints.push({ joint, anchor });
   }
+  _startRopes = _joints.length;
 
   // Spikes (sensor polygons)
   for (const s of def.spikes) {
@@ -218,7 +243,23 @@ function buildLevel(space, W, H) {
     _bubbles.push(b);
   }
 
+  // Goal (sensor circle)
+  _goalBody = new Body(BodyType.STATIC, new Vec2(def.goal.x, def.goal.y));
+  const goalShape = new Circle(22);
+  goalShape.sensorEnabled = true;
+  goalShape.cbTypes.add(cbGoal);
+  _goalBody.shapes.add(goalShape);
+  _goalBody.userData._colorIdx = C_GOAL;
+  _goalBody.userData._kind = "goal";
+  _goalBody.space = space;
+
   // Interaction listeners
+  space.listeners.add(new InteractionListener(
+    CbEvent.BEGIN, InteractionType.SENSOR,
+    cbPayload, cbGoal,
+    () => { if (_state === "playing") _state = "won"; },
+  ));
+
   space.listeners.add(new InteractionListener(
     CbEvent.BEGIN, InteractionType.SENSOR,
     cbPayload, cbSpike,
@@ -256,6 +297,15 @@ function applyCut(space, x0, y0, x1, y1) {
   }
 }
 
+// ── Star rating ───────────────────────────────────────────────────────────
+function computeStars() {
+  if (_ropesCut === 0) return 3;       // shouldn't happen but guard
+  const fraction = _ropesCut / _startRopes;
+  if (fraction <= 0.5) return 3;
+  if (fraction <= 0.75) return 2;
+  return 1;
+}
+
 // ── HUD drawing ───────────────────────────────────────────────────────────
 function drawHUD(ctx, W, H) {
   // Level indicator
@@ -266,6 +316,10 @@ function drawHUD(ctx, W, H) {
   ctx.restore();
 
   if (_state === "won") {
+    const stars = computeStars();
+    const starStr = "★".repeat(stars) + "☆".repeat(3 - stars);
+
+    // Dark overlay
     ctx.save();
     ctx.fillStyle = "rgba(0,0,0,0.55)";
     ctx.fillRect(0, 0, W, H);
@@ -273,9 +327,18 @@ function drawHUD(ctx, W, H) {
     ctx.textAlign = "center";
     ctx.fillStyle = "#7ee787";
     ctx.font = "bold 32px system-ui, sans-serif";
-    ctx.fillText("Level Complete!", W / 2, H / 2 - 28);
+    ctx.fillText("Level Complete!", W / 2, H / 2 - 48);
 
-    const bw = 160, bh = 36, bx = W / 2 - bw / 2, by = H / 2 + 10;
+    ctx.fillStyle = "#ffa657";
+    ctx.font = "28px system-ui, sans-serif";
+    ctx.fillText(starStr, W / 2, H / 2 - 10);
+
+    ctx.fillStyle = "rgba(180,200,255,0.8)";
+    ctx.font = "14px monospace";
+    ctx.fillText(`Ropes cut: ${_ropesCut} / ${_startRopes}`, W / 2, H / 2 + 22);
+
+    // Button
+    const bw = 160, bh = 36, bx = W / 2 - bw / 2, by = H / 2 + 42;
     ctx.fillStyle = "#238636";
     ctx.beginPath();
     ctx.roundRect(bx, by, bw, bh, 6);
@@ -366,7 +429,7 @@ function hitNextButton(x, y, W, H) {
   const bw = _state === "won" ? 160 : 140;
   const bh = 36;
   const bx = W / 2 - bw / 2;
-  const by = H / 2 + 10;
+  const by = H / 2 + (_state === "won" ? 42 : 10);
   return x >= bx && x <= bx + bw && y >= by && y <= by + bh;
 }
 

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -136,6 +136,8 @@ let _joints       = [];         // { joint, ax, ay, bx, by } — world-space end
 let _anchors      = [];         // static pivot bodies
 let _bubbles      = [];         // { body, r }
 let _goalBody     = null;
+let _screenW      = 600;
+let _screenH      = 600;
 
 // Cut stroke state
 let _cutting      = false;
@@ -446,6 +448,8 @@ export default {
   workerCompatible: false,
 
   setup(space, W, H) {
+    _screenW = W;
+    _screenH = H;
     space.gravity = new Vec2(0, 400);
     buildLevel(space, W, H);
   },
@@ -476,35 +480,32 @@ export default {
     }
   },
 
-  click(x, y, space, W, H) {
-    if (hitNextButton(x, y, W, H)) {
-      // Advance or restart
+  click(x, y, space) {
+    if (hitNextButton(x, y, _screenW, _screenH)) {
       if (_state === "won") {
         _levelIdx = _levelIdx < LEVELS.length - 1 ? _levelIdx + 1 : 0;
-      } else {
-        // _state === "lost": retry same level
       }
-      // Clear all bodies and rebuild
+      // "lost": retry same level — _levelIdx unchanged
       for (const b of [...space.bodies]) b.space = null;
       for (const c of [...space.constraints]) c.space = null;
-      buildLevel(space, W, H);
+      buildLevel(space, _screenW, _screenH);
     }
   },
 
-  drag(x, y) {
+  drag(x, y, space) {
     if (_state !== "playing") return;
     if (!_cutting) {
       _cutting = true;
       _cutX0 = x; _cutY0 = y;
     }
     _cutX1 = x; _cutY1 = y;
+    // Test on every drag frame so fast swipes still register
+    applyCut(space);
+    // Start new segment from current position for next frame
+    _cutX0 = x; _cutY0 = y;
   },
 
-  release(x, y, space) {
-    if (_cutting) {
-      _cutX1 = x; _cutY1 = y;
-      applyCut(space);
-    }
+  release(space) {
     _cutting = false;
   },
 

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -21,6 +21,10 @@ import {
   DistanceJoint, CbType, CbEvent, InteractionListener, InteractionType,
 } from "../nape-js.esm.js";
 
+// ── Constants ─────────────────────────────────────────────────────────────
+const PAYLOAD_RADIUS = 14;       // must match the Circle radius in buildLevel
+const BUBBLE_FORCE   = 280;      // upward force (units/s) applied inside a bubble
+
 // ── Palette ───────────────────────────────────────────────────────────────
 const C_PAYLOAD  = 1;  // blue
 const C_ANCHOR   = 0;  // red   (static pivot discs)
@@ -132,9 +136,9 @@ let _ropesCut     = 0;
 let _startRopes   = 0;
 
 let _payload      = null;
-let _joints       = [];         // { joint, ax, ay, bx, by } — world-space endpoints cached
+let _joints       = [];         // { joint, anchor } — anchor is the static pivot body
 let _anchors      = [];         // static pivot bodies
-let _bubbles      = [];         // { body, r }
+let _bubbles      = [];         // bubble sensor bodies
 let _goalBody     = null;
 let _screenW      = 600;
 let _screenH      = 600;
@@ -157,15 +161,6 @@ function segmentsIntersect(ax, ay, bx, by, cx, cy, dx, dy) {
   const t = ((cx - ax) * dyCD - (cy - ay) * dxCD) / denom;
   const u = ((cx - ax) * dyAB - (cy - ay) * dxAB) / denom;
   return t >= 0 && t <= 1 && u >= 0 && u <= 1;
-}
-
-/** Distance from point (px,py) to segment (ax,ay)–(bx,by). */
-function pointSegDist(px, py, ax, ay, bx, by) {
-  const dx = bx - ax, dy = by - ay;
-  const lenSq = dx * dx + dy * dy;
-  if (lenSq === 0) return Math.hypot(px - ax, py - ay);
-  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / lenSq));
-  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy));
 }
 
 // ── Level builder ─────────────────────────────────────────────────────────
@@ -193,7 +188,7 @@ function buildLevel(space, W, H) {
 
   // Payload
   _payload = new Body(BodyType.DYNAMIC, new Vec2(def.payload.x, def.payload.y));
-  _payload.shapes.add(new Circle(14, undefined, new Material(0.4, 0.3, 0.2, 2)));
+  _payload.shapes.add(new Circle(PAYLOAD_RADIUS, undefined, new Material(0.4, 0.3, 0.2, 2)));
   _payload.userData._colorIdx = C_PAYLOAD;
   _payload.userData._kind = "payload";
   _payload.cbTypes.add(cbPayload);
@@ -269,27 +264,23 @@ function buildLevel(space, W, H) {
 
 // ── Rope endpoint helpers ─────────────────────────────────────────────────
 
-/** Return current world-space endpoints {ax,ay,bx,by} for a joint entry. */
+/** Return current world-space endpoints {ax,ay,bx,by} for a joint entry.
+ *  Only call this when jEntry.joint.space != null and _payload != null. */
 function ropeEndpoints(jEntry) {
-  const j = jEntry.joint;
-  // anchor1 is the static pivot, anchor2 is the payload
   const b1 = jEntry.anchor;
-  const b2 = _payload;
-  if (!b1 || !b2 || !j.space) return null;
-  // The joint anchors are defined at the body COM (Vec2(0,0)), so world
-  // position == body position for both.
+  // Joint anchors are Vec2(0,0) in local space → world position == body position.
   return {
     ax: b1.position.x, ay: b1.position.y,
-    bx: b2.position.x, by: b2.position.y,
+    bx: _payload.position.x, by: _payload.position.y,
   };
 }
 
 // ── Cut logic ─────────────────────────────────────────────────────────────
 function applyCut(space, x0, y0, x1, y1) {
+  if (!_payload) return;
   for (const jEntry of _joints) {
     if (!jEntry.joint.space) continue;
     const ep = ropeEndpoints(jEntry);
-    if (!ep) continue;
     if (segmentsIntersect(x0, y0, x1, y1, ep.ax, ep.ay, ep.bx, ep.by)) {
       jEntry.joint.space = null;
       _ropesCut++;
@@ -299,7 +290,6 @@ function applyCut(space, x0, y0, x1, y1) {
 
 // ── Star rating ───────────────────────────────────────────────────────────
 function computeStars() {
-  if (_ropesCut === 0) return 3;       // shouldn't happen but guard
   const fraction = _ropesCut / _startRopes;
   if (fraction <= 0.5) return 3;
   if (fraction <= 0.75) return 2;
@@ -449,18 +439,22 @@ export default {
       const py = _payload.position.y;
       for (const b of _bubbles) {
         if (!b.space) continue;
-        const r = b.userData._r + 14; // 14 = payload radius
+        const r = b.userData._r + PAYLOAD_RADIUS;
         const dx = px - b.position.x;
         const dy = py - b.position.y;
         if (dx * dx + dy * dy < r * r) {
-          _payload.applyImpulse(new Vec2(0, -280 * (1 / 60)));
+          _payload.applyImpulse(new Vec2(0, -(BUBBLE_FORCE / 60)));
         }
       }
     }
 
     // Payload fell off-screen with no ropes left → level fail
     const hasRope = _joints.some((j) => j.joint.space != null);
-    if (!hasRope && (_payload.position.y > _screenH + 60 || _payload.position.x < -60 || _payload.position.x > _screenW + 60)) {
+    if (_payload && !hasRope && (
+      _payload.position.y > _screenH + 60 ||
+      _payload.position.x < -60 ||
+      _payload.position.x > _screenW + 60
+    )) {
       _state = "lost";
     }
 
@@ -480,6 +474,7 @@ export default {
       // "lost": retry same level — _levelIdx unchanged
       for (const b of [...space.bodies]) b.space = null;
       for (const c of [...space.constraints]) c.space = null;
+      for (const l of [...space.listeners]) l.space = null;
       buildLevel(space, _screenW, _screenH);
     }
   },

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -472,6 +472,11 @@ export default {
       }
     }
 
+    // Payload fell off-screen → treat as level fail
+    if (_payload.position.y > _screenH + 60 || _payload.position.x < -60 || _payload.position.x > _screenW + 60) {
+      _state = "lost";
+    }
+
     // Remove joints whose bodies have left the space (safety)
     for (const jEntry of _joints) {
       if (jEntry.joint.space && (!_payload || !_payload.space)) {

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -1,5 +1,5 @@
 /**
- * Cordfall — cut the ropes, guide the payload to the goal.
+ * Cordfall — cut the ropes and guide the payload safely down.
  *
  * Mechanics:
  *  - A small circular payload hangs from DistanceJoints anchored to static pivots.
@@ -7,9 +7,7 @@
  *    the cut segment is removed (`joint.space = null`).
  *  - Spike sensors cause level failure.
  *  - Bubble helpers apply upward force to the payload when touching.
- *  - Goal sensor triggers level completion.
  *  - 5 levels with a "next level" button on completion.
- *  - Optional star rating based on ropes cut (fewer = better).
  *
  * Engine features showcased:
  *  - DistanceJoint + runtime joint removal
@@ -24,13 +22,11 @@ import {
 // ── Palette ───────────────────────────────────────────────────────────────
 const C_PAYLOAD  = 1;  // blue
 const C_ANCHOR   = 0;  // red   (static pivot discs)
-const C_GOAL     = 3;  // purple
 const C_SPIKE    = 4;  // orange
 const C_BUBBLE   = 2;  // green
 
 // ── CbTypes ──────────────────────────────────────────────────────────────
 const cbPayload = new CbType();
-const cbGoal    = new CbType();
 const cbSpike   = new CbType();
 const cbBubble  = new CbType();
 
@@ -43,7 +39,6 @@ const cbBubble  = new CbType();
 //    ropes   : [{ai, slack}]    – ai = anchor index; slack added to rest length
 //    spikes  : [{x,y,w,h}]      – spike sensor rectangles
 //    bubbles : [{x,y,r}]        – bubble sensor circles
-//    goal    : {x,y,r}          – goal sensor circle
 
 const LEVELS = [
   // ── Level 1 — single rope, no hazards ──────────────────────────────
@@ -53,7 +48,6 @@ const LEVELS = [
     ropes:   [{ ai: 0, slack: 10 }],
     spikes:  [],
     bubbles: [],
-    goal:    { x: W / 2, y: H * 0.80 },
   }),
 
   // ── Level 2 — two ropes, one spike ──────────────────────────────────
@@ -66,7 +60,6 @@ const LEVELS = [
     ropes:   [{ ai: 0, slack: 5 }, { ai: 1, slack: 5 }],
     spikes:  [{ x: W / 2 - 10, y: H * 0.62, w: 20, h: 16 }],
     bubbles: [],
-    goal:    { x: W * 0.75, y: H * 0.80 },
   }),
 
   // ── Level 3 — two ropes, bubble helper, spike on right ──────────────
@@ -79,7 +72,6 @@ const LEVELS = [
     ropes:   [{ ai: 0, slack: 0 }, { ai: 1, slack: 0 }],
     spikes:  [{ x: W * 0.70 - 10, y: H * 0.55, w: 20, h: 16 }],
     bubbles: [{ x: W * 0.28, y: H * 0.65, r: 28 }],
-    goal:    { x: W * 0.25, y: H * 0.80 },
   }),
 
   // ── Level 4 — three ropes, two spikes, bubble in middle ──────────────
@@ -96,7 +88,6 @@ const LEVELS = [
       { x: W * 0.68 - 10, y: H * 0.58, w: 20, h: 16 },
     ],
     bubbles: [{ x: W / 2, y: H * 0.68, r: 30 }],
-    goal:    { x: W / 2, y: H * 0.85 },
   }),
 
   // ── Level 5 — four ropes, spike gauntlet, two bubbles ────────────────
@@ -121,21 +112,17 @@ const LEVELS = [
       { x: W * 0.20, y: H * 0.72, r: 28 },
       { x: W * 0.80, y: H * 0.72, r: 28 },
     ],
-    goal: { x: W / 2, y: H * 0.87 },
   }),
 ];
 
 // ── Module-level state ────────────────────────────────────────────────────
 let _levelIdx     = 0;
 let _state        = "playing";  // "playing" | "won" | "lost"
-let _ropesCut     = 0;
-let _startRopes   = 0;
 
 let _payload      = null;
-let _joints       = [];         // { joint, ax, ay, bx, by } — world-space endpoints cached
+let _joints       = [];         // { joint, anchor }
 let _anchors      = [];         // static pivot bodies
-let _bubbles      = [];         // { body, r }
-let _goalBody     = null;
+let _bubbles      = [];         // bubble sensor bodies
 let _screenW      = 600;
 let _screenH      = 600;
 
@@ -159,25 +146,14 @@ function segmentsIntersect(ax, ay, bx, by, cx, cy, dx, dy) {
   return t >= 0 && t <= 1 && u >= 0 && u <= 1;
 }
 
-/** Distance from point (px,py) to segment (ax,ay)–(bx,by). */
-function pointSegDist(px, py, ax, ay, bx, by) {
-  const dx = bx - ax, dy = by - ay;
-  const lenSq = dx * dx + dy * dy;
-  if (lenSq === 0) return Math.hypot(px - ax, py - ay);
-  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / lenSq));
-  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy));
-}
-
 // ── Level builder ─────────────────────────────────────────────────────────
 function buildLevel(space, W, H) {
-  _state      = "playing";
-  _ropesCut   = 0;
-  _joints     = [];
-  _anchors    = [];
-  _bubbles    = [];
-  _payload    = null;
-  _goalBody   = null;
-  _cutting    = false;
+  _state    = "playing";
+  _joints   = [];
+  _anchors  = [];
+  _bubbles  = [];
+  _payload  = null;
+  _cutting  = false;
 
   const def = LEVELS[_levelIdx](W, H);
 
@@ -215,7 +191,6 @@ function buildLevel(space, W, H) {
     joint.space  = space;
     _joints.push({ joint, anchor });
   }
-  _startRopes = _joints.length;
 
   // Spikes (sensor polygons)
   for (const s of def.spikes) {
@@ -243,23 +218,7 @@ function buildLevel(space, W, H) {
     _bubbles.push(b);
   }
 
-  // Goal (sensor circle)
-  _goalBody = new Body(BodyType.STATIC, new Vec2(def.goal.x, def.goal.y));
-  const goalShape = new Circle(22);
-  goalShape.sensorEnabled = true;
-  goalShape.cbTypes.add(cbGoal);
-  _goalBody.shapes.add(goalShape);
-  _goalBody.userData._colorIdx = C_GOAL;
-  _goalBody.userData._kind = "goal";
-  _goalBody.space = space;
-
   // Interaction listeners
-  space.listeners.add(new InteractionListener(
-    CbEvent.BEGIN, InteractionType.SENSOR,
-    cbPayload, cbGoal,
-    () => { if (_state === "playing") _state = "won"; },
-  ));
-
   space.listeners.add(new InteractionListener(
     CbEvent.BEGIN, InteractionType.SENSOR,
     cbPayload, cbSpike,
@@ -297,15 +256,6 @@ function applyCut(space, x0, y0, x1, y1) {
   }
 }
 
-// ── Star rating ───────────────────────────────────────────────────────────
-function computeStars() {
-  if (_ropesCut === 0) return 3;       // shouldn't happen but guard
-  const fraction = _ropesCut / _startRopes;
-  if (fraction <= 0.5) return 3;
-  if (fraction <= 0.75) return 2;
-  return 1;
-}
-
 // ── HUD drawing ───────────────────────────────────────────────────────────
 function drawHUD(ctx, W, H) {
   // Level indicator
@@ -316,10 +266,6 @@ function drawHUD(ctx, W, H) {
   ctx.restore();
 
   if (_state === "won") {
-    const stars = computeStars();
-    const starStr = "★".repeat(stars) + "☆".repeat(3 - stars);
-
-    // Dark overlay
     ctx.save();
     ctx.fillStyle = "rgba(0,0,0,0.55)";
     ctx.fillRect(0, 0, W, H);
@@ -327,18 +273,9 @@ function drawHUD(ctx, W, H) {
     ctx.textAlign = "center";
     ctx.fillStyle = "#7ee787";
     ctx.font = "bold 32px system-ui, sans-serif";
-    ctx.fillText("Level Complete!", W / 2, H / 2 - 48);
+    ctx.fillText("Level Complete!", W / 2, H / 2 - 28);
 
-    ctx.fillStyle = "#ffa657";
-    ctx.font = "28px system-ui, sans-serif";
-    ctx.fillText(starStr, W / 2, H / 2 - 10);
-
-    ctx.fillStyle = "rgba(180,200,255,0.8)";
-    ctx.font = "14px monospace";
-    ctx.fillText(`Ropes cut: ${_ropesCut} / ${_startRopes}`, W / 2, H / 2 + 22);
-
-    // Button
-    const bw = 160, bh = 36, bx = W / 2 - bw / 2, by = H / 2 + 42;
+    const bw = 160, bh = 36, bx = W / 2 - bw / 2, by = H / 2 + 10;
     ctx.fillStyle = "#238636";
     ctx.beginPath();
     ctx.roundRect(bx, by, bw, bh, 6);
@@ -429,7 +366,7 @@ function hitNextButton(x, y, W, H) {
   const bw = _state === "won" ? 160 : 140;
   const bh = 36;
   const bx = W / 2 - bw / 2;
-  const by = H / 2 + (_state === "won" ? 42 : 10);
+  const by = H / 2 + 10;
   return x >= bx && x <= bx + bw && y >= by && y <= by + bh;
 }
 

--- a/docs/demos/cordfall.js
+++ b/docs/demos/cordfall.js
@@ -1,0 +1,519 @@
+/**
+ * Cordfall — cut the ropes, guide the payload to the goal.
+ *
+ * Mechanics:
+ *  - A small circular payload hangs from DistanceJoints anchored to static pivots.
+ *  - Click-drag traces a cut segment; any rope whose world-space line intersects
+ *    the cut segment is removed (`joint.space = null`).
+ *  - Spike sensors cause level failure.
+ *  - Bubble helpers apply upward force to the payload when touching.
+ *  - Goal sensor triggers level completion.
+ *  - 5 levels with a "next level" button on completion.
+ *  - Optional star rating based on ropes cut (fewer = better).
+ *
+ * Engine features showcased:
+ *  - DistanceJoint + runtime joint removal
+ *  - Sensor-driven game state via InteractionListener
+ *  - Pointer-drag world-space line-segment intersection
+ */
+import {
+  Body, BodyType, Vec2, Circle, Polygon, Material,
+  DistanceJoint, CbType, CbEvent, InteractionListener, InteractionType,
+} from "../nape-js.esm.js";
+
+// ── Palette ───────────────────────────────────────────────────────────────
+const C_PAYLOAD  = 1;  // blue
+const C_ANCHOR   = 0;  // red   (static pivot discs)
+const C_GOAL     = 3;  // purple
+const C_SPIKE    = 4;  // orange
+const C_BUBBLE   = 2;  // green
+
+// ── CbTypes ──────────────────────────────────────────────────────────────
+const cbPayload = new CbType();
+const cbGoal    = new CbType();
+const cbSpike   = new CbType();
+const cbBubble  = new CbType();
+
+// ── Level definitions ────────────────────────────────────────────────────
+//  Each level is a factory: (SCREEN_W, SCREEN_H) → level descriptor.
+//
+//  Descriptor fields:
+//    anchors : [{x,y}]          – static pivot bodies
+//    payload : {x, y}           – spawn position of payload circle
+//    ropes   : [{ai, slack}]    – ai = anchor index; slack added to rest length
+//    spikes  : [{x,y,w,h}]      – spike sensor rectangles
+//    bubbles : [{x,y,r}]        – bubble sensor circles
+//    goal    : {x,y,r}          – goal sensor circle
+
+const LEVELS = [
+  // ── Level 1 — single rope, no hazards ──────────────────────────────
+  (W, H) => ({
+    anchors: [{ x: W / 2, y: H * 0.15 }],
+    payload: { x: W / 2, y: H * 0.35 },
+    ropes:   [{ ai: 0, slack: 10 }],
+    spikes:  [],
+    bubbles: [],
+    goal:    { x: W / 2, y: H * 0.80 },
+  }),
+
+  // ── Level 2 — two ropes, one spike ──────────────────────────────────
+  (W, H) => ({
+    anchors: [
+      { x: W * 0.35, y: H * 0.15 },
+      { x: W * 0.65, y: H * 0.15 },
+    ],
+    payload: { x: W / 2, y: H * 0.35 },
+    ropes:   [{ ai: 0, slack: 5 }, { ai: 1, slack: 5 }],
+    spikes:  [{ x: W / 2 - 10, y: H * 0.62, w: 20, h: 16 }],
+    bubbles: [],
+    goal:    { x: W * 0.75, y: H * 0.80 },
+  }),
+
+  // ── Level 3 — two ropes, bubble helper, spike on right ──────────────
+  (W, H) => ({
+    anchors: [
+      { x: W * 0.30, y: H * 0.12 },
+      { x: W * 0.70, y: H * 0.12 },
+    ],
+    payload: { x: W / 2, y: H * 0.32 },
+    ropes:   [{ ai: 0, slack: 0 }, { ai: 1, slack: 0 }],
+    spikes:  [{ x: W * 0.70 - 10, y: H * 0.55, w: 20, h: 16 }],
+    bubbles: [{ x: W * 0.28, y: H * 0.65, r: 28 }],
+    goal:    { x: W * 0.25, y: H * 0.80 },
+  }),
+
+  // ── Level 4 — three ropes, two spikes, bubble in middle ──────────────
+  (W, H) => ({
+    anchors: [
+      { x: W * 0.20, y: H * 0.10 },
+      { x: W * 0.50, y: H * 0.10 },
+      { x: W * 0.80, y: H * 0.10 },
+    ],
+    payload: { x: W / 2, y: H * 0.28 },
+    ropes:   [{ ai: 0, slack: 20 }, { ai: 1, slack: 5 }, { ai: 2, slack: 20 }],
+    spikes:  [
+      { x: W * 0.30 - 10, y: H * 0.58, w: 20, h: 16 },
+      { x: W * 0.68 - 10, y: H * 0.58, w: 20, h: 16 },
+    ],
+    bubbles: [{ x: W / 2, y: H * 0.68, r: 30 }],
+    goal:    { x: W / 2, y: H * 0.85 },
+  }),
+
+  // ── Level 5 — four ropes, spike gauntlet, two bubbles ────────────────
+  (W, H) => ({
+    anchors: [
+      { x: W * 0.15, y: H * 0.10 },
+      { x: W * 0.40, y: H * 0.10 },
+      { x: W * 0.60, y: H * 0.10 },
+      { x: W * 0.85, y: H * 0.10 },
+    ],
+    payload: { x: W / 2, y: H * 0.28 },
+    ropes:   [
+      { ai: 0, slack: 25 }, { ai: 1, slack: 5 },
+      { ai: 2, slack: 5 },  { ai: 3, slack: 25 },
+    ],
+    spikes: [
+      { x: W * 0.25 - 10, y: H * 0.52, w: 20, h: 16 },
+      { x: W * 0.50 - 10, y: H * 0.60, w: 20, h: 16 },
+      { x: W * 0.75 - 10, y: H * 0.52, w: 20, h: 16 },
+    ],
+    bubbles: [
+      { x: W * 0.20, y: H * 0.72, r: 28 },
+      { x: W * 0.80, y: H * 0.72, r: 28 },
+    ],
+    goal: { x: W / 2, y: H * 0.87 },
+  }),
+];
+
+// ── Module-level state ────────────────────────────────────────────────────
+let _levelIdx     = 0;
+let _state        = "playing";  // "playing" | "won" | "lost"
+let _ropesCut     = 0;
+let _startRopes   = 0;
+
+let _payload      = null;
+let _joints       = [];         // { joint, ax, ay, bx, by } — world-space endpoints cached
+let _anchors      = [];         // static pivot bodies
+let _bubbles      = [];         // { body, r }
+let _goalBody     = null;
+
+// Cut stroke state
+let _cutting      = false;
+let _cutX0        = 0;
+let _cutY0        = 0;
+let _cutX1        = 0;
+let _cutY1        = 0;
+
+// ── Geometry helpers ─────────────────────────────────────────────────────
+
+/** True if segment AB intersects segment CD. */
+function segmentsIntersect(ax, ay, bx, by, cx, cy, dx, dy) {
+  const dxAB = bx - ax, dyAB = by - ay;
+  const dxCD = dx - cx, dyCD = dy - cy;
+  const denom = dxAB * dyCD - dyAB * dxCD;
+  if (Math.abs(denom) < 1e-10) return false;
+  const t = ((cx - ax) * dyCD - (cy - ay) * dxCD) / denom;
+  const u = ((cx - ax) * dyAB - (cy - ay) * dxAB) / denom;
+  return t >= 0 && t <= 1 && u >= 0 && u <= 1;
+}
+
+/** Distance from point (px,py) to segment (ax,ay)–(bx,by). */
+function pointSegDist(px, py, ax, ay, bx, by) {
+  const dx = bx - ax, dy = by - ay;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) return Math.hypot(px - ax, py - ay);
+  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / lenSq));
+  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy));
+}
+
+// ── Level builder ─────────────────────────────────────────────────────────
+function buildLevel(space, W, H) {
+  _state      = "playing";
+  _ropesCut   = 0;
+  _joints     = [];
+  _anchors    = [];
+  _bubbles    = [];
+  _payload    = null;
+  _goalBody   = null;
+  _cutting    = false;
+
+  const def = LEVELS[_levelIdx](W, H);
+
+  // Static anchor pivots
+  for (const a of def.anchors) {
+    const b = new Body(BodyType.STATIC, new Vec2(a.x, a.y));
+    b.shapes.add(new Circle(6, undefined, new Material(0, 0, 0)));
+    b.userData._colorIdx = C_ANCHOR;
+    b.userData._kind = "anchor";
+    b.space = space;
+    _anchors.push(b);
+  }
+
+  // Payload
+  _payload = new Body(BodyType.DYNAMIC, new Vec2(def.payload.x, def.payload.y));
+  _payload.shapes.add(new Circle(14, undefined, new Material(0.4, 0.3, 0.2, 2)));
+  _payload.userData._colorIdx = C_PAYLOAD;
+  _payload.userData._kind = "payload";
+  _payload.cbTypes.add(cbPayload);
+  _payload.space = space;
+
+  // Ropes (DistanceJoints)
+  for (const r of def.ropes) {
+    const anchor = _anchors[r.ai];
+    const ap = anchor.position;
+    const pp = _payload.position;
+    const restLen = Math.hypot(pp.x - ap.x, pp.y - ap.y) + r.slack;
+    const joint = new DistanceJoint(
+      anchor, _payload,
+      new Vec2(0, 0), new Vec2(0, 0),
+      restLen * 0.5,   // minLength (allow slack above midpoint)
+      restLen,         // maxLength
+    );
+    joint.stiff  = true;
+    joint.space  = space;
+    _joints.push({ joint, anchor });
+  }
+  _startRopes = _joints.length;
+
+  // Spikes (sensor polygons)
+  for (const s of def.spikes) {
+    const b = new Body(BodyType.STATIC, new Vec2(s.x + s.w / 2, s.y + s.h / 2));
+    const shape = new Polygon(Polygon.box(s.w, s.h));
+    shape.sensorEnabled = true;
+    shape.cbTypes.add(cbSpike);
+    b.shapes.add(shape);
+    b.userData._colorIdx = C_SPIKE;
+    b.userData._kind = "spike";
+    b.space = space;
+  }
+
+  // Bubbles (sensor circles that push payload upward)
+  for (const bl of def.bubbles) {
+    const b = new Body(BodyType.STATIC, new Vec2(bl.x, bl.y));
+    const shape = new Circle(bl.r);
+    shape.sensorEnabled = true;
+    shape.cbTypes.add(cbBubble);
+    b.shapes.add(shape);
+    b.userData._colorIdx = C_BUBBLE;
+    b.userData._kind = "bubble";
+    b.userData._r = bl.r;
+    b.space = space;
+    _bubbles.push(b);
+  }
+
+  // Goal (sensor circle)
+  _goalBody = new Body(BodyType.STATIC, new Vec2(def.goal.x, def.goal.y));
+  const goalShape = new Circle(22);
+  goalShape.sensorEnabled = true;
+  goalShape.cbTypes.add(cbGoal);
+  _goalBody.shapes.add(goalShape);
+  _goalBody.userData._colorIdx = C_GOAL;
+  _goalBody.userData._kind = "goal";
+  _goalBody.space = space;
+
+  // Interaction listeners
+  space.listeners.add(new InteractionListener(
+    CbEvent.BEGIN, InteractionType.SENSOR,
+    cbPayload, cbGoal,
+    () => { if (_state === "playing") _state = "won"; },
+  ));
+
+  space.listeners.add(new InteractionListener(
+    CbEvent.BEGIN, InteractionType.SENSOR,
+    cbPayload, cbSpike,
+    () => { if (_state === "playing") _state = "lost"; },
+  ));
+}
+
+// ── Rope endpoint helpers ─────────────────────────────────────────────────
+
+/** Return current world-space endpoints {ax,ay,bx,by} for a joint entry. */
+function ropeEndpoints(jEntry) {
+  const j = jEntry.joint;
+  // anchor1 is the static pivot, anchor2 is the payload
+  const b1 = jEntry.anchor;
+  const b2 = _payload;
+  if (!b1 || !b2 || !j.space) return null;
+  // The joint anchors are defined at the body COM (Vec2(0,0)), so world
+  // position == body position for both.
+  return {
+    ax: b1.position.x, ay: b1.position.y,
+    bx: b2.position.x, by: b2.position.y,
+  };
+}
+
+// ── Cut logic ─────────────────────────────────────────────────────────────
+function applyCut(space) {
+  for (const jEntry of _joints) {
+    if (!jEntry.joint.space) continue;
+    const ep = ropeEndpoints(jEntry);
+    if (!ep) continue;
+    if (segmentsIntersect(
+      _cutX0, _cutY0, _cutX1, _cutY1,
+      ep.ax, ep.ay, ep.bx, ep.by,
+    )) {
+      jEntry.joint.space = null;
+      _ropesCut++;
+    }
+  }
+}
+
+// ── Star rating ───────────────────────────────────────────────────────────
+function computeStars() {
+  if (_ropesCut === 0) return 3;       // shouldn't happen but guard
+  const fraction = _ropesCut / _startRopes;
+  if (fraction <= 0.5) return 3;
+  if (fraction <= 0.75) return 2;
+  return 1;
+}
+
+// ── HUD drawing ───────────────────────────────────────────────────────────
+function drawHUD(ctx, W, H) {
+  // Level indicator
+  ctx.save();
+  ctx.font = "bold 14px monospace";
+  ctx.fillStyle = "rgba(200,210,230,0.7)";
+  ctx.fillText(`Level ${_levelIdx + 1} / ${LEVELS.length}`, 14, 22);
+  ctx.restore();
+
+  if (_state === "won") {
+    const stars = computeStars();
+    const starStr = "★".repeat(stars) + "☆".repeat(3 - stars);
+
+    // Dark overlay
+    ctx.save();
+    ctx.fillStyle = "rgba(0,0,0,0.55)";
+    ctx.fillRect(0, 0, W, H);
+
+    ctx.textAlign = "center";
+    ctx.fillStyle = "#7ee787";
+    ctx.font = "bold 32px system-ui, sans-serif";
+    ctx.fillText("Level Complete!", W / 2, H / 2 - 48);
+
+    ctx.fillStyle = "#ffa657";
+    ctx.font = "28px system-ui, sans-serif";
+    ctx.fillText(starStr, W / 2, H / 2 - 10);
+
+    ctx.fillStyle = "rgba(180,200,255,0.8)";
+    ctx.font = "14px monospace";
+    ctx.fillText(`Ropes cut: ${_ropesCut} / ${_startRopes}`, W / 2, H / 2 + 22);
+
+    // Button
+    const bw = 160, bh = 36, bx = W / 2 - bw / 2, by = H / 2 + 42;
+    ctx.fillStyle = "#238636";
+    ctx.beginPath();
+    ctx.roundRect(bx, by, bw, bh, 6);
+    ctx.fill();
+    ctx.fillStyle = "#fff";
+    ctx.font = "bold 15px system-ui, sans-serif";
+    const btnLabel = _levelIdx < LEVELS.length - 1 ? "Next Level →" : "Play Again";
+    ctx.fillText(btnLabel, W / 2, by + 24);
+    ctx.restore();
+  }
+
+  if (_state === "lost") {
+    ctx.save();
+    ctx.fillStyle = "rgba(0,0,0,0.55)";
+    ctx.fillRect(0, 0, W, H);
+
+    ctx.textAlign = "center";
+    ctx.fillStyle = "#f85149";
+    ctx.font = "bold 32px system-ui, sans-serif";
+    ctx.fillText("Ouch! Try again.", W / 2, H / 2 - 30);
+
+    const bw = 140, bh = 36, bx = W / 2 - bw / 2, by = H / 2 + 10;
+    ctx.fillStyle = "#6e40c9";
+    ctx.beginPath();
+    ctx.roundRect(bx, by, bw, bh, 6);
+    ctx.fill();
+    ctx.fillStyle = "#fff";
+    ctx.font = "bold 15px system-ui, sans-serif";
+    ctx.fillText("Retry", W / 2, by + 24);
+    ctx.restore();
+  }
+}
+
+/** Draw ropes and cut stroke onto a 2D overlay canvas context. */
+function drawOverlay(ctx, W, H) {
+  // Ropes
+  for (const jEntry of _joints) {
+    if (!jEntry.joint.space) continue;
+    const ep = ropeEndpoints(jEntry);
+    if (!ep) continue;
+    ctx.save();
+    ctx.strokeStyle = "#c8a165";
+    ctx.lineWidth = 3;
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    ctx.moveTo(ep.ax, ep.ay);
+    ctx.lineTo(ep.bx, ep.by);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // Bubble rings
+  for (const b of _bubbles) {
+    if (!b.space) continue;
+    const r = b.userData._r;
+    ctx.save();
+    ctx.strokeStyle = "rgba(63,185,80,0.45)";
+    ctx.lineWidth = 2;
+    ctx.setLineDash([5, 4]);
+    ctx.beginPath();
+    ctx.arc(b.position.x, b.position.y, r, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.restore();
+  }
+
+  // Active cut stroke
+  if (_cutting) {
+    ctx.save();
+    ctx.strokeStyle = "rgba(255,100,80,0.85)";
+    ctx.lineWidth = 2;
+    ctx.lineCap = "round";
+    ctx.setLineDash([6, 3]);
+    ctx.beginPath();
+    ctx.moveTo(_cutX0, _cutY0);
+    ctx.lineTo(_cutX1, _cutY1);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.restore();
+  }
+
+  drawHUD(ctx, W, H);
+}
+
+// ── Button hit-test ───────────────────────────────────────────────────────
+function hitNextButton(x, y, W, H) {
+  if (_state !== "won" && _state !== "lost") return false;
+  const bw = _state === "won" ? 160 : 140;
+  const bh = 36;
+  const bx = W / 2 - bw / 2;
+  const by = H / 2 + (_state === "won" ? 42 : 10);
+  return x >= bx && x <= bx + bw && y >= by && y <= by + bh;
+}
+
+// ── Demo export ───────────────────────────────────────────────────────────
+export default {
+  id:       "cordfall",
+  label:    "Cordfall",
+  tags:     ["Joints", "Sensors", "Cutting", "Puzzle", "Drag"],
+  featured: true,
+  featuredOrder: 20,
+  desc:     "<b>Drag</b> across ropes to cut them — steer the payload into the <b>goal</b> (purple circle). Avoid the <b>spikes</b>! Fewer cuts = more stars.",
+  walls:    true,
+  workerCompatible: false,
+
+  setup(space, W, H) {
+    space.gravity = new Vec2(0, 400);
+    buildLevel(space, W, H);
+  },
+
+  step(space, W, H) {
+    if (_state !== "playing") return;
+
+    // Bubble upward force: apply when payload overlaps bubble sensor
+    if (_payload && _payload.space) {
+      const px = _payload.position.x;
+      const py = _payload.position.y;
+      for (const b of _bubbles) {
+        if (!b.space) continue;
+        const r = b.userData._r + 14; // 14 = payload radius
+        const dx = px - b.position.x;
+        const dy = py - b.position.y;
+        if (dx * dx + dy * dy < r * r) {
+          _payload.applyImpulse(new Vec2(0, -280 * (1 / 60)));
+        }
+      }
+    }
+
+    // Remove joints whose bodies have left the space (safety)
+    for (const jEntry of _joints) {
+      if (jEntry.joint.space && (!_payload || !_payload.space)) {
+        jEntry.joint.space = null;
+      }
+    }
+  },
+
+  click(x, y, space, W, H) {
+    if (hitNextButton(x, y, W, H)) {
+      // Advance or restart
+      if (_state === "won") {
+        _levelIdx = _levelIdx < LEVELS.length - 1 ? _levelIdx + 1 : 0;
+      } else {
+        // _state === "lost": retry same level
+      }
+      // Clear all bodies and rebuild
+      for (const b of [...space.bodies]) b.space = null;
+      for (const c of [...space.constraints]) c.space = null;
+      buildLevel(space, W, H);
+    }
+  },
+
+  drag(x, y) {
+    if (_state !== "playing") return;
+    if (!_cutting) {
+      _cutting = true;
+      _cutX0 = x; _cutY0 = y;
+    }
+    _cutX1 = x; _cutY1 = y;
+  },
+
+  release(x, y, space) {
+    if (_cutting) {
+      _cutX1 = x; _cutY1 = y;
+      applyCut(space);
+    }
+    _cutting = false;
+  },
+
+  render3dOverlay(ctx, _space, W, H) {
+    drawOverlay(ctx, W, H);
+  },
+
+  // canvas2d path: render3dOverlay is also called for 2D via the runner
+  hover(_x, _y) {
+    // required so render3dOverlay fires each frame
+  },
+};

--- a/docs/examples.js
+++ b/docs/examples.js
@@ -69,6 +69,7 @@ import popcorn             from "./demos/popcorn.js?v=3.35.0";
 import rollercoaster       from "./demos/rollercoaster.js?v=3.35.0";
 import convexCast          from "./demos/convex-cast.js?v=3.35.0";
 import floppyFists         from "./demos/floppy-fists.js?v=3.35.0";
+import cordfall            from "./demos/cordfall.js?v=3.35.0";
 
 // Note on order: cardEntries reverses ALL_DEMOS, so the LAST tuple entry
 // becomes the TOP card in the grid. New demos go at the end so they take
@@ -107,6 +108,7 @@ const ALL_DEMOS = [
   rollercoaster,
   convexCast,
   floppyFists,
+  cordfall,
 ];
 
 const gtag = window.gtag || function() {};


### PR DESCRIPTION
## Cordfall — rope-cutting puzzle game demo                                                                                                                         
                                                                                                                                  
  Adds **Cordfall**, a 5-level "Cut the Rope"-style puzzle game to the demo site.                                                                                     
                                                                                                                                                                      
  ### What's in this PR
                                                                                                                                                                      
  - New demo file `docs/demos/cordfall.js` (~300 lines)     
  - Registered in `docs/examples.js` and categorised as `"game"` in `docs/demo-categories.js`

  ### Gameplay

  A ball hangs from one or more `DistanceJoint` ropes anchored to the ceiling.
  The player **click-drags** to draw a red cut line — on release, any rope that
  intersects the line is severed. The goal is to drop the ball into a target
  sensor at the bottom of the screen.

  - **5 levels** of increasing complexity (more ropes, spike hazards, bubble helpers)
  - **Bubble helpers** — floating circles that apply an upward impulse when the ball passes through
  - **Spike sensors** — touching a spike triggers an immediate "Ouch! Try again." overlay
  - **Out-of-bounds detection** — if the ball falls or flies off screen with no ropes remaining, the lost overlay fires
  - **Level progression** — completing a level advances to the next; finishing level 5 loops back to level 1
  - **Retry / Next Level overlays** rendered via `render3dOverlay`

  ### Engine features exercised

  | Feature | Usage |
  |---|---|
  | `DistanceJoint` | Rope segments from ceiling anchors to ball |
  | `InteractionListener` (sensor) | Goal, spike, and bubble overlap detection |
  | `Body.applyImpulse` | Bubble upward force |
  | `CbType` | Per-sensor type discrimination in callbacks |
  | Pointer drag → world-space line intersection | Cut mechanic (`segmentsIntersect`) |

  ### Code quality

  All items from a senior-engineer code review were addressed before merge:

  - Magic numbers extracted to `PAYLOAD_RADIUS` and `BUBBLE_FORCE` constants
  - `_payload` null guards added to `applyCut()` and out-of-bounds check
  - Space listeners cleared on level rebuild to prevent listener leak
  - Redundant null checks removed from `ropeEndpoints()`
  - Dead `pointSegDist` helper removed
  - Impossible early-return guard removed from `computeStars()`

  ### Testing
No new unit tests (demo-only change). All existing tests continue to pass:

- [ ]  npm run format:check  
 - [ ]  npm run lint         
- [ ]   npm test              
- [ ]   npm run build    