### PR TITLE
test(native/phys): expand ZPP_Body, ZPP_Compound, ZPP_Interactor coverage (#166)

### DIFF
--- a/packages/nape-js/tests/native/phys/ZPP_Body.test.ts
+++ b/packages/nape-js/tests/native/phys/ZPP_Body.test.ts
@@ -13,92 +13,578 @@ function makeShape(area: number, inertia: number, density: number) {
   };
 }
 
+function setupBodyStatics() {
+  const zpp = createMockZpp();
+  zpp.util.ZNPList_ZPP_Arbiter = MockZNPList;
+  zpp.util.ZNPList_ZPP_CallbackSet = MockZNPList;
+  zpp.util.ZPP_ShapeList = {
+    get: (list: any) => ({ zpp_inner: { inner: list } }),
+  };
+  ZPP_Body._zpp = zpp;
+  ZPP_Body._nape = createMockNape();
+  ZPP_Interactor._zpp = zpp;
+  ZPP_Interactor._nape = createMockNape();
+  return zpp;
+}
+
 describe("ZPP_Body", () => {
   beforeEach(() => {
-    const zpp = createMockZpp();
-    zpp.util.ZNPList_ZPP_Arbiter = MockZNPList;
-    zpp.util.ZNPList_ZPP_CallbackSet = MockZNPList;
-    zpp.util.ZPP_ShapeList = {
-      get: (list: any) => ({ zpp_inner: { inner: list } }),
-    };
-    ZPP_Body._zpp = zpp;
-    ZPP_Body._nape = createMockNape();
-    ZPP_Interactor._zpp = zpp;
-    ZPP_Interactor._nape = createMockNape();
+    setupBodyStatics();
   });
 
-  it("recalculates mass and gravity mass from shape densities", () => {
-    const body = new ZPP_Body();
-    body.type = 2;
-    body.zip_mass = true;
-    body.zip_gravMass = true;
-    body.shapes.add(makeShape(3, 10, 2));
-    body.shapes.add(makeShape(4, 20, 0.5));
+  describe("mass / inertia recalculation", () => {
+    it("recalculates mass and gravity mass from shape densities", () => {
+      const body = new ZPP_Body();
+      body.type = 2;
+      body.zip_mass = true;
+      body.zip_gravMass = true;
+      body.shapes.add(makeShape(3, 10, 2));
+      body.shapes.add(makeShape(4, 20, 0.5));
 
-    body.validate_mass();
-    body.validate_gravMass();
+      body.validate_mass();
+      body.validate_gravMass();
 
-    expect(body.cmass).toBe(8);
-    expect(body.mass).toBe(8);
-    expect(body.imass).toBe(1 / 8);
-    expect(body.smass).toBe(1 / 8);
-    expect(body.gravMass).toBe(8);
-    expect(body.zip_mass).toBe(false);
-    expect(body.zip_gravMass).toBe(false);
+      expect(body.cmass).toBe(8);
+      expect(body.mass).toBe(8);
+      expect(body.imass).toBe(1 / 8);
+      expect(body.smass).toBe(1 / 8);
+      expect(body.gravMass).toBe(8);
+      expect(body.zip_mass).toBe(false);
+      expect(body.zip_gravMass).toBe(false);
+    });
+
+    it("uses configured gravity mass scaling while preserving computed mass", () => {
+      const body = new ZPP_Body();
+      body.type = 2;
+      body.zip_mass = true;
+      body.gravMassMode = 2;
+      body.zip_gravMass = true;
+      body.gravMassScale = 1.5;
+      body.shapes.add(makeShape(2, 5, 4));
+
+      body.validate_gravMass();
+
+      expect(body.mass).toBe(8);
+      expect(body.gravMass).toBe(12);
+    });
+
+    it("sets infinite mass and inertia for non-dynamic bodies", () => {
+      const body = new ZPP_Body();
+      body.type = 1;
+      body.zip_mass = true;
+      body.zip_inertia = true;
+      body.shapes.add(makeShape(3, 4, 2));
+
+      body.validate_mass();
+      body.validate_inertia();
+
+      expect(body.cmass).toBe(6);
+      expect(body.mass).toBe(Infinity);
+      expect(body.imass).toBe(0);
+      expect(body.cinertia).toBe(24);
+      expect(body.inertia).toBe(Infinity);
+      expect(body.iinertia).toBe(0);
+    });
+
+    it("keeps inertia finite while honoring nomove on dynamic bodies", () => {
+      const body = new ZPP_Body();
+      body.type = 2;
+      body.nomove = true;
+      body.zip_mass = true;
+      body.zip_inertia = true;
+      body.shapes.add(makeShape(2, 3, 1));
+
+      body.validate_mass();
+      body.validate_inertia();
+
+      // nomove fixes linear motion but rotation remains
+      expect(body.mass).toBe(Infinity);
+      expect(body.imass).toBe(0);
+      expect(body.inertia).toBe(6);
+      expect(body.iinertia).toBeCloseTo(1 / 6);
+    });
+
+    it("keeps mass finite while norotate freezes rotation only", () => {
+      const body = new ZPP_Body();
+      body.type = 2;
+      body.norotate = true;
+      body.zip_mass = true;
+      body.zip_inertia = true;
+      body.shapes.add(makeShape(5, 2, 2));
+
+      body.validate_mass();
+      body.validate_inertia();
+
+      expect(body.mass).toBe(10);
+      expect(body.imass).toBe(0.1);
+      expect(body.inertia).toBe(Infinity);
+      expect(body.iinertia).toBe(0);
+    });
+
+    it("invalidate_mass marks both mass and gravMass dirty and wakes", () => {
+      const body = new ZPP_Body();
+      body.zip_mass = false;
+      body.zip_gravMass = false;
+      body.zip_gravMassScale = false;
+      // Stub the inherited wake to avoid touching cbSet/space
+      const wake = vi.fn();
+      (body as any).wake = wake;
+
+      body.invalidate_mass();
+
+      expect(body.zip_mass).toBe(true);
+      expect(body.zip_gravMass).toBe(true);
+      expect(body.zip_gravMassScale).toBe(true);
+      expect(wake).toHaveBeenCalled();
+    });
+
+    it("invalidate_type cascades to mass and inertia", () => {
+      const body = new ZPP_Body();
+      body.zip_mass = false;
+      body.zip_inertia = false;
+      (body as any).wake = vi.fn();
+
+      body.invalidate_type();
+
+      expect(body.zip_mass).toBe(true);
+      expect(body.zip_inertia).toBe(true);
+    });
+
+    it("invalidate_shapes also re-flags AABB and centre of mass", () => {
+      const body = new ZPP_Body();
+      body.zip_aabb = false;
+      body.zip_localCOM = false;
+      body.zip_worldCOM = false;
+      body.zip_mass = false;
+      body.zip_inertia = false;
+      (body as any).wake = vi.fn();
+
+      body.invalidate_shapes();
+
+      expect(body.zip_aabb).toBe(true);
+      expect(body.zip_localCOM).toBe(true);
+      expect(body.zip_worldCOM).toBe(true);
+      expect(body.zip_mass).toBe(true);
+      expect(body.zip_inertia).toBe(true);
+    });
+
+    it("gravMassMode INTERNAL (1) skips zip_gravMass on invalidate_gravMass", () => {
+      const body = new ZPP_Body();
+      body.gravMassMode = 1;
+      body.zip_gravMass = false;
+      body.zip_gravMassScale = false;
+      (body as any).wake = vi.fn();
+
+      body.invalidate_gravMass();
+
+      // mode 1 = gravMass is the source of truth, don't recompute it
+      expect(body.zip_gravMass).toBe(false);
+      // mode != 2 so scale should be flagged dirty
+      expect(body.zip_gravMassScale).toBe(true);
+    });
+
+    it("invalidate_gravMassScale only marks scale dirty when mode != 2", () => {
+      const body = new ZPP_Body();
+      body.gravMassMode = 0;
+      body.zip_gravMassScale = false;
+      (body as any).wake = vi.fn();
+
+      body.invalidate_gravMassScale();
+
+      expect(body.zip_gravMassScale).toBe(true);
+    });
+
+    it("invalidate_gravMassScale defers to invalidate_gravMass when mode == 2", () => {
+      const body = new ZPP_Body();
+      body.gravMassMode = 2;
+      body.zip_gravMass = false;
+      body.zip_gravMassScale = false;
+      (body as any).wake = vi.fn();
+
+      body.invalidate_gravMassScale();
+
+      expect(body.zip_gravMass).toBe(true);
+    });
+
+    it("validate_gravMassScale fills in scale from gravMass/cmass for mode 1", () => {
+      const body = new ZPP_Body();
+      body.type = 2;
+      body.gravMassMode = 1;
+      body.cmass = 0; // forces validate_mass to recompute via shapes
+      body.zip_mass = true;
+      body.zip_gravMassScale = true;
+      body.gravMass = 12;
+      body.shapes.add(makeShape(2, 5, 3));
+
+      body.validate_gravMassScale();
+
+      // cmass = 2 * 3 = 6, gravMass = 12, scale = 12/6 = 2
+      expect(body.cmass).toBe(6);
+      expect(body.gravMassScale).toBe(2);
+      expect(body.zip_gravMassScale).toBe(false);
+    });
+
+    it("validate_gravMassScale resets to 1.0 in default mode", () => {
+      const body = new ZPP_Body();
+      body.gravMassMode = 0;
+      body.zip_gravMassScale = true;
+      body.gravMassScale = 99;
+
+      body.validate_gravMassScale();
+
+      expect(body.gravMassScale).toBe(1.0);
+    });
   });
 
-  it("uses configured gravity mass scaling while preserving computed mass", () => {
-    const body = new ZPP_Body();
-    body.type = 2;
-    body.zip_mass = true;
-    body.gravMassMode = 2;
-    body.zip_gravMass = true;
-    body.gravMassScale = 1.5;
-    body.shapes.add(makeShape(2, 5, 4));
+  describe("sweep integration (CCD)", () => {
+    it("tracks sweep time and integrates position and rotation", () => {
+      const body = new ZPP_Body();
+      body.posx = 1;
+      body.posy = -2;
+      body.rot = 0;
+      body.axisx = 0;
+      body.axisy = 1;
+      body.velx = 4;
+      body.vely = 3;
+      body.angvel = 1;
+      body.sweep_angvel = 0.5;
 
-    body.validate_gravMass();
+      body.sweepIntegrate(2);
 
-    expect(body.mass).toBe(8);
-    expect(body.gravMass).toBe(12);
+      expect(body.sweepTime).toBe(2);
+      expect(body.posx).toBe(9);
+      expect(body.posy).toBe(4);
+      expect(body.rot).toBe(1);
+      expect(body.axisx).toBeCloseTo(Math.sin(1));
+      expect(body.axisy).toBeCloseTo(Math.cos(1));
+    });
+
+    it("no-ops when sweepTime already matches dt (delta is zero)", () => {
+      const body = new ZPP_Body();
+      body.posx = 5;
+      body.posy = -5;
+      body.velx = 10;
+      body.vely = 10;
+      body.sweepTime = 3;
+
+      body.sweepIntegrate(3);
+
+      expect(body.posx).toBe(5);
+      expect(body.posy).toBe(5 - 10); // unchanged
+      // posx stays at 5; the assertion above using `-5+10` is hand-derived
+      expect(body.posy).toBe(-5);
+      expect(body.sweepTime).toBe(3);
+    });
+
+    it("rolls subsequent sweepIntegrate forward using the delta from previous sweepTime", () => {
+      const body = new ZPP_Body();
+      body.posx = 0;
+      body.posy = 0;
+      body.velx = 2;
+      body.vely = 0;
+      body.angvel = 0; // disable rotation path
+
+      body.sweepIntegrate(1);
+      body.sweepIntegrate(3); // delta = 2
+
+      expect(body.sweepTime).toBe(3);
+      expect(body.posx).toBe(6);
+    });
+
+    it("uses small-angle Taylor expansion path for tiny rotations", () => {
+      const body = new ZPP_Body();
+      body.posx = 0;
+      body.posy = 0;
+      body.rot = 0;
+      body.axisx = 0;
+      body.axisy = 1;
+      body.velx = 0;
+      body.vely = 0;
+      body.angvel = 1; // non-zero so we enter rotation branch
+      body.sweep_angvel = 0.001; // dr*dr = 1e-6 < 1e-4
+
+      body.sweepIntegrate(1);
+
+      // Taylor approximation should produce values very close to true sin/cos
+      expect(body.axisx).toBeCloseTo(Math.sin(0.001), 6);
+      expect(body.axisy).toBeCloseTo(Math.cos(0.001), 6);
+    });
+
+    it("skips rotation update entirely when angvel is zero", () => {
+      const body = new ZPP_Body();
+      body.axisx = 0;
+      body.axisy = 1;
+      body.rot = 0.5;
+      body.angvel = 0;
+      body.sweep_angvel = 5; // even non-zero sweep_angvel should not apply
+
+      body.sweepIntegrate(2);
+
+      expect(body.rot).toBe(0.5);
+      expect(body.axisx).toBe(0);
+      expect(body.axisy).toBe(1);
+    });
   });
 
-  it("sets infinite mass and inertia for non-dynamic bodies", () => {
-    const body = new ZPP_Body();
-    body.type = 1;
-    body.zip_mass = true;
-    body.zip_inertia = true;
-    body.shapes.add(makeShape(3, 4, 2));
+  describe("type checks", () => {
+    it("isStatic/isDynamic/isKinematic reflect the type code", () => {
+      const body = new ZPP_Body();
+      body.type = 1;
+      expect(body.isStatic()).toBe(true);
+      expect(body.isDynamic()).toBe(false);
+      expect(body.isKinematic()).toBe(false);
 
-    body.validate_mass();
-    body.validate_inertia();
+      body.type = 2;
+      expect(body.isDynamic()).toBe(true);
 
-    expect(body.cmass).toBe(6);
-    expect(body.mass).toBe(Infinity);
-    expect(body.imass).toBe(0);
-    expect(body.cinertia).toBe(24);
-    expect(body.inertia).toBe(Infinity);
-    expect(body.iinertia).toBe(0);
+      body.type = 3;
+      expect(body.isKinematic()).toBe(true);
+    });
   });
 
-  it("tracks sweep time and integrates position and rotation", () => {
-    const body = new ZPP_Body();
-    body.posx = 1;
-    body.posy = -2;
-    body.rot = 0;
-    body.axisx = 0;
-    body.axisy = 1;
-    body.velx = 4;
-    body.vely = 3;
-    body.angvel = 1;
-    body.sweep_angvel = 0.5;
+  describe("rotation helpers", () => {
+    it("validate_axis recomputes sin/cos only while zip_axis is set", () => {
+      const body = new ZPP_Body();
+      body.rot = Math.PI / 4;
+      body.zip_axis = true;
+      body.axisx = 0;
+      body.axisy = 0;
 
-    body.sweepIntegrate(2);
+      body.validate_axis();
 
-    expect(body.sweepTime).toBe(2);
-    expect(body.posx).toBe(9);
-    expect(body.posy).toBe(4);
-    expect(body.rot).toBe(1);
-    expect(body.axisx).toBeCloseTo(Math.sin(1));
-    expect(body.axisy).toBeCloseTo(Math.cos(1));
+      expect(body.axisx).toBeCloseTo(Math.sin(Math.PI / 4));
+      expect(body.axisy).toBeCloseTo(Math.cos(Math.PI / 4));
+      expect(body.zip_axis).toBe(false);
+    });
+
+    it("validate_axis is a no-op when zip_axis is false", () => {
+      const body = new ZPP_Body();
+      body.rot = Math.PI / 2;
+      body.zip_axis = false;
+      body.axisx = 0.42;
+      body.axisy = 0.42;
+
+      body.validate_axis();
+
+      expect(body.axisx).toBe(0.42);
+      expect(body.axisy).toBe(0.42);
+    });
+
+    it("quick_validate_axis updates axis without clearing the flag", () => {
+      const body = new ZPP_Body();
+      body.rot = 0;
+      body.zip_axis = true;
+      body.axisx = 99;
+      body.axisy = 99;
+
+      body.quick_validate_axis();
+
+      expect(body.axisx).toBeCloseTo(0);
+      expect(body.axisy).toBeCloseTo(1);
+      // intentionally does NOT clear zip_axis (quick-path used during step()
+      // when other callers will clear it later)
+      expect(body.zip_axis).toBe(true);
+    });
+
+    it("delta_rot applies the Taylor expansion for small rotations", () => {
+      const body = new ZPP_Body();
+      body.axisx = 0;
+      body.axisy = 1;
+      body.zip_axis = true;
+
+      body.delta_rot(0.001); // small dr → Taylor branch
+
+      expect(body.zip_axis).toBe(false);
+      // (p*0 + dr*1)*m ≈ 0.001
+      expect(body.axisx).toBeCloseTo(0.001, 5);
+      expect(body.axisy).toBeCloseTo(1, 5);
+    });
+
+    it("delta_rot uses exact sin/cos for large rotations", () => {
+      const body = new ZPP_Body();
+      body.axisx = 0;
+      body.axisy = 1;
+      body.rot = Math.PI / 3;
+      body.zip_axis = true;
+
+      body.delta_rot(1.0); // dr*dr > 1e-4 → exact branch
+
+      expect(body.zip_axis).toBe(false);
+      expect(body.axisx).toBeCloseTo(Math.sin(Math.PI / 3));
+      expect(body.axisy).toBeCloseTo(Math.cos(Math.PI / 3));
+    });
+  });
+
+  describe("velocity / force guards", () => {
+    it("force_invalidate rejects non-dynamic bodies", () => {
+      const body = new ZPP_Body();
+      body.type = 1;
+      (body as any).wake = vi.fn();
+
+      expect(() => body.force_invalidate({ x: 1, y: 1 } as any)).toThrow(/Non-dynamic/);
+    });
+
+    it("vel_invalidate rejects static bodies", () => {
+      const body = new ZPP_Body();
+      body.type = 1;
+
+      expect(() => body.vel_invalidate({ x: 1, y: 1 } as any)).toThrow(/Static body/);
+    });
+
+    it("force_invalidate writes through and wakes for dynamic bodies", () => {
+      const body = new ZPP_Body();
+      body.type = 2;
+      const wake = vi.fn();
+      (body as any).wake = wake;
+
+      body.force_invalidate({ x: 3, y: -4 } as any);
+
+      expect(body.forcex).toBe(3);
+      expect(body.forcey).toBe(-4);
+      expect(wake).toHaveBeenCalled();
+    });
+
+    it("kinvel_invalidate and svel_invalidate write through and wake", () => {
+      const body = new ZPP_Body();
+      body.type = 3;
+      const wake = vi.fn();
+      (body as any).wake = wake;
+
+      body.kinvel_invalidate({ x: 5, y: 6 } as any);
+      body.svel_invalidate({ x: 7, y: 8 } as any);
+
+      expect(body.kinvelx).toBe(5);
+      expect(body.kinvely).toBe(6);
+      expect(body.svelx).toBe(7);
+      expect(body.svely).toBe(8);
+      expect(wake).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("AABB validation", () => {
+    it("throws if requested with no shapes attached", () => {
+      const body = new ZPP_Body();
+      expect(() => body.aabb_validate()).toThrow(/bounds only makes sense/);
+    });
+
+    it("invalidate_aabb sets zip_aabb", () => {
+      const body = new ZPP_Body();
+      body.zip_aabb = false;
+      body.invalidate_aabb();
+      expect(body.zip_aabb).toBe(true);
+    });
+
+    it("invalidate_localCOM cascades to worldCOM", () => {
+      const body = new ZPP_Body();
+      body.zip_localCOM = false;
+      body.zip_worldCOM = false;
+
+      body.invalidate_localCOM();
+
+      expect(body.zip_localCOM).toBe(true);
+      expect(body.zip_worldCOM).toBe(true);
+    });
+  });
+
+  describe("immutability guard", () => {
+    it("world bodies (Space::world) cannot be mutated", () => {
+      const body = new ZPP_Body();
+      body.world = true;
+      expect(() => body.__immutable_midstep()).toThrow(/Space::world is immutable/);
+    });
+
+    it("non-world bodies pass the guard", () => {
+      const body = new ZPP_Body();
+      body.world = false;
+      expect(() => body.__immutable_midstep()).not.toThrow();
+    });
+  });
+
+  describe("clear()", () => {
+    it("rejects clear when body is still in a space", () => {
+      const body = new ZPP_Body();
+      body.space = { fake: true };
+      expect(() => body.clear()).toThrow(
+        /Cannot clear a Body if it is currently being used by a Space/,
+      );
+    });
+
+    it("rejects clear when constraints are attached", () => {
+      const body = new ZPP_Body();
+      body.constraints.add({ fake: true });
+      expect(() => body.clear()).toThrow(/used by a constraint/);
+    });
+
+    it("resets all dynamic state and mode flags", () => {
+      const body = new ZPP_Body();
+      body.posx = 5;
+      body.posy = 6;
+      body.velx = 1;
+      body.vely = 2;
+      body.forcex = 3;
+      body.forcey = 4;
+      body.kinvelx = 5;
+      body.kinvely = 6;
+      body.svelx = 7;
+      body.svely = 8;
+      body.angvel = 9;
+      body.torque = 10;
+      body.kinangvel = 11;
+      body.rot = 12;
+      body.pre_rot = 13;
+      body.massMode = 1;
+      body.gravMassMode = 1;
+      body.gravMassScale = 4.2;
+      body.inertiaMode = 1;
+      body.norotate = true;
+      body.nomove = true;
+      (body as any).wake = vi.fn();
+
+      body.clear();
+
+      expect(body.posx).toBe(0);
+      expect(body.posy).toBe(0);
+      expect(body.velx).toBe(0);
+      expect(body.vely).toBe(0);
+      expect(body.forcex).toBe(0);
+      expect(body.forcey).toBe(0);
+      expect(body.kinvelx).toBe(0);
+      expect(body.kinvely).toBe(0);
+      expect(body.svelx).toBe(0);
+      expect(body.svely).toBe(0);
+      expect(body.angvel).toBe(0);
+      expect(body.torque).toBe(0);
+      expect(body.kinangvel).toBe(0);
+      expect(body.rot).toBe(0);
+      expect(body.pre_rot).toBe(0);
+      expect(body.massMode).toBe(0);
+      expect(body.gravMassMode).toBe(0);
+      expect(body.gravMassScale).toBe(1.0);
+      expect(body.inertiaMode).toBe(0);
+      expect(body.norotate).toBe(false);
+      expect(body.nomove).toBe(false);
+      expect(body.axisx).toBe(0);
+      expect(body.axisy).toBe(1);
+    });
+  });
+
+  describe("refreshArbiters", () => {
+    it("marks every attached arbiter invalidated", () => {
+      const body = new ZPP_Body();
+      const a = { invalidated: false };
+      const b = { invalidated: false };
+      body.arbiters.add(a);
+      body.arbiters.add(b);
+
+      body.refreshArbiters();
+
+      expect(a.invalidated).toBe(true);
+      expect(b.invalidated).toBe(true);
+    });
+
+    it("is safe on an empty arbiter list", () => {
+      const body = new ZPP_Body();
+      expect(() => body.refreshArbiters()).not.toThrow();
+    });
   });
 });

--- a/packages/nape-js/tests/native/phys/ZPP_Compound.test.ts
+++ b/packages/nape-js/tests/native/phys/ZPP_Compound.test.ts
@@ -24,74 +24,303 @@ function setupCompoundStatics() {
   ZPP_Interactor._nape = createMockNape();
 }
 
+function fakeSpace(overrides: any = {}) {
+  return {
+    midstep: false,
+    addBody: vi.fn(),
+    remBody: vi.fn(),
+    addConstraint: vi.fn(),
+    remConstraint: vi.fn(),
+    addCompound: vi.fn(),
+    remCompound: vi.fn(),
+    nullInteractorType: vi.fn(),
+    freshInteractorType: vi.fn(),
+    bodies: new MockZNPList(),
+    constraints: new MockZNPList(),
+    compounds: new MockZNPList(),
+    ...overrides,
+  };
+}
+
 describe("ZPP_Compound", () => {
   beforeEach(() => {
     setupCompoundStatics();
   });
 
-  it("initializes empty child lists and list callbacks", () => {
-    const compound = new ZPP_Compound();
+  describe("construction", () => {
+    it("initializes empty child lists and list callbacks", () => {
+      const compound = new ZPP_Compound();
 
-    expect(compound.depth).toBe(1);
-    expect(compound.bodies.length).toBe(0);
-    expect(compound.constraints.length).toBe(0);
-    expect(compound.compounds.length).toBe(0);
-    expect(compound.wrap_bodies.zpp_inner.adder).toBeTypeOf("function");
-    expect(compound.wrap_constraints.zpp_inner.subber).toBeTypeOf("function");
-    expect(compound.wrap_compounds.zpp_inner._modifiable).toBeTypeOf("function");
+      expect(compound.depth).toBe(1);
+      expect(compound.bodies.length).toBe(0);
+      expect(compound.constraints.length).toBe(0);
+      expect(compound.compounds.length).toBe(0);
+      expect(compound.wrap_bodies.zpp_inner.adder).toBeTypeOf("function");
+      expect(compound.wrap_constraints.zpp_inner.subber).toBeTypeOf("function");
+      expect(compound.wrap_compounds.zpp_inner._modifiable).toBeTypeOf("function");
+    });
+
+    it("self-references icompound so isCompound() works", () => {
+      const compound = new ZPP_Compound();
+      expect(compound.icompound).toBe(compound);
+      expect(compound.isCompound()).toBe(true);
+      expect(compound.isBody()).toBe(false);
+      expect(compound.isShape()).toBe(false);
+    });
   });
 
-  it("parents and de-parents bodies while forwarding space membership", () => {
-    const compound = new ZPP_Compound();
-    const addBody = vi.fn();
-    const remBody = vi.fn();
-    compound.space = { addBody, remBody };
-    const body = { compound: null, space: null };
-    const wrapper = { zpp_inner: body };
+  describe("body parenting", () => {
+    it("parents and de-parents bodies while forwarding space membership", () => {
+      const compound = new ZPP_Compound();
+      const space = fakeSpace();
+      compound.space = space;
+      const body = { compound: null, space: null };
+      const wrapper = { zpp_inner: body };
 
-    expect(compound.bodies_adder(wrapper)).toBe(true);
-    expect(body.compound).toBe(compound);
-    expect(addBody).toHaveBeenCalledWith(body);
+      expect(compound.bodies_adder(wrapper)).toBe(true);
+      expect(body.compound).toBe(compound);
+      expect(space.addBody).toHaveBeenCalledWith(body);
 
-    compound.bodies_subber(wrapper);
+      compound.bodies_subber(wrapper);
 
-    expect(body.compound).toBeNull();
-    expect(remBody).toHaveBeenCalledWith(body);
+      expect(body.compound).toBeNull();
+      expect(space.remBody).toHaveBeenCalledWith(body);
+    });
+
+    it("returns false and skips space.addBody when the body already belongs to this compound", () => {
+      const compound = new ZPP_Compound();
+      const space = fakeSpace();
+      compound.space = space;
+      const body = { compound: compound, space: null };
+      const wrapper = { zpp_inner: body };
+
+      expect(compound.bodies_adder(wrapper)).toBe(false);
+      expect(space.addBody).not.toHaveBeenCalled();
+    });
+
+    it("reparents a body from one compound to another", () => {
+      const oldParent = new ZPP_Compound();
+      const newParent = new ZPP_Compound();
+      const oldBodies = new MockZNPList();
+      // wrap_bodies.remove is what reparenting calls — stub it
+      const removeSpy = vi.fn((x: any) => oldBodies.remove(x));
+      oldParent.wrap_bodies = { remove: removeSpy } as any;
+
+      const body = { compound: oldParent, space: null };
+      const wrapper = { zpp_inner: body };
+
+      expect(newParent.bodies_adder(wrapper)).toBe(true);
+      expect(removeSpy).toHaveBeenCalledWith(wrapper);
+      expect(body.compound).toBe(newParent);
+    });
+
+    it("moves a free-roaming body out of its space when it gets parented", () => {
+      const compound = new ZPP_Compound();
+      const oldSpace = { wrap_bodies: { remove: vi.fn() } };
+      const body = { compound: null, space: oldSpace };
+      const wrapper = { zpp_inner: body };
+
+      expect(compound.bodies_adder(wrapper)).toBe(true);
+      expect(oldSpace.wrap_bodies.remove).toHaveBeenCalledWith(wrapper);
+      expect(body.compound).toBe(compound);
+    });
+
+    it("bodies_modifiable throws during space step", () => {
+      const compound = new ZPP_Compound();
+      compound.space = { midstep: true };
+      expect(() => compound.bodies_modifiable()).toThrow(/cannot be set during/);
+    });
+
+    it("bodies_modifiable is a no-op outside a step", () => {
+      const compound = new ZPP_Compound();
+      compound.space = { midstep: false };
+      expect(() => compound.bodies_modifiable()).not.toThrow();
+    });
   });
 
-  it("updates nested compound depth and rejects cycles", () => {
-    const parent = new ZPP_Compound();
-    const child = new ZPP_Compound();
-    child.outer = { toString: () => "child" };
-    parent.depth = 3;
+  describe("constraint parenting", () => {
+    it("forwards constraints into the compound's space", () => {
+      const compound = new ZPP_Compound();
+      const space = fakeSpace();
+      compound.space = space;
+      const c = { compound: null, space: null };
+      const wrapper = { zpp_inner: c };
 
-    expect(parent.compounds_adder({ zpp_inner: child, toString: () => "child" })).toBe(true);
-    expect(child.compound).toBe(parent);
-    expect(child.depth).toBe(4);
+      expect(compound.constraints_adder(wrapper)).toBe(true);
+      expect(c.compound).toBe(compound);
+      expect(space.addConstraint).toHaveBeenCalledWith(c);
 
-    expect(() => child.compounds_adder({ zpp_inner: parent, toString: () => "parent" })).toThrow(
-      /cycle/,
-    );
+      compound.constraints_subber(wrapper);
+      expect(c.compound).toBeNull();
+      expect(space.remConstraint).toHaveBeenCalledWith(c);
+    });
 
-    parent.compounds_subber({ zpp_inner: child });
-    expect(child.compound).toBeNull();
-    expect(child.depth).toBe(1);
+    it("constraints_modifiable mirrors body guard", () => {
+      const compound = new ZPP_Compound();
+      compound.space = { midstep: true };
+      expect(() => compound.constraints_modifiable()).toThrow(/cannot be set during/);
+    });
   });
 
-  it("breaks apart an empty compound without requiring children", () => {
-    const compound = new ZPP_Compound();
-    compound.__iremovedFromSpace = vi.fn();
-    const remove = vi.fn();
-    compound.space = {
-      nullInteractorType: vi.fn(),
-      compounds: { remove },
-    };
+  describe("compound parenting and depth", () => {
+    it("updates nested compound depth and rejects cycles", () => {
+      const parent = new ZPP_Compound();
+      const child = new ZPP_Compound();
+      child.outer = { toString: () => "child" };
+      parent.depth = 3;
 
-    compound.breakApart();
+      expect(parent.compounds_adder({ zpp_inner: child, toString: () => "child" })).toBe(true);
+      expect(child.compound).toBe(parent);
+      expect(child.depth).toBe(4);
 
-    expect(compound.__iremovedFromSpace).toHaveBeenCalled();
-    expect(remove).toHaveBeenCalledWith(compound);
-    expect(compound.space).toBeNull();
-    expect(compound.compound).toBeNull();
+      expect(() => child.compounds_adder({ zpp_inner: parent, toString: () => "parent" })).toThrow(
+        /cycle/,
+      );
+
+      parent.compounds_subber({ zpp_inner: child });
+      expect(child.compound).toBeNull();
+      expect(child.depth).toBe(1);
+    });
+
+    it("forwards nested compound add to space.addCompound", () => {
+      const parent = new ZPP_Compound();
+      const child = new ZPP_Compound();
+      const space = fakeSpace();
+      parent.space = space;
+      parent.outer = { toString: () => "parent" };
+
+      const wrapper = { zpp_inner: child, toString: () => "child" };
+      expect(parent.compounds_adder(wrapper)).toBe(true);
+      expect(space.addCompound).toHaveBeenCalledWith(child);
+
+      parent.compounds_subber(wrapper);
+      expect(space.remCompound).toHaveBeenCalledWith(child);
+    });
+
+    it("detects deep cycles (grandparent assignment)", () => {
+      const root = new ZPP_Compound();
+      const mid = new ZPP_Compound();
+      const leaf = new ZPP_Compound();
+      root.outer = { toString: () => "root" };
+      mid.outer = { toString: () => "mid" };
+      leaf.outer = { toString: () => "leaf" };
+
+      root.compounds_adder({ zpp_inner: mid, toString: () => "mid" });
+      mid.compounds_adder({ zpp_inner: leaf, toString: () => "leaf" });
+
+      // Attempting to make root a child of leaf would create root→mid→leaf→root cycle.
+      expect(() => leaf.compounds_adder({ zpp_inner: root, toString: () => "root" })).toThrow(
+        /cycle/,
+      );
+    });
+
+    it("compounds_modifiable enforces mid-step guard", () => {
+      const compound = new ZPP_Compound();
+      compound.space = { midstep: true };
+      expect(() => compound.compounds_modifiable()).toThrow(/cannot be set during/);
+    });
+  });
+
+  describe("breakApart", () => {
+    it("breaks apart an empty compound without requiring children", () => {
+      const compound = new ZPP_Compound();
+      compound.__iremovedFromSpace = vi.fn();
+      const remove = vi.fn();
+      compound.space = {
+        nullInteractorType: vi.fn(),
+        compounds: { remove },
+      };
+
+      compound.breakApart();
+
+      expect(compound.__iremovedFromSpace).toHaveBeenCalled();
+      expect(remove).toHaveBeenCalledWith(compound);
+      expect(compound.space).toBeNull();
+      expect(compound.compound).toBeNull();
+    });
+
+    it("hoists bodies to the parent compound when there is one", () => {
+      const parent = new ZPP_Compound();
+      const compound = new ZPP_Compound();
+      compound.compound = parent;
+      compound.__iremovedFromSpace = vi.fn();
+      const b1 = { compound: compound };
+      const b2 = { compound: compound };
+      compound.bodies.add(b1);
+      compound.bodies.add(b2);
+      // parent.compounds must contain compound so the remove() in breakApart finds it
+      parent.compounds.add(compound);
+
+      compound.breakApart();
+
+      expect(parent.bodies.has(b1)).toBe(true);
+      expect(parent.bodies.has(b2)).toBe(true);
+      expect(b1.compound).toBe(parent);
+      expect(b2.compound).toBe(parent);
+      expect(parent.compounds.has(compound)).toBe(false);
+      expect(compound.space).toBeNull();
+      expect(compound.compound).toBeNull();
+    });
+
+    it("releases bodies/constraints/compounds into the space when there is no parent", () => {
+      const compound = new ZPP_Compound();
+      compound.__iremovedFromSpace = vi.fn();
+      const space = fakeSpace();
+      compound.space = space;
+
+      const b = { compound: compound };
+      const c = { compound: compound };
+      const sub = { compound: compound };
+      compound.bodies.add(b);
+      compound.constraints.add(c);
+      compound.compounds.add(sub);
+
+      compound.breakApart();
+
+      expect(space.bodies.has(b)).toBe(true);
+      expect(space.constraints.has(c)).toBe(true);
+      expect(space.compounds.has(sub)).toBe(true);
+      expect(b.compound).toBeNull();
+      expect(c.compound).toBeNull();
+      expect(sub.compound).toBeNull();
+      // both bodies and nested compounds should re-register interactor types
+      expect(space.freshInteractorType).toHaveBeenCalledWith(b);
+      expect(space.freshInteractorType).toHaveBeenCalledWith(sub);
+    });
+  });
+
+  describe("__imutable_midstep guard", () => {
+    it("throws while space is mid-step", () => {
+      const compound = new ZPP_Compound();
+      compound.space = { midstep: true };
+      expect(() => compound.__imutable_midstep("Compound::field")).toThrow(/cannot be set during/);
+    });
+
+    it("does nothing without an attached space", () => {
+      const compound = new ZPP_Compound();
+      expect(() => compound.__imutable_midstep("Compound::field")).not.toThrow();
+    });
+
+    it("does nothing when the space is not mid-step", () => {
+      const compound = new ZPP_Compound();
+      compound.space = { midstep: false };
+      expect(() => compound.__imutable_midstep("Compound::field")).not.toThrow();
+    });
+  });
+
+  describe("space integration delegation", () => {
+    it("addedToSpace and removedFromSpace delegate to the interactor variants", () => {
+      const compound = new ZPP_Compound();
+      const added = vi.fn();
+      const removed = vi.fn();
+      (compound as any).__iaddedToSpace = added;
+      (compound as any).__iremovedFromSpace = removed;
+
+      compound.addedToSpace();
+      compound.removedFromSpace();
+
+      expect(added).toHaveBeenCalled();
+      expect(removed).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/nape-js/tests/native/phys/ZPP_Interactor.test.ts
+++ b/packages/nape-js/tests/native/phys/ZPP_Interactor.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ZPP_Interactor } from "../../../src/native/phys/ZPP_Interactor";
+import { ZPP_OptionType } from "../../../src/native/callbacks/ZPP_OptionType";
+import { ZPP_CbSet } from "../../../src/native/callbacks/ZPP_CbSet";
+import { createMockNape, createMockZpp, MockZNPList } from "../_mocks";
+
+/**
+ * ZPP_Interactor is the abstract base for ZPP_Body, ZPP_Compound, and ZPP_Shape.
+ *
+ * These tests exercise the base directly with a minimal interactor (no body/shape/compound
+ * specialisation) so the focus stays on the shared filtering, group, and cbSet behaviour.
+ */
+
+function setupInteractorStatics() {
+  const zpp = createMockZpp();
+  zpp.util.ZNPList_ZPP_CallbackSet = MockZNPList;
+  zpp.util.ZNPList_ZPP_CbType = MockZNPList;
+  ZPP_Interactor._zpp = zpp;
+  ZPP_Interactor._nape = createMockNape();
+  ZPP_OptionType._zpp = zpp;
+  return zpp;
+}
+
+describe("ZPP_Interactor", () => {
+  beforeEach(() => {
+    setupInteractorStatics();
+    ZPP_CbSet.zpp_pool = null;
+  });
+
+  describe("initFields / construction", () => {
+    it("seeds an id and empty cbType/cbset lists", () => {
+      const i = new ZPP_Interactor();
+      expect(typeof i.id).toBe("number");
+      expect(i.cbTypes).toBeInstanceOf(MockZNPList);
+      expect(i.cbsets).toBeInstanceOf(MockZNPList);
+      expect(i.userData).toBeNull();
+      expect(i.group).toBeNull();
+    });
+
+    it("assigns monotonically increasing interactor ids", () => {
+      const a = new ZPP_Interactor();
+      const b = new ZPP_Interactor();
+      expect(b.id).not.toBe(a.id);
+    });
+
+    it("isShape/isBody/isCompound default to false on a bare interactor", () => {
+      const i = new ZPP_Interactor();
+      expect(i.isShape()).toBe(false);
+      expect(i.isBody()).toBe(false);
+      expect(i.isCompound()).toBe(false);
+    });
+  });
+
+  describe("static get()", () => {
+    it("returns null when neither interactor has matching cbset pair", () => {
+      const a = new ZPP_Interactor();
+      const b = new ZPP_Interactor();
+      expect(ZPP_Interactor.get(a, b)).toBeNull();
+    });
+
+    it("finds a cbset keyed on (lowId, highId) regardless of argument order", () => {
+      const a = new ZPP_Interactor();
+      const b = new ZPP_Interactor();
+      const lo = a.id < b.id ? a.id : b.id;
+      const hi = a.id < b.id ? b.id : a.id;
+      const pair = { id: lo, di: hi };
+      // a real shared cbset would be on both interactors — engine scans the shorter list
+      a.cbsets.add(pair);
+      b.cbsets.add(pair);
+
+      expect(ZPP_Interactor.get(a, b)).toBe(pair);
+      expect(ZPP_Interactor.get(b, a)).toBe(pair);
+    });
+
+    it("scans the shorter cbset list for efficiency", () => {
+      const a = new ZPP_Interactor();
+      const b = new ZPP_Interactor();
+      const lo = a.id < b.id ? a.id : b.id;
+      const hi = a.id < b.id ? b.id : a.id;
+      const matching = { id: lo, di: hi };
+      // a has 3 entries (including the match), b has just the match itself
+      a.cbsets.add({ id: -1, di: -1 });
+      a.cbsets.add(matching);
+      a.cbsets.add({ id: -2, di: -2 });
+      b.cbsets.add(matching);
+
+      expect(ZPP_Interactor.get(a, b)).toBe(matching);
+    });
+  });
+
+  describe("int_callback() — direction filtering", () => {
+    function makeOpt(includesList: any[], excludesList: any[]): any {
+      const includes = new MockZNPList();
+      const excludes = new MockZNPList();
+      includesList.forEach((e) => includes.add(e));
+      excludesList.forEach((e) => excludes.add(e));
+      return {
+        includes,
+        excludes,
+        nonemptyintersection: (xs: any, ys: any) => {
+          // simple "share at least one element" check
+          let xite = xs.head;
+          while (xite != null) {
+            let yite = ys.head;
+            while (yite != null) {
+              if (yite.elt === xite.elt) return true;
+              yite = yite.next;
+            }
+            xite = xite.next;
+          }
+          return false;
+        },
+      };
+    }
+
+    function makeInteractor(types: any[]): any {
+      const cbTypes = new MockZNPList();
+      types.forEach((t) => cbTypes.add(t));
+      return { cbTypes };
+    }
+
+    it("assigns int1=o1/int2=o2 when both sides pass the include filter", () => {
+      const t1 = { id: 1 };
+      const t2 = { id: 2 };
+      const o1 = makeInteractor([t1]);
+      const o2 = makeInteractor([t2]);
+      const set = {
+        int1: o1,
+        int2: o2,
+        options1: makeOpt([t1], []),
+        options2: makeOpt([t2], []),
+      };
+      const cb: any = { int1: null, int2: null };
+
+      ZPP_Interactor.int_callback(set, set, cb);
+
+      expect(cb.int1).toBe(o1);
+      expect(cb.int2).toBe(o2);
+    });
+
+    it("flips int1/int2 when the first interactor fails the filter", () => {
+      const t1 = { id: 1 };
+      const t2 = { id: 2 };
+      const o1 = makeInteractor([t1]);
+      const o2 = makeInteractor([t2]);
+      const set = {
+        int1: o1,
+        int2: o2,
+        // options1 includes t2 only — o1 (carrying t1) fails the filter
+        options1: makeOpt([t2], []),
+        options2: makeOpt([t1], []),
+      };
+      const cb: any = { int1: null, int2: null };
+
+      ZPP_Interactor.int_callback(set, set, cb);
+
+      expect(cb.int1).toBe(o2);
+      expect(cb.int2).toBe(o1);
+    });
+
+    it("flips when an exclude on the second side rejects o2", () => {
+      const t1 = { id: 1 };
+      const t2 = { id: 2 };
+      const o1 = makeInteractor([t1]);
+      const o2 = makeInteractor([t2]);
+      const set = {
+        int1: o1,
+        int2: o2,
+        options1: makeOpt([t1], []),
+        options2: makeOpt([t2], [t2]), // include t2 but also exclude it
+      };
+      const cb: any = { int1: null, int2: null };
+
+      ZPP_Interactor.int_callback(set, set, cb);
+
+      // tmp is false → flipped assignment
+      expect(cb.int1).toBe(o2);
+      expect(cb.int2).toBe(o1);
+    });
+  });
+
+  describe("setGroup()", () => {
+    it("attaches a group without touching space lists when not in a space", () => {
+      const i = new ZPP_Interactor();
+      // Concrete interactors always have one of ishape/ibody/icompound set; pretend body with no space.
+      i.ibody = { space: null } as any;
+      const oldGroup = { interactors: new MockZNPList() };
+      const newGroup = { interactors: new MockZNPList() };
+      i.group = oldGroup;
+
+      i.setGroup(newGroup);
+
+      expect(i.group).toBe(newGroup);
+      // when not in a space neither list is modified
+      expect(oldGroup.interactors.length).toBe(0);
+      expect(newGroup.interactors.length).toBe(0);
+    });
+
+    it("does nothing if the same group is assigned", () => {
+      const i = new ZPP_Interactor();
+      i.ibody = { space: null } as any;
+      const g = { interactors: new MockZNPList() };
+      i.group = g;
+
+      i.setGroup(g);
+
+      expect(g.interactors.length).toBe(0);
+    });
+
+    it("transfers an in-space interactor's group membership and wakes the owning body", () => {
+      const i = new ZPP_Interactor();
+      const wake = vi.fn();
+      // Pretend this interactor is a shape with a body in a space
+      i.ishape = { body: { wake, space: { stamp: 0 } } };
+      const oldGroup = { interactors: new MockZNPList() };
+      const newGroup = { interactors: new MockZNPList() };
+      // pre-populate to confirm removal
+      oldGroup.interactors.add(i);
+      i.group = oldGroup;
+
+      i.setGroup(newGroup);
+
+      expect(oldGroup.interactors.has(i)).toBe(false);
+      expect(newGroup.interactors.has(i)).toBe(true);
+      expect(wake).toHaveBeenCalled();
+    });
+
+    it("can clear group (set to null) while in a space", () => {
+      const i = new ZPP_Interactor();
+      const wake = vi.fn();
+      i.ibody = { space: { stamp: 0 }, wake };
+      const oldGroup = { interactors: new MockZNPList() };
+      oldGroup.interactors.add(i);
+      i.group = oldGroup;
+
+      i.setGroup(null);
+
+      expect(i.group).toBeNull();
+      expect(oldGroup.interactors.has(i)).toBe(false);
+      expect(wake).toHaveBeenCalled();
+    });
+  });
+
+  describe("lookup_group()", () => {
+    it("returns null when nothing in the chain has a group", () => {
+      const i = new ZPP_Interactor();
+      i.ibody = { compound: null }; // a body without a parent compound
+
+      expect(i.lookup_group()).toBeNull();
+    });
+
+    it("returns this interactor's own group when present", () => {
+      const i = new ZPP_Interactor();
+      const g = { interactors: new MockZNPList() };
+      i.group = g;
+      expect(i.lookup_group()).toBe(g);
+    });
+
+    it("walks shape → body → compound until it finds a group", () => {
+      // outer compound owns the group
+      const outerCompound = new ZPP_Interactor();
+      outerCompound.icompound = outerCompound;
+      outerCompound.group = { tag: "outer" };
+      // body sits under outerCompound
+      const body = new ZPP_Interactor();
+      body.ibody = body as any;
+      (body as any).compound = outerCompound;
+      // shape sits under body
+      const shape = new ZPP_Interactor();
+      shape.ishape = { body };
+
+      expect(shape.lookup_group()).toBe(outerCompound.group);
+    });
+
+    it("falls off the end and returns null when nothing has a group", () => {
+      const top = new ZPP_Interactor();
+      top.icompound = top;
+      (top as any).compound = null;
+      const child = new ZPP_Interactor();
+      child.icompound = child;
+      (child as any).compound = top;
+
+      expect(child.lookup_group()).toBeNull();
+    });
+  });
+
+  describe("immutable_midstep()", () => {
+    it("throws when an attached body's space is mid-step", () => {
+      const i = new ZPP_Interactor();
+      i.ibody = { space: { midstep: true } };
+      expect(() => i.immutable_midstep("X")).toThrow(/cannot be set during a space step/);
+    });
+
+    it("does nothing when no space attached", () => {
+      const i = new ZPP_Interactor();
+      i.ibody = { space: null };
+      expect(() => i.immutable_midstep("X")).not.toThrow();
+    });
+
+    it("forwards through ishape's __immutable_midstep when interactor is a shape", () => {
+      const fn = vi.fn();
+      const i = new ZPP_Interactor();
+      i.ishape = { __immutable_midstep: fn };
+      i.immutable_midstep("Shape::x");
+      expect(fn).toHaveBeenCalledWith("Shape::x");
+    });
+
+    it("forwards through icompound's __imutable_midstep when interactor is a compound", () => {
+      const fn = vi.fn();
+      const i = new ZPP_Interactor();
+      i.icompound = { __imutable_midstep: fn };
+      i.immutable_midstep("Compound::x");
+      expect(fn).toHaveBeenCalledWith("Compound::x");
+    });
+  });
+
+  describe("__iaddedToSpace / __iremovedFromSpace", () => {
+    function makeCbType() {
+      return { id: Math.random(), interactors: new MockZNPList() };
+    }
+    function makeInSpaceInteractor(): any {
+      const i = new ZPP_Interactor();
+      // Stub out alloc_cbSet so we don't need a full space.cbsets.get
+      (i as any).alloc_cbSet = vi.fn();
+      (i as any).dealloc_cbSet = vi.fn();
+      return i;
+    }
+
+    it("registers the interactor with its group and each cbType", () => {
+      const i = makeInSpaceInteractor();
+      const g = { interactors: new MockZNPList() };
+      i.group = g;
+      const cb1 = makeCbType();
+      const cb2 = makeCbType();
+      i.cbTypes.add(cb1);
+      i.cbTypes.add(cb2);
+
+      i.__iaddedToSpace();
+
+      expect(g.interactors.has(i)).toBe(true);
+      expect(cb1.interactors.has(i)).toBe(true);
+      expect(cb2.interactors.has(i)).toBe(true);
+      expect((i as any).alloc_cbSet).toHaveBeenCalled();
+    });
+
+    it("symmetric removal undoes the registrations", () => {
+      const i = makeInSpaceInteractor();
+      const g = { interactors: new MockZNPList() };
+      g.interactors.add(i);
+      i.group = g;
+      const cb1 = makeCbType();
+      cb1.interactors.add(i);
+      i.cbTypes.add(cb1);
+
+      i.__iremovedFromSpace();
+
+      expect(g.interactors.has(i)).toBe(false);
+      expect(cb1.interactors.has(i)).toBe(false);
+      expect((i as any).dealloc_cbSet).toHaveBeenCalled();
+    });
+
+    it("works on an interactor with no group attached", () => {
+      const i = makeInSpaceInteractor();
+      expect(() => i.__iaddedToSpace()).not.toThrow();
+      expect(() => i.__iremovedFromSpace()).not.toThrow();
+    });
+  });
+
+  describe("wake() dispatch", () => {
+    it("routes shape→body via body.space.non_inlined_wake", () => {
+      const non_inlined_wake = vi.fn();
+      const body = { space: { non_inlined_wake } };
+      const i = new ZPP_Interactor();
+      i.ishape = { body };
+
+      i.wake();
+
+      expect(non_inlined_wake).toHaveBeenCalledWith(body);
+    });
+
+    it("routes body via ibody.space.non_inlined_wake", () => {
+      const non_inlined_wake = vi.fn();
+      const body: any = { space: { non_inlined_wake } };
+      const i = new ZPP_Interactor();
+      i.ibody = body;
+
+      i.wake();
+
+      expect(non_inlined_wake).toHaveBeenCalledWith(body);
+    });
+
+    it("routes compound via icompound.space.wakeCompound", () => {
+      const wakeCompound = vi.fn();
+      const c: any = { space: { wakeCompound } };
+      const i = new ZPP_Interactor();
+      i.icompound = c;
+
+      i.wake();
+
+      expect(wakeCompound).toHaveBeenCalledWith(c);
+    });
+
+    it("is a no-op when the owning object is not in a space", () => {
+      const i = new ZPP_Interactor();
+      i.ibody = { space: null } as any;
+      expect(() => i.wake()).not.toThrow();
+    });
+  });
+
+  describe("getSpace()", () => {
+    it("returns null for a free-standing shape (no body)", () => {
+      const i = new ZPP_Interactor();
+      i.ishape = { body: null };
+      expect(i.getSpace()).toBeNull();
+    });
+
+    it("returns the body's space for a shape with a body", () => {
+      const i = new ZPP_Interactor();
+      const space = { tag: "s1" };
+      i.ishape = { body: { space } };
+      expect(i.getSpace()).toBe(space);
+    });
+
+    it("returns ibody.space for a body interactor", () => {
+      const i = new ZPP_Interactor();
+      const space = { tag: "body-space" };
+      i.ibody = { space } as any;
+      expect(i.getSpace()).toBe(space);
+    });
+
+    it("returns icompound.space for a compound interactor", () => {
+      const i = new ZPP_Interactor();
+      const space = { tag: "compound-space" };
+      i.icompound = { space };
+      expect(i.getSpace()).toBe(space);
+    });
+  });
+
+  describe("setupcbTypes()", () => {
+    it("creates a cbTypes wrapper with adder/subber/_modifiable callbacks", () => {
+      const i = new ZPP_Interactor();
+      i.setupcbTypes();
+
+      expect(i.wrap_cbTypes).toBeTruthy();
+      expect(i.wrap_cbTypes.zpp_inner.adder).toBeTypeOf("function");
+      expect(i.wrap_cbTypes.zpp_inner.subber).toBeTypeOf("function");
+      expect(i.wrap_cbTypes.zpp_inner.dontremove).toBe(true);
+      expect(i.wrap_cbTypes.zpp_inner._modifiable).toBeTypeOf("function");
+    });
+
+    it("immutable_cbTypes delegates to immutable_midstep with 'Interactor::cbTypes'", () => {
+      const i = new ZPP_Interactor();
+      const spy = vi.fn();
+      (i as any).immutable_midstep = spy;
+      i.immutable_cbTypes();
+      expect(spy).toHaveBeenCalledWith("Interactor::cbTypes");
+    });
+  });
+});


### PR DESCRIPTION
Closes #166.

## Summary

- **ZPP_Body** (+34 new tests): mass/inertia branches (`nomove`, `norotate`, `gravMassMode` 0/1/2, `validate_gravMassScale`); CCD `sweepIntegrate` edges (zero delta, small-angle Taylor branch, `angvel==0` short-circuit); rotation helpers (`validate_axis`, `quick_validate_axis`, `delta_rot` small vs exact); force/velocity guards on static/non-dynamic bodies; AABB/COM invalidation cascades; `clear()` resets; `refreshArbiters`; immutability guard.
- **ZPP_Compound** (+17 new tests): re-parenting bodies from space and from another compound; mid-step `_modifiable` guards on bodies/constraints/compounds; deep cycle detection (grandparent assignment); `breakApart` for empty compounds, hoisting to parent compound, and release into space; `__imutable_midstep` matrix; `addedToSpace` / `removedFromSpace` delegation.
- **ZPP_Interactor** (new file, 34 tests): `get()` pair lookup symmetry and short-list scan; `int_callback()` direction-flip filtering across include and exclude paths; `setGroup()` in-space transitions and clearing; `lookup_group()` shape→body→compound chain walk; `immutable_midstep` dispatch into shape/compound; `__iaddedToSpace` / `__iremovedFromSpace` group + cbType registration; `wake()` routing for shape/body/compound; `getSpace()` fan-out; `setupcbTypes` wrapper bindings.

Engine tests **6003 → 6088** (+85). All four pre-push checks pass (`format:check`, `lint`, `test`, `build`).

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test` — 6088 + 71 passing
- [x] `npm run build` — DTS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)