### PR TITLE
docs: sync test counts + refresh roadmap after issue closures

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -88,7 +88,7 @@ npm test
 npm run build
 ```
 
-Report each as ✅ / ❌ with specifics. **Format failures** can usually be fixed with `npm run format` (suggest this to the contributor). **Test counts**: baseline is 5761 (nape-js) + 71 (nape-pixi); anything below that is a regression. **Build failure** usually means a TypeScript error vitest skipped.
+Report each as ✅ / ❌ with specifics. **Format failures** can usually be fixed with `npm run format` (suggest this to the contributor). **Test counts**: baseline is 6169 (nape-js) + 73 (nape-pixi); anything below that is a regression. **Build failure** usually means a TypeScript error vitest skipped.
 
 ### 5. Manual review — what to look for
 

--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: solve-issue
+description: Solve a GitHub issue on the NewKrok/nape-js repo end-to-end — check for an existing PR first and assess how well it satisfies the issue, scope the remaining work, implement on a branch, run the full pre-push checks, and open a PR that references the issue. Trigger when the user pastes a nape-js issue URL/number to solve, or types `/solve-issue`.
+---
+
+# Solve issue — nape-js
+
+This skill walks through the standard nape-js issue-resolution process. The first
+job on **any** issue is to find out whether someone already started on it, because
+the `Tests:` / `Cleanup:` / `feat:` issues are scoped to land across one or more
+incremental PRs — a partial PR may already cover part of the acceptance list.
+
+## Inputs
+
+Accept any of:
+
+- A full URL like `https://github.com/NewKrok/nape-js/issues/168`
+- Just a number like `168`
+
+## Steps
+
+Work through these in order. Use the TodoWrite tool to track progress. Each step is
+a checkpoint — if any one fails, stop and report; don't bury blockers in a summary.
+
+### 1. Read the issue + its full acceptance criteria
+
+```bash
+gh issue view <N> --repo NewKrok/nape-js --json number,title,body,state,labels,comments
+```
+
+Most issues carry a multi-checkbox acceptance list and may reference other files
+("could be its own micro-issue", "the equivalent in …"). Extract every checkbox and
+every concrete ask (e.g. "add a `PROTOCOL_VERSION` constant") into your todo list —
+that list is the definition of done.
+
+### 2. **Check for an existing PR — and assess how well it satisfies the issue**
+
+> This is the step that's easy to skip and expensive to skip. Always do it before
+> writing any code.
+
+```bash
+# PRs that explicitly close it, or mention the number anywhere:
+gh pr list --repo NewKrok/nape-js --state all --search "<N>" --json number,title,state,headRefName,body,url
+# Broader net by topic — contributors forget the `Closes #N` keyword:
+gh pr list --repo NewKrok/nape-js --state open --json number,title,headRefName,url
+```
+
+For every candidate PR, pull the real diff and judge it against the Step 1 checklist
+— do not trust the PR's "Closes #N" claim at face value:
+
+```bash
+gh pr view <PR> --repo NewKrok/nape-js --json additions,deletions,changedFiles,files,body,mergeable,state
+gh pr diff <PR> --repo NewKrok/nape-js
+```
+
+Produce an explicit **coverage table**: for each acceptance checkbox, mark
+covered / partial / not-covered by the existing PR(s). Then decide and **tell the
+user the decision with the table** before proceeding:
+
+- **PR fully satisfies the issue** → don't duplicate work. Recommend `/pr-review`
+  on that PR instead, or (if it forgot the keyword) note it closes the issue.
+- **PR is a genuine partial slice** (the common case) → keep it, and scope your
+  work to the *remaining* boxes only. In your PR body, credit the existing PR and
+  spell out which boxes it ticked vs which yours adds, so the two don't collide.
+- **PR is stale / wrong / abandoned** → say why, and proceed with a fresh,
+  complete implementation.
+
+When in doubt about whether to extend vs. replace, ask the user (AskUserQuestion).
+
+### 3. Understand the code under test/change
+
+Read the source files named in the issue and their existing tests so new work
+matches surrounding idiom (naming, comment density, test-mock patterns). Reuse the
+existing test harness/mocks rather than inventing new ones.
+
+### 4. Branch + implement
+
+Branch off `master` (never commit to `master` directly). Follow repo conventions:
+`strict` TypeScript, no DOM deps, conventional-commit subjects. Scope strictly to
+the remaining boxes from Step 2 — don't expand the issue.
+
+### 5. Pre-push checklist — all four must pass
+
+```bash
+npm run format:check
+npm run lint
+npm test
+npm run build
+```
+
+`build` catches DTS/type errors that vitest misses. If any fails, fix before pushing.
+
+### 6. Push + open PR
+
+```bash
+git push -u origin <branch>
+gh pr create --repo NewKrok/nape-js --base master --title "<conventional title>" --body "<body>"
+```
+
+PR body must: reference the issue (`Closes #N` only if it fully closes it, else
+`Refs #N` + a checklist of which boxes this PR adds vs. which remain), credit any
+existing partial PR from Step 2, and list the test command. End with the standard
+Claude Code attribution footer.
+
+### 7. Report
+
+Summarize: the coverage decision from Step 2, what was implemented, pre-push results,
+and the PR link.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ A fully typed TypeScript 2D physics engine — modernized rewrite of the origina
 - **Replay** — `Recorder` + `Player` with input-log recording, keyframe scrub, binary encode/decode (`@newkrok/nape-js/replay`)
 - **Debug draw** — abstract `DebugDraw` interface, reference impls for Canvas/Three.js/PixiJS/p5.js
 - **Character controller** — geometric collide-and-slide (`CharacterController` class)
-- **~123 KB** minified ESM bundle (~27 KB gzip), TSDoc documented, 5761 engine tests + 71 pixi-adapter tests
+- **~123 KB** minified ESM bundle (~27 KB gzip), TSDoc documented, 6169 engine tests + 73 pixi-adapter tests
 
 ## Repo Layout (npm workspaces)
 
@@ -59,7 +59,7 @@ npm run format:check # prettier across both workspaces
 
 1. `npm run format:check` — must pass (Prettier code style, both packages)
 2. `npm run lint` — must pass (ESLint, both packages)
-3. `npm test` — all tests must pass (5761 + 71)
+3. `npm test` — all tests must pass (6169 + 73)
 4. `npm run build` — DTS generation must succeed (catches type errors vitest misses)
 
 ## Release (per-package, auto)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ To save a round-trip, please:
    ```bash
    npm run format:check    # Prettier (auto-fix with `npm run format`)
    npm run lint            # ESLint
-   npm test                # Vitest (5761 + 71 tests baseline)
+   npm test                # Vitest (6169 + 73 tests baseline)
    npm run build           # tsup — catches type errors that vitest doesn't
    ```
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ present, with automatic `postMessage` fallback otherwise.
 ```bash
 npm install
 npm run build      # tsup → packages/*/dist/ (ESM + CJS + DTS)
-npm test           # vitest — 5761 engine tests + 71 pixi-adapter tests
+npm test           # vitest — 6169 engine tests + 73 pixi-adapter tests
 npm run benchmark  # Performance benchmarks
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Completed Items
 
-Done: P21-P28, P30-P33, P35, P37-P43, P44, P45-P48, P50-P57, P60, P62, P63, P64, P66-P68, P69, P70, P71.
+Done: P21-P28, P30-P33, P35, P37-P43, P44, P45-P48, P50-P57, P60, P62, P63, P64, P66-P68, P69, P70, P71, P72, P76, P78, P79, P80, P81, P82, P85.
 Done (partial): P65 — platformer template + `/templates` page shipped; the `create-nape-game` CLI is implemented but **on hold** (kept private, not published) until adoption signal justifies the maintenance surface.
 Cancelled: P34 (tree shaking — architectural limit), P36 (server demos — superseded by P52), P49 (ECS adapter — trivial pattern).
 
@@ -39,12 +39,11 @@ already saturated.
 
 | #   | Priority                  | Effort | Impact          | Notes                                                                                                                                                                                                                                                              |
 | --- | ------------------------- | ------ | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P75 | **More game templates**   | M      | :fire: adoption | Follow-ups to the platformer: top-down car, pinball, ragdoll fighter, top-down shooter. Each adds another card on `/templates`. **Follow-up:** re-surface the `Templates` tab on the homepage (currently removed — only one starter justified hiding it) and decide whether to revive `create-nape-game` (currently `private: true`, parked) once template count grows |
-| P72 | **`convexCast` demo**     | S      | docs            | `Space.convexCast` / `convexMultiCast` is public API but invisible in the demo grid. A swept-shape hit-prediction demo (e.g. swung sword) makes it discoverable           |
+| P75 | **More game templates**   | M      | :fire: adoption | Standalone demos shipped (ragdoll #179, thrust-runner #181, block-stacking #182, minigolf #183, top-down kart #184, pulley #197, tilt-maze #200). **Remaining:** promote the strongest of these into a first-class `/templates` starter (clone/StackBlitz), re-surface the `Templates` tab on the homepage, and decide whether to revive `create-nape-game` (currently `private: true`, parked) once template count grows |
 | P61 | **Bundle size reduction** | S-M    | competitiveness | 123 KB vs Phaser Box2D 65 KB, gap is widening (+~36 KB from recent helpers). Real adoption blocker. Dead-code audit, hot-path review, helper opt-in re-export plan        |
 | P58 | **Phaser plugin/adapter** | M      | :fire: adoption | #1 JS game framework. Worth doing now that the platformer template is live — adapters need a working onboarding story to demo against                                     |
 | P59 | **React/R3F integration** | M      | adoption        | `@react-three/rapier`-style package for the React gamedev community. After P58                                                                                            |
-| P29 | Test coverage → 80%       | L      | safety          | :diamonds: ~72% statements (5761 tests). Background work, not blocking anything                                                                                           |
+| P29 | Test coverage → 80%       | L      | safety          | :diamonds: 6169 tests (+73 pixi). Background work, not blocking anything. Recent closes: #161, #163, #164, #165, #166, #168, #169, #170                                   |
 
 ---
 
@@ -61,10 +60,9 @@ Not blocking anything; revisit only when a concrete user request justifies the c
 
 ## Recommended Execution Order
 
-1. **P75** — More game templates (top-down car, pinball, ragdoll fighter); reuses the platformer pipeline (the CLI stays parked until template count or user demand justifies it)
-2. **P72** — `convexCast` demo (small, ships the visibility win quickly)
-3. **P61** — Bundle size reduction
-4. **P58** — Phaser plugin/adapter
-5. **P59** — React/R3F integration
-6. **P29** — Continue test coverage push toward 80% (background)
-7. (Defer **P73** and **P74** until a concrete user request appears)
+1. **P75** — Promote a shipped demo into a first-class `/templates` starter (the standalone game demos are done; the CLI stays parked until template count or user demand justifies it)
+2. **P61** — Bundle size reduction
+3. **P58** — Phaser plugin/adapter
+4. **P59** — React/R3F integration
+5. **P29** — Continue test coverage push toward 80% (background)
+6. (Defer **P73** and **P74** until a concrete user request appears)

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -70,7 +70,7 @@ packages/nape-pixi/tests/
 └── workerProtocol.test.ts
 ```
 
-**5761 engine tests across 254 files, plus 71 pixi-adapter tests across 5 files.**
+**6169 engine tests across 279 files, plus 73 pixi-adapter tests across 5 files.**
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation-only sync to reflect recently merged work and closed issues. No engine/source changes.

- **Test counts** updated everywhere from the stale `5761 + 71` baseline to the current **`6169 + 73`** (engine 279 files, pixi 5 files): `CLAUDE.md` (2×), `README.md`, `CONTRIBUTING.md`, `docs/guides/testing.md`, and the `pr-review` skill regression baseline.
- **ROADMAP.md:**
  - Moved into **Completed**: P72 (`convexCast` demo, #151) and the shipped game demos P76, P78, P79, P80, P81, P82, P85.
  - Removed **P72** from Active Priorities + execution order (demo shipped).
  - Rewrote **P75** — the standalone game demos are done (#179/#181/#182/#183/#184/#197/#200); remaining work is promoting one into a first-class `/templates` starter + reviving the parked CLI decision.
  - Refreshed the **P29** coverage line: `6169 tests (+73 pixi)` and the list of closed test tickets (#161, #163–#166, #168–#170).

Bundle size (~123 KB / ~27 KB gzip) was re-measured and is unchanged, so those numbers were left as-is.

## Verification

All four pre-push checks pass on this branch:

- ✅ `npm run format:check`
- ✅ `npm run lint`
- ✅ `npm test` — 6169 engine + 73 pixi
- ✅ `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)