### PR TITLE
feat(docs): add Dirtline — hill-climb motorbike demo with welded ragdoll rider (#214)

### DIFF
--- a/docs/demo-categories.js
+++ b/docs/demo-categories.js
@@ -29,6 +29,7 @@ export const GAME_DEMO_IDS = new Set([
   "brickline",
   "tinywheels-cup",
   "tiltrun",
+  "dirtline",
 ]);
 
 export const CATEGORIES = [

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -197,6 +197,8 @@ const TORSO_LEAN_LERP = 0.12;   // how fast the torso eases to the new lean targ
 // Legs extend with the lean too (rider pushes up off the pegs), so the whole
 // body shifts — not just the torso. Hip opens by this much at full lean.
 const LEG_LEAN = 0.5;           // rad the hip opens (extends the leg) on lean
+const FOOT_ANGLE_SLACK = 0.25;  // ± rad the foot may rotate around the peg — keeps
+                                // the sole sitting on the peg, not dangling free
 
 // ── Module state ────────────────────────────────────────────────────────────
 let _space = null;
@@ -435,6 +437,16 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
       d.frequency = 6;
       d.damping = 0.7;
       _pegJoints.push(d);
+      // Hold the FOOT at a fixed orientation on the peg (the sole rests flat,
+      // not dangling) with a soft AngleJoint to the chassis. A ± window keeps it
+      // soft enough that the leg can still shift a little on a lean. It breaks
+      // away with the other peg joints on a crash (it's in _pegJoints).
+      const footRest = leg.shin.rotation - chassis.rotation;
+      const foot = new AngleJoint(chassis, leg.shin, footRest - FOOT_ANGLE_SLACK, footRest + FOOT_ANGLE_SLACK);
+      foot.stiff = false;
+      foot.frequency = 6;
+      foot.damping = 0.7;
+      _pegJoints.push(foot);
     }
   }
   for (const j of _gripJoints) j.space = space;

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -1,6 +1,6 @@
 import {
   Body, BodyType, Vec2, Circle, Polygon, Material, InteractionFilter,
-  SpringJoint, LineJoint, MotorJoint, PivotJoint, AngleJoint, WeldJoint,
+  SpringJoint, LineJoint, MotorJoint, PivotJoint, AngleJoint, WeldJoint, DistanceJoint,
 } from "../nape-js.esm.js";
 
 // Dirtline — a side-view hill-climb / trials motorbike with an articulated
@@ -189,11 +189,14 @@ const CRASH_SPIN_FRAMES = 14;   // ~0.23s of that spin before the rider bails
 const POSE_SOFT = 0.04;         // half-width of each hinge's rest window
 // Torso lean: how far the rider's upper body shifts when you lean the bike, and
 // the cap on forward dip so the torso can't fold down into the bike body.
-const TORSO_LEAN_BACK = -0.5;   // rad added to the torso rest angle on lean-back
-const TORSO_LEAN_FWD = 0.22;    // rad added on lean-forward (positive = nose-down)
-const TORSO_FWD_MAX = 0.22;     // hard cap on forward torso tilt past rest so the
+const TORSO_LEAN_BACK = -0.65;  // rad added to the torso rest angle on lean-back (×1.3)
+const TORSO_LEAN_FWD = 0.29;    // rad added on lean-forward (positive = nose-down) (×1.3)
+const TORSO_FWD_MAX = 0.29;     // hard cap on forward torso tilt past rest so the
                                 // upper body can't fold flat onto the bike
 const TORSO_LEAN_LERP = 0.12;   // how fast the torso eases to the new lean target
+// Legs extend with the lean too (rider pushes up off the pegs), so the whole
+// body shifts — not just the torso. Hip opens by this much at full lean.
+const LEG_LEAN = 0.5;           // rad the hip opens (extends the leg) on lean
 
 // ── Module state ────────────────────────────────────────────────────────────
 let _space = null;
@@ -217,6 +220,8 @@ let _riderJoints = [];
 let _torsoHinge = null;       // pelvis→torso AngleJoint, retargeted on lean
 let _torsoBase = 0;           // its built rest angle (the upright seated pose)
 let _torsoLean = 0;           // current eased lean offset applied to the torso
+let _legHinges = [];          // [{ joint, base }] hip + knee hinges, retargeted on
+                              // lean so the legs extend/tuck with the weight shift
 let _crashed = false;
 let _flipFrames = 0;
 let _spinFrames = 0;
@@ -248,6 +253,7 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   _riderJoints = [];
   _gripJoints = [];
   _pegJoints = [];
+  _legHinges = [];
 
   const add = (body) => { _riderParts.push(body); return body; };
 
@@ -369,8 +375,10 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     thigh.shapes.add(new Polygon(Polygon.box(thighLen, legW), RM(0.5)));
     try { thigh.userData._colorIdx = 2; } catch (_) {}
     thigh.space = space;
-    hips.push(poseHinge(pelvis, thigh, new Vec2(8, 4), new Vec2(-thighLen / 2, 0),
-      { freq: 4, damp: 0.6 }));
+    const hipH = poseHinge(pelvis, thigh, new Vec2(8, 4), new Vec2(-thighLen / 2, 0),
+      { freq: 9, damp: 0.8 });  // firmer so retargeting actually swings the leg
+    hips.push(hipH);
+    _legHinges.push(hipH);      // retargeted on lean to extend/tuck the legs
 
     const kneeX = hipX + Math.cos(ta) * thighLen;
     const kneeY = hipY + Math.sin(ta) * thighLen;
@@ -412,11 +420,21 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     }
   }
   if (chassis && pegLocal) {
+    // Feet use a SOFT DistanceJoint (not a rigid pivot) so the foot stays near
+    // the peg but the leg can EXTEND when the rider shifts weight on a lean —
+    // a rigid pin locked the leg and killed that motion. jointMin=0 lets the
+    // foot pull in; jointMax gives a little slack; the soft spring keeps it on
+    // the peg under normal riding.
     for (const leg of [lLeg, rLeg]) {
-      _pegJoints.push(new PivotJoint(
+      const d = new DistanceJoint(
         chassis, leg.shin,
         new Vec2(pegLocal.x, pegLocal.y), new Vec2(shinLen / 2, 0),
-      ));
+        0, 10,
+      );
+      d.stiff = false;
+      d.frequency = 6;
+      d.damping = 0.7;
+      _pegJoints.push(d);
     }
   }
   for (const j of _gripJoints) j.space = space;
@@ -629,6 +647,7 @@ function teardownBikeAndRider() {
   _chassis = _fWheel = _rWheel = _swingarm = _rider = null;
   _torsoHinge = null;
   _torsoLean = 0;
+  _legHinges = [];
 }
 
 function respawn() {
@@ -826,6 +845,17 @@ export default {
       const t = _torsoBase + Math.min(TORSO_FWD_MAX, _torsoLean);
       _torsoHinge.jointMin = t - POSE_SOFT;
       _torsoHinge.jointMax = t + POSE_SOFT;
+
+      // Legs extend with the lean too: lean-back pushes the legs out (rider rises
+      // off the pegs), lean-forward tucks them. _torsoLean is negative on
+      // lean-back, so scale the hip offset off it for a synced whole-body shift.
+      const legOffset = (_torsoLean / Math.abs(TORSO_LEAN_BACK)) * -LEG_LEAN;
+      for (const h of _legHinges) {
+        if (!h || !h.joint || h.joint.space === null) continue;
+        const a = h.base + legOffset;
+        h.joint.jointMin = a - POSE_SOFT;
+        h.joint.jointMax = a + POSE_SOFT;
+      }
     }
 
     // ── Distance HUD ───────────────────────────────────────────────────────

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -196,9 +196,6 @@ const TORSO_FWD_MAX = 0.29;     // hard cap on forward torso tilt past rest so t
 const TORSO_LEAN_LERP = 0.12;   // how fast the torso eases to the new lean target
 // Legs extend with the lean too (rider pushes up off the pegs), so the whole
 // body shifts — not just the torso. Hip opens by this much at full lean.
-const LEG_LEAN = 0.5;           // rad the hip opens (extends the leg) on lean
-const FOOT_ANGLE_SLACK = 0.25;  // ± rad the foot may rotate around the peg — keeps
-                                // the sole sitting on the peg, not dangling free
 
 // ── Module state ────────────────────────────────────────────────────────────
 let _space = null;
@@ -222,9 +219,6 @@ let _riderJoints = [];
 let _torsoHinge = null;       // pelvis→torso AngleJoint, retargeted on lean
 let _torsoBase = 0;           // its built rest angle (the upright seated pose)
 let _torsoLean = 0;           // current eased lean offset applied to the torso
-let _legExtend = 0;           // eased 0→1: how much the legs are extended on a lean
-let _legHinges = [];          // [{ joint, base }] hip hinges, retargeted on lean so
-                              // the legs extend with the weight shift
 let _crashed = false;
 let _flipFrames = 0;
 let _spinFrames = 0;
@@ -256,7 +250,6 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   _riderJoints = [];
   _gripJoints = [];
   _pegJoints = [];
-  _legHinges = [];
 
   const add = (body) => { _riderParts.push(body); return body; };
 
@@ -378,11 +371,8 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     thigh.shapes.add(new Polygon(Polygon.box(thighLen, legW), RM(0.5)));
     try { thigh.userData._colorIdx = 2; } catch (_) {}
     thigh.space = space;
-    const hipH = poseHinge(pelvis, thigh, new Vec2(8, 4), new Vec2(-thighLen / 2, 0),
-      { freq: 14, damp: 0.85 }); // firm: with no pelvis weld, the hips hold the
-                                 // seated posture up (and let lean swing the leg)
-    hips.push(hipH);
-    _legHinges.push(hipH);      // retargeted on lean to extend/tuck the legs
+    hips.push(poseHinge(pelvis, thigh, new Vec2(8, 4), new Vec2(-thighLen / 2, 0),
+      { freq: 14, damp: 0.85 }));  // firm hip holds the seated leg posture
 
     const kneeX = hipX + Math.cos(ta) * thighLen;
     const kneeY = hipY + Math.sin(ta) * thighLen;
@@ -646,8 +636,6 @@ function teardownBikeAndRider() {
   _chassis = _fWheel = _rWheel = _swingarm = _rider = null;
   _torsoHinge = null;
   _torsoLean = 0;
-  _legExtend = 0;
-  _legHinges = [];
 }
 
 function respawn() {
@@ -846,17 +834,8 @@ export default {
       const t = _torsoBase + Math.max(-Math.abs(TORSO_LEAN_BACK), Math.min(TORSO_FWD_MAX, _torsoLean));
       _torsoHinge.jointMin = t - POSE_SOFT;
       _torsoHinge.jointMax = t + POSE_SOFT;
-
-      // Leg extension: extend on EITHER lean (rider rises off the pegs / stretches),
-      // bent when neutral. _legExtend eases 0→1; the hip opens by LEG_LEAN.
-      const wantExtend = (leanBack || leanFwd) ? 1 : 0;
-      _legExtend += (wantExtend - _legExtend) * TORSO_LEAN_LERP;
-      for (const h of _legHinges) {
-        if (!h || !h.joint || h.joint.space === null) continue;
-        const a = h.base - LEG_LEAN * _legExtend;   // open the hip → leg straightens
-        h.joint.jointMin = a - POSE_SOFT;
-        h.joint.jointMax = a + POSE_SOFT;
-      }
+      // Note: the legs are pinned at a fixed point on the pegs, so the visible
+      // weight shift comes from the torso; the legs intentionally stay planted.
     }
 
     // ── Distance HUD ───────────────────────────────────────────────────────

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -1,6 +1,7 @@
 import {
   Body, BodyType, Vec2, Circle, Polygon, Material, InteractionFilter,
   SpringJoint, LineJoint, MotorJoint, PivotJoint, AngleJoint, WeldJoint,
+  ParticleEmitter,
 } from "../nape-js.esm.js";
 
 // Dirtline — a side-view hill-climb / trials motorbike with an articulated
@@ -25,7 +26,8 @@ const SCREEN_H = 500;
 const BUILD_RIDER = true;
 
 // ── World / terrain ─────────────────────────────────────────────────────────
-const WORLD_W = 6000;
+const WORLD_W = 18000;          // 3× the old 6000 — a long course with room for
+                                // several big jumps spread out between the hills
 const SEG_W = 24;               // terrain sample spacing (fine enough that the
                                 // ramp lips read as smooth launches, not steps)
 const GRAVITY = 1100;
@@ -37,12 +39,25 @@ const GRAVITY = 1100;
 // bump: a long gentle approach up the front and a sharp drop off the back, so
 // you hit it, get launched, and have to control rotation before landing. Folded
 // into terrainY so the surface stays continuous (no seams to snag a wheel on).
+// Mixed-size kickers spread across the long (18000px) course. The small ones
+// (up ≈ 46-62) are the original gentle launches; interleaved between them are a
+// handful of BIG jumps (up ≈ 100-150, with a long approach `w`) that throw the
+// bike for real air — land them clean or over-rotate and eat it.
 const RAMPS = [
   { x: 1100, up: 46, w: 220 },
-  { x: 2200, up: 56, w: 250 },
-  { x: 3300, up: 50, w: 230 },
-  { x: 4400, up: 62, w: 260 },
-  { x: 5300, up: 54, w: 240 },
+  { x: 2400, up: 120, w: 360 },   // big #1
+  { x: 3500, up: 54, w: 240 },
+  { x: 4700, up: 56, w: 250 },
+  { x: 6000, up: 150, w: 420 },   // big #2 — the course's biggest
+  { x: 7300, up: 50, w: 230 },
+  { x: 8600, up: 62, w: 260 },
+  { x: 9900, up: 130, w: 380 },   // big #3
+  { x: 11200, up: 52, w: 240 },
+  { x: 12500, up: 58, w: 250 },
+  { x: 13900, up: 140, w: 400 },  // big #4
+  { x: 15200, up: 50, w: 230 },
+  { x: 16400, up: 110, w: 350 },  // big #5
+  { x: 17300, up: 54, w: 240 },
 ];
 
 function rampLift(x) {
@@ -102,6 +117,22 @@ function buildTerrain(space, groundY) {
 // Terrain bodies keep the default filter (group 1, mask −1 → hits everything).
 const GROUP_TERRAIN = 1;
 const BIKE_FILTER = new InteractionFilter(2, GROUP_TERRAIN);   // collides only w/ terrain
+// Kicked-up gravel particles: their own group (bit 3), and they collide ONLY
+// with the terrain (mask = GROUP_TERRAIN). So gravel never touches the bike, the
+// rider, or other gravel — it only bounces and skitters on the track, exactly
+// the "wheel throws dirt, but the dirt doesn't hit the bike" ask.
+const GROUP_GRAVEL = 4;        // bit 3
+const GRAVEL_FILTER = new InteractionFilter(GROUP_GRAVEL, GROUP_TERRAIN);
+
+// ── Gravel spray tuning ──────────────────────────────────────────────────────
+// A moving wheel in contact with the track flings gravel backward off its
+// contact patch. Emission scales with wheel speed so a fast/spinning wheel
+// sprays more; a parked wheel sprays none. Particles are real dynamic bodies
+// (pooled by the emitter) that only collide with the terrain.
+const GRAVEL_MAX = 90;          // pool cap — plenty of medium-count debris
+const GRAVEL_MIN_SPEED = 90;    // px/s wheel surface speed below which no spray
+const GRAVEL_RATE_MAX = 70;     // particles/sec at full chat (scaled by speed)
+const GRAVEL_R = 2.2;           // medium pebble radius
 
 // ── Bike tuning ─────────────────────────────────────────────────────────────
 // Realistic crossmotor (dirt-bike) proportions: smaller wheels relative to a
@@ -143,13 +174,16 @@ const SHOCK_MAX = 12;           // a little top-out travel
 const SWINGARM_PIVOT = { x: -22, y: 8 };
 const SHOCK_TOP = { x: -44, y: -12 };
 
-const MOTOR_RATE = 30;          // rear-wheel motor target angular rate. Kept
-                                // moderate ON PURPOSE: cranking it higher just
-                                // spins the wheel faster than it can grip (heavy
-                                // wheelspin → the bike surges/bogs). Grip + a
-                                // sane rate give smooth, fast power delivery.
-const MOTOR_FORCE = 75000;      // torque cap — moderate so acceleration doesn't
-                                // break traction (or loft the front into a flip).
+const MOTOR_RATE = 48;          // rear-wheel motor target angular rate. Raised
+                                // for a notably faster top speed; paired with a
+                                // bigger MOTOR_FORCE so the wheel actually REACHES
+                                // this rate under load instead of bogging. Grip
+                                // (high wheel friction) keeps the extra power from
+                                // turning straight into wheelspin.
+const MOTOR_FORCE = 130000;     // torque cap — raised so the engine pulls hard and
+                                // holds the higher rate up climbs. The progressive
+                                // cap still limits a standstill launch from looping
+                                // the front, but the bike now feels much stronger.
 // Ground lean drives the chassis toward a TARGET pitch rate and holds it there,
 // strong enough to overpower the wheels' tendency to cancel the rotation each
 // frame (a gentle nudge just gets absorbed — that's why leaning felt dead).
@@ -239,6 +273,32 @@ const KNEE_STRAIGHTEN_BACK = 1.1;
 const PELVIS_TILT_FWD = 0.15;   // rad the pelvis tips forward (nose-down) on fwd lean
 const PELVIS_TILT_BACK = -0.3;  // rad the pelvis reclines on back lean (sits back)
 
+// ── Crash ragdoll tuning ─────────────────────────────────────────────────────
+// On a bail the rider goes ragdoll but must KEEP A HUMAN SHAPE — the earlier very
+// loose, low-frequency joints let the torso/neck/limbs collapse onto each other
+// (the "crumpled heap" look). The fix: keep the windows fairly TIGHT around each
+// joint's rest pose and the springs FIRM. The body still tumbles and flails as a
+// unit, but the spine stays roughly its length, the head sits off the chest, and
+// the legs hold their proportion — a thrown dummy, not a sack.
+const RAGDOLL_LIMB_RANGE = 0.6; // rad — elbow/knee swing range (~34°): enough life
+                                // to bend, tight enough to keep the limb proportion
+const RAGDOLL_LIMB_FREQ = 9;    // firm spring on the limb links so they don't fold
+const RAGDOLL_LIMB_DAMP = 0.8;
+const RAGDOLL_LOOSE_RANGE = 0.6;// rad — torso/shoulders/hips/neck swing ~34°: enough
+                                // to drape and tumble, tight enough that the spine,
+                                // neck and hips keep their length (no collapse)
+const RAGDOLL_LOOSE_FREQ = 11;  // firm spring — verified to hold the body shape to
+                                // ~1% length change on a hard landing (was ~18%)
+const RAGDOLL_LOOSE_DAMP = 0.8;
+// Bail launch — a GENTLE separation, not a violent ejection. The earlier strong
+// kick + 0.9 velocity-inherit flung the rider off absurdly fast. The rider now
+// keeps only a little of the bike's momentum plus a soft nudge, so it tips off
+// the bike and tumbles rather than rocketing away.
+const BAIL_KICK_X = -40;        // px/s backward (a small shove off the bike)
+const BAIL_KICK_Y = -90;        // px/s up (just enough to clear the seat)
+const BAIL_INHERIT = 0.45;      // keep under half the chassis velocity — separates
+                                // from the bike without the ragdoll flying off hard
+
 // ── Module state ────────────────────────────────────────────────────────────
 let _space = null;
 let _chassis = null;
@@ -262,9 +322,16 @@ let _torsoHinge = null;       // pelvis→torso AngleJoint, retargeted on lean
 let _torsoBase = 0;           // its built rest angle (the upright seated pose)
 let _torsoLean = 0;           // current eased lean offset applied to the torso
 let _kneeHinges = [];         // [{ joint, base }] knee hinges, straightened on lean
+let _angleHinges = [];        // [{ joint, base }] EVERY rider AngleJoint + its rest
+                              // angle — on a crash we slacken each into a loose but
+                              // BOUNDED window around `base` so the body ragdolls
+                              // with believable anatomical limits (a limp limb that
+                              // still can't hyperextend) instead of folding flat.
 let _legExtend = 0;           // eased 0→1: how straight the legs are on a lean
 let _seatLift = 0;            // eased 0→1: how far the rider has risen off the seat
 let _seatShift = 0;           // eased −1..1: fore(+)/aft(−) seat anchor shift
+let _gravelF = null;          // front-wheel gravel spray emitter
+let _gravelR = null;          // rear-wheel gravel spray emitter
 let _crashed = false;
 let _flipFrames = 0;
 let _spinFrames = 0;
@@ -297,6 +364,7 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   _gripJoints = [];
   _pegJoints = [];
   _kneeHinges = [];
+  _angleHinges = [];
 
   const add = (body) => { _riderParts.push(body); return body; };
 
@@ -313,7 +381,7 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   // exactly the built silhouette. A stiff joint rigidly commands the pose
   // (needed to posture a limb against gravity); soft joints get a little life.
   const poseHinge = (a, b, anchorA, anchorB, opts = {}) => {
-    const { stiff = false, freq = 13, damp = 0.85 } = opts;
+    const { stiff = false, freq = 13, damp = 0.85, limbLink = false } = opts;
     const pin = new PivotJoint(a, b, anchorA, anchorB);
     pin.space = space;
     _riderJoints.push(pin);
@@ -328,7 +396,14 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     }
     ang.space = space;
     _riderJoints.push(ang);
-    return { joint: ang, base };            // (return kept for symmetry; unused)
+    // limbLink marks the two-segment joints (elbow, knee) whose RELATIVE angle
+    // must stay believable on a crash — those keep a real limit so the forearm
+    // doesn't fold through the upper arm / the shin through the thigh. Every
+    // other joint (shoulder, hip, torso, head, neck) goes fully loose so the
+    // ragdoll sprawls out naturally instead of holding a rigid posture.
+    const hinge = { joint: ang, base, limbLink };
+    _angleHinges.push(hinge);               // tracked for crash-time slackening
+    return hinge;
   };
 
   // Lighter limbs than the bike so the rider doesn't overpower the suspension.
@@ -350,7 +425,13 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   torso.shapes.add(new Polygon(Polygon.box(14, 30), RM(0.5)));
   try { torso.userData._colorIdx = 1; } catch (_) {}
   torso.space = space;
-  new PivotJoint(pelvis, torso, new Vec2(0, -5), new Vec2(-2, 15)).space = space;
+  // The pelvis↔torso pin MUST be tracked in _riderJoints so teardown detaches it
+  // on respawn — an untracked joint here left a dangling PivotJoint in the space
+  // every reset, which threw "Constraints must have each body within the same
+  // space" on the next step after rebuilding the rig.
+  const torsoPin = new PivotJoint(pelvis, torso, new Vec2(0, -5), new Vec2(-2, 15));
+  torsoPin.space = space;
+  _riderJoints.push(torsoPin);
   _torsoBase = torso.rotation - pelvis.rotation;
   _torsoHinge = new AngleJoint(pelvis, torso, _torsoBase - POSE_SOFT, _torsoBase + POSE_SOFT);
   // STIFF: the torso angle is posture-critical and must win against the pull of
@@ -361,6 +442,7 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   _torsoHinge.stiff = true;
   _torsoHinge.space = space;
   _riderJoints.push(_torsoHinge);
+  _angleHinges.push({ joint: _torsoHinge, base: _torsoBase });
 
   // Head — sits atop the torso, follows its lean.
   const head = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + 7, seatY - 44)));
@@ -400,7 +482,9 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     try { lower.userData._colorIdx = 2; } catch (_) {}
     lower.space = space;
     elbows.push(poseHinge(upper, lower, new Vec2(armLen / 2, 0), new Vec2(-armLen / 2, 0),
-      { freq: 4, damp: 0.5 }));   // soft elbow → the arm bends/relaxes on the bars
+      { freq: 4, damp: 0.5, limbLink: true }));   // soft elbow → the arm bends/relaxes
+                                  // on the bars; limbLink keeps the forearm↔upper-arm
+                                  // angle sane when the rider goes ragdoll
     return { upper, lower };
   };
   const lArm = buildArm();
@@ -435,7 +519,8 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     try { shin.userData._colorIdx = 2; } catch (_) {}
     shin.space = space;
     const kneeH = poseHinge(thigh, shin, new Vec2(thighLen / 2, 0), new Vec2(-shinLen / 2, 0),
-      { freq: 12, damp: 0.85 });
+      { freq: 12, damp: 0.85, limbLink: true });   // limbLink keeps the shin↔thigh
+                                  // angle sane on a crash (no shin folding through)
     knees.push(kneeH);
     _kneeHinges.push(kneeH);    // straightened on lean to extend the leg
     return { thigh, shin };
@@ -691,6 +776,7 @@ function teardownBikeAndRider() {
   _torsoHinge = null;
   _torsoLean = 0;
   _kneeHinges = [];
+  _angleHinges = [];
   _legExtend = 0;
   _seatLift = 0;
   _seatShift = 0;
@@ -719,20 +805,36 @@ function bailRider() {
   for (const j of _pegJoints) { if (j.space) j.space = null; }
   _gripJoints = [];
   _pegJoints = [];
-  // A small backward+up kick on the pelvis so the rider visibly tumbles off
-  // the back rather than sitting in place.
-  if (_rider && _rider.pelvis && _rider.pelvis.space) {
-    const v = _rider.pelvis.velocity;
-    _rider.pelvis.velocity = new Vec2(v.x - 120, v.y - 160);
+  // Gently separate the rider from the bike — it tips off and tumbles, it does
+  // not get ejected. Each part keeps a fraction of the bike's velocity plus a
+  // soft nudge (direction follows travel so a reversing crash sheds it forward).
+  const cv = _chassis && _chassis.space ? _chassis.velocity : new Vec2(0, 0);
+  const dir = cv.x < 0 ? -1 : 1;
+  const launchX = cv.x * BAIL_INHERIT + BAIL_KICK_X * dir;
+  const launchY = cv.y * BAIL_INHERIT + BAIL_KICK_Y;
+  for (const b of _riderParts) {
+    if (!b || !b.space) continue;
+    b.velocity = new Vec2(launchX, launchY);
+    b.angularVel += (b === _rider.pelvis ? -2 : -1);   // a little tumble
   }
-  // Throw every limb hinge window wide so the freed rider flops loosely
-  // instead of holding its seated shape.
-  for (const j of _riderJoints) {
-    if (j.jointMin !== undefined && j.jointMax !== undefined) {
-      j.jointMin = -Math.PI;
-      j.jointMax = Math.PI;
-      j.frequency = 2;
-      j.damping = 0.3;
+  // Go limp and sprawl. Limb links (elbow/knee) keep a bounded but generous soft
+  // window so the limb stays in proportion without folding through itself; every
+  // other joint goes very loose and low-frequency so the body drapes out like a
+  // real ragdoll rather than holding a rigid pose.
+  for (const h of _angleHinges) {
+    const j = h && h.joint;
+    if (!j || j.space === null) continue;
+    j.stiff = false;
+    if (h.limbLink) {
+      j.jointMin = h.base - RAGDOLL_LIMB_RANGE;
+      j.jointMax = h.base + RAGDOLL_LIMB_RANGE;
+      j.frequency = RAGDOLL_LIMB_FREQ;
+      j.damping = RAGDOLL_LIMB_DAMP;
+    } else {
+      j.jointMin = h.base - RAGDOLL_LOOSE_RANGE;
+      j.jointMax = h.base + RAGDOLL_LOOSE_RANGE;
+      j.frequency = RAGDOLL_LOOSE_FREQ;
+      j.damping = RAGDOLL_LOOSE_DAMP;
     }
   }
 }
@@ -741,15 +843,17 @@ export default {
   id: "dirtline",
   label: "Dirtline",
   featured: false,
-  tags: ["MotorJoint", "SpringJoint", "WeldJoint", "Ragdoll", "Vehicle", "Camera", "Break-away"],
+  tags: ["MotorJoint", "SpringJoint", "WeldJoint", "Ragdoll", "Vehicle", "Camera", "Break-away", "ParticleEmitter"],
   desc:
     "Hill-climb trials bike with an articulated ragdoll rider welded to the " +
-    "seat. <b>→</b> / <b>D</b> throttle, <b>←</b> / <b>A</b> reverse, " +
-    "<b>↑</b> / <b>W</b> lean back (pop the front), <b>↓</b> / <b>S</b> lean " +
-    "forward (nose-down). Flip the bike or smack the ground hard and the rider " +
-    "breaks away and tumbles off. <b>R</b> or click to respawn. " +
-    "Showcases MotorJoint wheels on SpringJoint suspension, a ragdoll attached " +
-    "to a moving vehicle, and a break-away WeldJoint.",
+    "seat, on a long course with several big jumps. <b>→</b> / <b>D</b> " +
+    "throttle, <b>←</b> / <b>A</b> reverse, <b>↑</b> / <b>W</b> lean back " +
+    "(pop the front), <b>↓</b> / <b>S</b> lean forward (nose-down). The moving " +
+    "wheels fling physics-based gravel that skitters on the track. Flip the " +
+    "bike or smack the ground hard and the rider breaks away and ragdolls off. " +
+    "<b>R</b> or click to respawn. Showcases MotorJoint wheels on SpringJoint " +
+    "suspension, a ragdoll attached to a moving vehicle, a break-away " +
+    "WeldJoint, and a terrain-only ParticleEmitter.",
   walls: false,
 
   camera: null,
@@ -774,6 +878,35 @@ export default {
     wallR.space = space;
 
     buildBike(space, _spawnX, groundY);
+
+    // Gravel spray — one pooled emitter per wheel. Real dynamic pebbles that
+    // ONLY collide with the terrain (GRAVEL_FILTER), so they skitter on the
+    // track and never touch the bike or rider. Created disabled with rate 0;
+    // step() moves each emitter's origin onto its wheel's contact patch and
+    // dials the rate up with wheel speed, so a moving/spinning wheel flings
+    // gravel and a parked one flings none. The cone fires up-and-back (screen
+    // −y is up) — dirt kicked rearward off the contact patch.
+    const makeGravel = () => new ParticleEmitter({
+      space,
+      origin: new Vec2(0, 0),
+      velocity: { kind: "cone", direction: -2.5, spread: 0.6, speedMin: 140, speedMax: 360 },
+      rate: 0,
+      enabled: false,
+      maxParticles: GRAVEL_MAX,
+      lifetimeMin: 0.4,
+      lifetimeMax: 1.0,
+      particleRadius: GRAVEL_R,
+      // Gritty, draggy pebbles: almost no bounce (elasticity ~0) and HIGH
+      // friction (1.4 dyn / 1.6 stat) so a thrown stone bites the track and
+      // skids to a stop instead of sliding around frictionlessly — that
+      // low-friction slide was the "fluid"/runny look. Heavier (density 0.9)
+      // too, so they settle quickly rather than drifting.
+      particleMaterial: new Material(0.02, 1.4, 1.6, 0.9),
+      particleFilter: GRAVEL_FILTER,
+      bounds: { minX: -200, minY: -2000, maxX: WORLD_W + 200, maxY: SCREEN_H + 400 },
+    });
+    _gravelF = makeGravel();
+    _gravelR = makeGravel();
 
     _crashed = false;
     _flipFrames = 0;
@@ -817,12 +950,27 @@ export default {
       if (_onKeyUp) window.removeEventListener("keyup", _onKeyUp);
     }
     _onKeyDown = _onKeyUp = null;
+    if (_gravelF) { _gravelF.destroy(); _gravelF = null; }
+    if (_gravelR) { _gravelR.destroy(); _gravelR = null; }
   },
 
   step(space) {
     _frame++;
     _stepped = true;
     if (!_chassis) return;
+
+    // Once the rider has bailed (death), the bike is no longer controllable —
+    // kill the motor and ignore throttle/lean input. The chassis + wheels keep
+    // coasting on physics alone until respawn (R / click).
+    if (_crashed) {
+      if (_rMotor) _rMotor.rate = 0;
+      const DT = 1 / 60;
+      updateGravel(_gravelF, _fWheel);
+      updateGravel(_gravelR, _rWheel);
+      if (_gravelF) _gravelF.update(DT);
+      if (_gravelR) _gravelR.update(DT);
+      return;
+    }
 
     // ── Throttle (rear motor) ──────────────────────────────────────────────
     const fwd = keys.ArrowRight || keys.KeyD || keys._touchRight;
@@ -944,32 +1092,49 @@ export default {
     // angle, so the angle test alone misses it — catch it by angular speed);
     // (3) a hard ground smack. Any one breaks the seat weld and the rider bails.
     if (!_crashed) {
-      // Normalise chassis rotation into [-π, π] and measure tilt from upright.
+      // The crash rule: the rider only bails when their UPPER BODY actually hits
+      // the ground. The bike going past vertical (a flip, an endo, rolling on a
+      // steep slope, reversing into a tip-over) is NOT a crash on its own — the
+      // rider stays welded on and rides it out unless the head/torso smacks down.
+      // This matches the ask: "don't fall off when the dummy never touches the
+      // ground." We still track the flip/spin counters as a *qualifier* so a
+      // brief touch during normal riding doesn't bail — the rider must both be
+      // upended (sustained flip OR violent spin) AND have the upper body grounded.
       let rot = _chassis.rotation % (Math.PI * 2);
       if (rot > Math.PI) rot -= Math.PI * 2;
       if (rot < -Math.PI) rot += Math.PI * 2;
-      // Accumulate while past the tip angle; decay (don't hard-reset) so a fast
-      // tumble that flickers under the angle each rotation still trips it.
-      if (Math.abs(rot) > FLIP_ANGLE) _flipFrames += 1;
+      if (Math.abs(rot) > FLIP_ANGLE && !bothWheelsGrounded()) _flipFrames += 1;
       else _flipFrames = Math.max(0, _flipFrames - 2);
-      if (_flipFrames > FLIP_FRAMES) bailRider();
 
-      // Spinning out of control — a violent tumble in the air or after a bad
-      // landing. Sustained high angular speed = you've lost it.
-      if (Math.abs(_chassis.angularVel) > CRASH_SPIN_RATE) {
-        _spinFrames += 1;
-        if (_spinFrames > CRASH_SPIN_FRAMES) bailRider();
-      } else {
-        _spinFrames = Math.max(0, _spinFrames - 1);
+      if (Math.abs(_chassis.angularVel) > CRASH_SPIN_RATE) _spinFrames += 1;
+      else _spinFrames = Math.max(0, _spinFrames - 1);
+
+      const upended = _flipFrames > FLIP_FRAMES || _spinFrames > CRASH_SPIN_FRAMES;
+      if (upended && riderHeadHitsGround()) {
+        bailRider();
+        if (this._runner) this._runner.shakeCamera(6, 0.2);
       }
 
-      // Hard impact: chassis driving down fast onto the ground.
+      // Hard impact: the bike slams down fast AND the rider's upper body is driven
+      // into the ground with it (a flat landing that whips the rider down).
       const vy = _chassis.velocity.y;
-      if (vy > CRASH_IMPACT_SPEED && wheelTouchingGround()) {
+      if (vy > CRASH_IMPACT_SPEED && riderHeadHitsGround()) {
         bailRider();
         if (this._runner) this._runner.shakeCamera(8, 0.25);
       }
     }
+
+    // ── Gravel spray ─────────────────────────────────────────────────────────
+    // Each grounded, moving wheel flings gravel off its contact patch. Speed is
+    // the wheel-surface speed: forward travel plus spin (|ω|·R), so wheelspin on
+    // the gas sprays hard even before the bike moves. The emitter origin rides
+    // the bottom of the wheel; rate scales with speed. Particles only hit the
+    // terrain (GRAVEL_FILTER), never the bike/rider.
+    updateGravel(_gravelF, _fWheel);
+    updateGravel(_gravelR, _rWheel);
+    const DT = 1 / 60;
+    if (_gravelF) _gravelF.update(DT);
+    if (_gravelR) _gravelR.update(DT);
   },
 
   click(x, y, space) {
@@ -1010,15 +1175,71 @@ export default {
 // strong ground-lean). Instead we test geometry: a wheel is grounded if its
 // bottom edge is at/below the terrain surface (within a small tolerance). This
 // is independent of step order and matches what `buildTerrain` lays down.
+function wheelOnGround(w) {
+  if (!w) return false;
+  const p = w.position;
+  const surfaceY = terrainY(p.x, _spawnGroundY);
+  // wheel bottom = p.y + WHEEL_R; grounded if it's at/under the surface.
+  return p.y + WHEEL_R >= surfaceY - GROUND_TOL;
+}
 function wheelTouchingGround() {
-  const onGround = (w) => {
-    if (!w) return false;
-    const p = w.position;
-    const surfaceY = terrainY(p.x, _spawnGroundY);
-    // wheel bottom = p.y + WHEEL_R; grounded if it's at/under the surface.
-    return p.y + WHEEL_R >= surfaceY - GROUND_TOL;
+  return wheelOnGround(_rWheel) || wheelOnGround(_fWheel);
+}
+// Both wheels planted = the bike is sitting on the terrain (however steep the
+// slope), NOT flipping. The tip-over crash test ignores the angle while this is
+// true, so riding/reversing up a steep face — where the chassis can lean well
+// past the flip angle just following the ground — never triggers a bail. A real
+// flip lifts at least one wheel off the surface.
+function bothWheelsGrounded() {
+  return wheelOnGround(_rWheel) && wheelOnGround(_fWheel);
+}
+// True when the rider's UPPER BODY (head or torso) has actually been driven into
+// the terrain. This is what turns a flip into a crash: the bike tipping past
+// vertical only bails the rider if the head/torso genuinely reaches the ground —
+// standing the bike on its nose, or rolling it on a steep slope where the rider
+// never touches down, does NOT count. Geometry test against the terrain surface,
+// same approach as the wheel grounding check (step-order independent).
+function riderHeadHitsGround() {
+  if (!_rider) return false;
+  const hit = (b, r) => {
+    if (!b || !b.space) return false;
+    const p = b.position;
+    // Require a genuine touch: the part's lower edge must reach the surface (no
+    // GROUND_TOL slack here — unlike the wheels, the head shouldn't "count" while
+    // still hovering a few px above the dirt).
+    return p.y + r >= terrainY(p.x, _spawnGroundY);
   };
-  return onGround(_rWheel) || onGround(_fWheel);
+  // head is a Circle(8.5); torso a box ~30 tall → ~15 to its lower edge.
+  return hit(_rider.head, 8.5) || hit(_rider.torso, 15);
+}
+
+// Drive one wheel's gravel emitter: position its origin on the wheel's lower
+// contact patch and scale the spawn rate by the wheel-surface speed (travel +
+// spin). A grounded, fast/spinning wheel sprays; an airborne or parked one
+// doesn't. Per-wheel grounding is checked here (wheelTouchingGround() is an
+// either-wheel test, too coarse for deciding which wheel throws dirt).
+function updateGravel(emitter, wheel) {
+  if (!emitter || !wheel) return;
+  const p = wheel.position;
+  const surfaceY = terrainY(p.x, _spawnGroundY);
+  const grounded = p.y + WHEEL_R >= surfaceY - GROUND_TOL;
+  // Surface speed = how fast the contact patch moves over the ground: linear
+  // travel plus the spin component |ω|·R. Wheelspin counts even at a standstill.
+  const v = wheel.velocity;
+  const surfSpeed = Math.hypot(v.x, v.y) + Math.abs(wheel.angularVel) * WHEEL_R;
+  if (!grounded || _crashed || surfSpeed < GRAVEL_MIN_SPEED) {
+    emitter.enabled = false;
+    emitter.rate = 0;
+    return;
+  }
+  // Origin sits at the wheel bottom (the contact patch), nudged just below the
+  // surface so pebbles spawn out of the dirt.
+  emitter.origin.x = p.x;
+  emitter.origin.y = surfaceY - 1;
+  // Rate ramps from 0 at GRAVEL_MIN_SPEED up to GRAVEL_RATE_MAX, then saturates.
+  const t = Math.min(1, (surfSpeed - GRAVEL_MIN_SPEED) / 600);
+  emitter.enabled = true;
+  emitter.rate = GRAVEL_RATE_MAX * t;
 }
 
 // Draw the suspension springs (chassis anchor → wheel hub) in world space.

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -187,6 +187,13 @@ const CRASH_SPIN_FRAMES = 14;   // ~0.23s of that spin before the rider bails
 // the body hangs naturally on those points — the hinges just keep the limbs
 // from flailing, they don't pose the body rigidly.
 const POSE_SOFT = 0.04;         // half-width of each hinge's rest window
+// Torso lean: how far the rider's upper body shifts when you lean the bike, and
+// the cap on forward dip so the torso can't fold down into the bike body.
+const TORSO_LEAN_BACK = -0.5;   // rad added to the torso rest angle on lean-back
+const TORSO_LEAN_FWD = 0.22;    // rad added on lean-forward (positive = nose-down)
+const TORSO_FWD_MAX = 0.22;     // hard cap on forward torso tilt past rest so the
+                                // upper body can't fold flat onto the bike
+const TORSO_LEAN_LERP = 0.12;   // how fast the torso eases to the new lean target
 
 // ── Module state ────────────────────────────────────────────────────────────
 let _space = null;
@@ -207,6 +214,9 @@ let _gripJoints = [];         // hand→handlebar pins (break away with the seat
 let _pegJoints = [];          // foot→footpeg pins (break away with the seat weld)
 let _riderParts = [];
 let _riderJoints = [];
+let _torsoHinge = null;       // pelvis→torso AngleJoint, retargeted on lean
+let _torsoBase = 0;           // its built rest angle (the upright seated pose)
+let _torsoLean = 0;           // current eased lean offset applied to the torso
 let _crashed = false;
 let _flipFrames = 0;
 let _spinFrames = 0;
@@ -281,14 +291,24 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   try { pelvis.userData._colorIdx = 1; } catch (_) {}
   pelvis.space = space;
 
-  // Torso — slightly forward-leaning rest pose (a rider crouches a touch over
-  // the bars). Its pose delta is the visible weight shift (crouch / stand).
+  // Torso — sits fairly upright. The torso hinge is special: step() retargets
+  // its window so the rider leans the upper body forward/back WITH the bike
+  // (the visible weight shift). We keep a module ref + its rest angle, and an
+  // ASYMMETRIC window: plenty of room to sit up / lean back, but limited
+  // forward dip so the rider can't fold down into the bike body.
   const torso = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + 3, seatY - 21)));
   torso.rotation = -0.15;         // sit fairly upright (slight back lean at rest)
   torso.shapes.add(new Polygon(Polygon.box(14, 30), RM(0.5)));
   try { torso.userData._colorIdx = 1; } catch (_) {}
   torso.space = space;
-  poseHinge(pelvis, torso, new Vec2(0, -5), new Vec2(-2, 15), { freq: 9, damp: 0.8 });
+  new PivotJoint(pelvis, torso, new Vec2(0, -5), new Vec2(-2, 15)).space = space;
+  _torsoBase = torso.rotation - pelvis.rotation;
+  _torsoHinge = new AngleJoint(pelvis, torso, _torsoBase - POSE_SOFT, _torsoBase + POSE_SOFT);
+  _torsoHinge.stiff = false;
+  _torsoHinge.frequency = 13;    // strong enough to hold the torso up against the
+  _torsoHinge.damping = 0.9;     // forward pull of the arms gripping the bars
+  _torsoHinge.space = space;
+  _riderJoints.push(_torsoHinge);
 
   // Head — sits atop the torso, follows its lean.
   const head = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + 7, seatY - 44)));
@@ -607,6 +627,8 @@ function teardownBikeAndRider() {
   _riderParts = [];
   for (const b of [_chassis, _fWheel, _rWheel, _swingarm]) { if (b && b.space) b.space = null; }
   _chassis = _fWheel = _rWheel = _swingarm = _rider = null;
+  _torsoHinge = null;
+  _torsoLean = 0;
 }
 
 function respawn() {
@@ -789,11 +811,22 @@ export default {
       }
     }
 
-    // No active-pose driving: the rider is held to the bike only at the hands
-    // (handlebar) and feet (pegs), with soft limb hinges, so the body hangs and
-    // sways naturally between those four points. Leaning the bike moves the grip
-    // + peg anchors, which carries the rider's weight shift for free — no posed
-    // AngleJoint targets fighting the pins (that conflict caused the jitter).
+    // The rider is held to the bike at the hands (handlebar) and feet (pegs)
+    // with soft limb hinges, so the body hangs naturally. On top of that we
+    // shift the UPPER BODY with the lean keys: lean-back eases the torso back/up
+    // (the rider sits up and shifts weight rearward), lean-forward eases it
+    // forward over the bars. Only the torso hinge is retargeted (a soft spring,
+    // so it sways rather than snapping), and its window is clamped so the torso
+    // can't fold forward into the bike body (TORSO_FWD_MAX).
+    if (!_crashed && _torsoHinge && _torsoHinge.space) {
+      let leanTarget = 0;
+      if (leanBack) leanTarget = TORSO_LEAN_BACK;
+      else if (leanFwd) leanTarget = TORSO_LEAN_FWD;
+      _torsoLean += (leanTarget - _torsoLean) * TORSO_LEAN_LERP;
+      const t = _torsoBase + Math.min(TORSO_FWD_MAX, _torsoLean);
+      _torsoHinge.jointMin = t - POSE_SOFT;
+      _torsoHinge.jointMax = t + POSE_SOFT;
+    }
 
     // ── Distance HUD ───────────────────────────────────────────────────────
     const dist = Math.max(0, (_chassis.position.x - _spawnX));

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -330,7 +330,7 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     upper.space = space;
     shoulders.push(poseHinge(torso, upper,
       new Vec2(shoulderX - (seatX + 3), shoulderY - (seatY - 21)), new Vec2(-armLen / 2, 0),
-      { stiff: true }));
+      { freq: 5, damp: 0.6 }));   // soft shoulder so the arm isn't rigid
 
     const elbowX = shoulderX + Math.cos(ua) * armLen;
     const elbowY = shoulderY + Math.sin(ua) * armLen;
@@ -343,7 +343,7 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     try { lower.userData._colorIdx = 2; } catch (_) {}
     lower.space = space;
     elbows.push(poseHinge(upper, lower, new Vec2(armLen / 2, 0), new Vec2(-armLen / 2, 0),
-      { stiff: true }));
+      { freq: 4, damp: 0.5 }));   // soft elbow → the arm bends/relaxes on the bars
     return { upper, lower };
   };
   const lArm = buildArm();

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -1,5 +1,5 @@
 import {
-  Body, BodyType, Vec2, Circle, Polygon, Material,
+  Body, BodyType, Vec2, Circle, Polygon, Material, InteractionFilter,
   SpringJoint, LineJoint, MotorJoint, PivotJoint, AngleJoint, WeldJoint,
 } from "../nape-js.esm.js";
 
@@ -19,6 +19,10 @@ import {
 
 const SCREEN_W = 900;
 const SCREEN_H = 500;
+
+// Dev toggle: build the bike alone (no rider) while iterating on the chassis +
+// suspension. Flip back to true once the bike looks/behaves right.
+const BUILD_RIDER = false;
 
 // ── World / terrain ─────────────────────────────────────────────────────────
 const WORLD_W = 6000;
@@ -89,22 +93,63 @@ function buildTerrain(space, groundY) {
   }
 }
 
+// ── Collision filters ───────────────────────────────────────────────────────
+// The bike's own parts (frame + both wheels) must NOT collide with each other —
+// when a big landing fully compresses the suspension the wheel can touch the
+// frame, and two solid bodies in contact "stick"/jam. Each bike part collides
+// ONLY with the terrain (group 1); their own groups are left out of each
+// other's mask, so frame↔wheel and wheel↔wheel pairs never generate contacts.
+// Terrain bodies keep the default filter (group 1, mask −1 → hits everything).
+const GROUP_TERRAIN = 1;
+const BIKE_FILTER = new InteractionFilter(2, GROUP_TERRAIN);   // collides only w/ terrain
+
 // ── Bike tuning ─────────────────────────────────────────────────────────────
-// Crossmotor (dirt-bike) proportions — bigger spoked wheels, longer wheelbase,
-// and a higher seat than a road bike so it reads as a trials/MX machine.
-const WHEEL_R = 26;
-const WHEEL_BASE = 58;          // half the axle-to-axle distance
-const CHASSIS_H = 14;
-const SUSP_REST = 40;           // spring rest length (chassis → wheel) — long MX travel
-const SUSP_FREQ = 3.2;
-const SUSP_DAMP = 0.55;
-const SUSP_MIN = -10;           // LineJoint travel limits — generous suspension stroke
-const SUSP_MAX = 38;
-const MOTOR_RATE = 18;          // rear-wheel motor target angular rate (caps top
-                                // wheel speed → caps how violently a wheelie develops)
-const MOTOR_FORCE = 200000;     // torque cap — high so the bike can actually
-                                // climb under load; the low RATE (not the force)
-                                // is what keeps it from instantly looping out
+// Realistic crossmotor (dirt-bike) proportions: smaller wheels relative to a
+// long-ish frame, with two DIFFERENT suspensions — a telescopic fork up front
+// and a swingarm + monoshock at the rear (see buildBike).
+const WHEEL_R = 19;             // MX wheel — smaller than the old 26 so the bike
+                                // reads as a motorcycle, not a monster truck
+const WHEEL_BASE = 60;          // half the axle-to-axle distance
+const CHASSIS_H = 12;
+
+// Front telescopic fork — the wheel slides along a RAKED axis. FORK_OFFSET is a
+// FIXED extension that places the wheel well forward/below the steering head
+// (long wheelbase, good reach); the spring then only travels a SMALL window
+// (FORK_MIN..FORK_MAX) around that offset. This keeps the wheel from wandering
+// far out under accel/landing — it sits at a fixed ride height and just rugóz a
+// little, instead of shooting out to the end of a long soft spring.
+const FORK_RAKE = 0.42;         // radians the fork leans back from vertical (~24°)
+const FORK_OFFSET = 40;         // fixed wheel-out distance from the steering head
+// Spring tuning, the way real suspension works: FREQ is high enough that the
+// bike's own weight only sags a little (it RESTS near FORK_OFFSET with travel to
+// spare), so a big hit (jump/landing/bump) drives it deep and then it springs
+// back to ride height. DAMP stays low so the spring-back stays lively (not dead).
+const FORK_FREQ = 6.5;          // firm enough to hold ride height under static weight
+const FORK_DAMP = 0.32;         // low → lively spring-back, but no endless pogo
+const FORK_MIN = -24;           // deep compression available for big hits
+const FORK_MAX = 10;            // a little top-out travel
+
+// Rear monoshock — the rear wheel rides a near-vertical sprung sliding axis on
+// the frame (canonical 3-body bike; no pivoting swingarm body — see buildBike).
+// Same idea: a fixed offset (the ride height) + a small spring window.
+const SHOCK_OFFSET = 30;        // fixed rear axle drop from the frame anchor
+const SHOCK_FREQ = 4.4;         // holds ride height, but softer/livelier than 6.0
+const SHOCK_DAMP = 0.2;         // low → lively, springy rear (more dynamic feel)
+const SHOCK_MIN = -26;          // deep compression available for jumps/landings
+const SHOCK_MAX = 12;           // a little top-out travel
+// Visual swingarm + monoshock anchors (drawn only — no physics). Pivot under
+// the engine; SHOCK_TOP sits just above the rear axle so the coil drops nearly
+// straight down to the wheel instead of crossing the bike diagonally.
+const SWINGARM_PIVOT = { x: -22, y: 8 };
+const SHOCK_TOP = { x: -44, y: -12 };
+
+const MOTOR_RATE = 30;          // rear-wheel motor target angular rate. Kept
+                                // moderate ON PURPOSE: cranking it higher just
+                                // spins the wheel faster than it can grip (heavy
+                                // wheelspin → the bike surges/bogs). Grip + a
+                                // sane rate give smooth, fast power delivery.
+const MOTOR_FORCE = 75000;      // torque cap — moderate so acceleration doesn't
+                                // break traction (or loft the front into a flip).
 const LEAN_TORQUE = 40;         // ground lean impulse per frame — pops a wheelie
                                 // / pushes the nose down for jump setup
 const AIR_SPIN_RATE = 0.45;     // rad/s added to chassis angularVel per frame
@@ -148,9 +193,11 @@ let _space = null;
 let _chassis = null;
 let _fWheel = null;
 let _rWheel = null;
+let _swingarm = null;         // rear swingarm body (pivots off the frame)
 let _rMotor = null;
-let _fSusp = null;
-let _rSusp = null;
+let _fSusp = null;            // front fork spring
+let _rSusp = null;            // rear monoshock spring
+const _bikeJoints = [];       // every bike constraint, for clean teardown
 
 // Rider rig — the welded ragdoll. `_seatWeld` is the break-away joint; the rest
 // are the articulation. `_riderParts` / `_riderJoints` are kept for teardown.
@@ -356,112 +403,167 @@ function applyPose() {
 // rear wheel gets a MotorJoint = throttle. The rider's pelvis is WELDED to the
 // chassis seat — that weld is the break-away joint.
 function buildBike(space, spawnX, groundY) {
-  const cy = groundY - 96;
+  const cy = groundY - 78;
+  _bikeJoints.length = 0;
+  const J = (j) => { j.space = space; _bikeJoints.push(j); return j; };
 
-  // Chassis — a crossmotor silhouette: low slim frame, kicked-up seat/tail at
-  // the back, sloped tank + number plate at the front. Default material on
-  // purpose (dodges the Polygon+Material tunneling bug on fast landings).
+  // ── Frame ────────────────────────────────────────────────────────────────
+  // A recognizable dirt-bike profile, drawn in chassis-local coords. The bike
+  // faces +x (right). Origin sits at the frame centre, roughly axle height.
+  // No explicit Material on the frame (dodges the Polygon+Material tunneling
+  // bug on hard landings). Layout (local x): rear axle ≈ -WHEEL_BASE via the
+  // swingarm, steering head ≈ +44, front axle ≈ +WHEEL_BASE via the fork.
   const chassis = new Body(BodyType.DYNAMIC, new Vec2(spawnX, cy));
-  // Main frame spar (slim, between the wheels).
+  // Central frame triangle (backbone + downtube) — the structural mass.
   chassis.shapes.add(new Polygon([
-    new Vec2(-50, 0), new Vec2(46, 0),
-    new Vec2(50, 6), new Vec2(44, 11),
-    new Vec2(-48, 11), new Vec2(-54, 6),
+    new Vec2(-20, -10), new Vec2(20, -8),
+    new Vec2(34, 6), new Vec2(2, 8),
+    new Vec2(-20, 4),
   ]));
-  // Kicked-up rear fender + seat (the high MX tail).
+  // Engine block slung low under the frame (the heavy bit, keeps CoM low).
   chassis.shapes.add(new Polygon([
-    new Vec2(-54, -16), new Vec2(-22, -12),
-    new Vec2(-16, 0), new Vec2(-50, 0),
+    new Vec2(-8, 4), new Vec2(20, 4),
+    new Vec2(22, 16), new Vec2(-6, 16),
   ]));
-  // Tank / shroud up front, sloping down toward the bars.
+  // Seat + rear subframe sweeping up to the tail (reaches back over the rear
+  // wheel so the bike reads as one connected machine).
   chassis.shapes.add(new Polygon([
-    new Vec2(4, -12), new Vec2(30, -7),
-    new Vec2(40, 0), new Vec2(4, 0),
+    new Vec2(-44, -14), new Vec2(-8, -11),
+    new Vec2(-6, -4), new Vec2(-44, -7),
   ]));
-  // Front number plate / fork shroud (thin, angled forward).
+  // Rear fender stub over the back wheel.
   chassis.shapes.add(new Polygon([
-    new Vec2(40, -4), new Vec2(54, -10),
-    new Vec2(58, -4), new Vec2(46, 2),
+    new Vec2(-52, -10), new Vec2(-40, -12),
+    new Vec2(-38, -6), new Vec2(-52, -4),
   ]));
-  // Handlebar riser + grip — gives the rider's hands a target to reach and
-  // reads as the cockpit. Riser climbs up from the front of the tank; the grip
-  // is a short crossbar at the top, pulled back toward the rider so the arms
-  // reach it.
+  // Fuel tank rising in front of the seat.
   chassis.shapes.add(new Polygon([
-    new Vec2(24, -8), new Vec2(30, -8),
-    new Vec2(28, -28), new Vec2(22, -28),
+    new Vec2(-8, -11), new Vec2(10, -16),
+    new Vec2(20, -8), new Vec2(0, -8),
+  ]));
+  // Steering head + a stub of the upper fork triple-clamp at the front.
+  chassis.shapes.add(new Polygon([
+    new Vec2(28, -6), new Vec2(40, -16),
+    new Vec2(46, -12), new Vec2(36, 2),
+  ]));
+  // Handlebar riser + grip above the steering head (cockpit + a hand target).
+  chassis.shapes.add(new Polygon([
+    new Vec2(36, -16), new Vec2(41, -18),
+    new Vec2(34, -34), new Vec2(29, -32),
   ]));
   chassis.shapes.add(new Polygon([
-    new Vec2(14, -30), new Vec2(30, -30),
-    new Vec2(30, -25), new Vec2(14, -25),
+    new Vec2(20, -36), new Vec2(36, -33),
+    new Vec2(35, -28), new Vec2(19, -31),
   ]));
   try { chassis.userData._colorIdx = 0; } catch (_) {}
+  // Frame collides only with the terrain, never with its own wheels.
+  for (const shape of chassis.shapes) shape.filter = BIKE_FILTER;
   chassis.space = space;
 
-  // Low bounce, grippy MX tyre. Friction kept moderate (1.2) on purpose: with
-  // the torque-capped motor, *too much* grip stalls the bike on a steep face
-  // (the contact locks before the wheel can roll up it). 1.2 climbs the hills
-  // cleanly while still biting enough to launch off jumps.
-  const wheelMat = new Material(0.15, 1.4, 1.4, 1.3);
-  const makeWheel = (dx) => {
-    const w = new Body(BodyType.DYNAMIC, new Vec2(spawnX + dx, cy + 52));
-    w.shapes.add(new Circle(WHEEL_R, undefined, wheelMat));
+  // Low bounce, grippy MX tyre. Friction at 1.6 — enough that the wheel hooks
+  // up and delivers power smoothly (less wheelspin / surging) without being so
+  // grippy it stalls the bike on a steep face.
+  const wheelMat = new Material(0.15, 1.6, 1.6, 1.2);
+  const makeWheel = (x, y) => {
+    const w = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+    // Same filter as the frame → wheel never collides with the frame or the
+    // other wheel (only the terrain), so a fully-compressed suspension can't
+    // jam the wheel against the frame.
+    w.shapes.add(new Circle(WHEEL_R, undefined, wheelMat, BIKE_FILTER));
     try { w.userData._colorIdx = 3; } catch (_) {}
+    // Continuous collision check — at the higher top speed a fast wheel could
+    // otherwise tunnel through a thin terrain segment between two steps.
+    w.isBullet = true;
     w.space = space;
     return w;
   };
-  const fWheel = makeWheel(WHEEL_BASE);
-  const rWheel = makeWheel(-WHEEL_BASE);
 
-  // Suspension: spring + vertical line constraint per wheel.
-  const suspend = (wheel, dx) => {
-    const spring = new SpringJoint(
-      chassis, wheel,
-      new Vec2(dx, CHASSIS_H / 2), new Vec2(0, 0),
-      SUSP_REST,
-    );
-    spring.frequency = SUSP_FREQ;
-    spring.damping = SUSP_DAMP;
-    spring.space = space;
-    new LineJoint(
-      chassis, wheel,
-      new Vec2(dx, CHASSIS_H / 2), new Vec2(0, 0),
-      new Vec2(0, 1), SUSP_MIN, SUSP_MAX,
-    ).space = space;
-    return spring;
-  };
-  _fSusp = suspend(fWheel, WHEEL_BASE);
-  _rSusp = suspend(rWheel, -WHEEL_BASE);
+  // ── Front telescopic fork ──────────────────────────────────────────────────
+  // The wheel slides along the RAKED fork axis (down-and-forward from the
+  // steering head). FORK_OFFSET fixes where the wheel sits; the LineJoint only
+  // allows a small window (FORK_MIN..FORK_MAX) around it, and the SpringJoint's
+  // rest length IS the offset so the wheel is held there and just rugóz a little.
+  const headLocal = new Vec2(40, -12);
+  const forkAxis = new Vec2(Math.sin(FORK_RAKE), Math.cos(FORK_RAKE)); // down-forward
+  const fWheel = makeWheel(
+    spawnX + headLocal.x + forkAxis.x * FORK_OFFSET,
+    cy + headLocal.y + forkAxis.y * FORK_OFFSET,
+  );
+  J(new LineJoint(
+    chassis, fWheel,
+    new Vec2(headLocal.x, headLocal.y), new Vec2(0, 0),
+    new Vec2(forkAxis.x, forkAxis.y), FORK_OFFSET + FORK_MIN, FORK_OFFSET + FORK_MAX,
+  ));
+  _fSusp = J(new SpringJoint(
+    chassis, fWheel,
+    new Vec2(headLocal.x, headLocal.y), new Vec2(0, 0),
+    FORK_OFFSET,
+  ));
+  _fSusp.frequency = FORK_FREQ;
+  _fSusp.damping = FORK_DAMP;
 
-  // Rear-wheel motor = throttle (rate set per frame in step()). maxForce caps
-  // the torque so the throttle is progressive — climbs hills without the rear
-  // wheel snapping the whole bike into an instant backflip.
-  _rMotor = new MotorJoint(chassis, rWheel, 0);
+  // ── Rear wheel — sprung sliding axle (the canonical 2D-bike model) ─────────
+  // Researching the genre (TeaGames-style motocross, Trials, Hill Climb, Box2D
+  // bike demos) the universal recipe is a 3-body bike — frame + 2 wheels — with
+  // NO separate swingarm body. A pivoting swingarm puts the motor's drive
+  // *reaction* torque onto a light, softly-sprung arm, which kicks it back ~23°
+  // (exactly what we saw). Instead the rear wheel rides a near-vertical sprung
+  // sliding axis bolted to the frame, and the motor drives the wheel relative
+  // to the FRAME: the reaction now lands on the heavy frame as a mild wheelie,
+  // not as a structural collapse. The swingarm + monoshock you SEE are drawn in
+  // drawSuspension purely for looks (drawn over this physics).
+  const rearAxleLocal = new Vec2(-52, 4);           // where the rear axle hangs
+  const rearAxis = new Vec2(0.05, 0.999);           // essentially vertical
+  const rWheel = makeWheel(
+    spawnX + rearAxleLocal.x + rearAxis.x * SHOCK_OFFSET,
+    cy + rearAxleLocal.y + rearAxis.y * SHOCK_OFFSET,
+  );
+  J(new LineJoint(
+    chassis, rWheel,
+    new Vec2(rearAxleLocal.x, rearAxleLocal.y), new Vec2(0, 0),
+    new Vec2(rearAxis.x, rearAxis.y), SHOCK_OFFSET + SHOCK_MIN, SHOCK_OFFSET + SHOCK_MAX,
+  ));
+  _rSusp = J(new SpringJoint(
+    chassis, rWheel,
+    new Vec2(rearAxleLocal.x, rearAxleLocal.y), new Vec2(0, 0),
+    SHOCK_OFFSET,
+  ));
+  _rSusp.frequency = SHOCK_FREQ;     // a touch stiffer than the fork
+  _rSusp.damping = SHOCK_DAMP;
+
+  // Rear-wheel motor = throttle, between FRAME and rear wheel. The drive
+  // reaction lands on the heavy low-CoM frame (mild wheelie), never tipping a
+  // swingarm. maxForce caps the torque so the throttle is progressive — the
+  // single most important anti-flip knob in the genre. (rate set in step()).
+  _rMotor = J(new MotorJoint(chassis, rWheel, 0));
   _rMotor.maxForce = MOTOR_FORCE;
-  _rMotor.space = space;
 
   _chassis = chassis;
   _fWheel = fWheel;
   _rWheel = rWheel;
+  // No physical swingarm body — it's drawn for looks in drawSuspension.
+  _swingarm = null;
 
-  // Rider welded to the seat over the kicked-up MX tail. The pelvis locks
-  // rigidly to that point so the chassis lean drives the whole rig; the *visible*
-  // weight shift comes from the active pose (applyPose), not from weld give — so
-  // this weld is firm. Breaking it (`_seatWeld.space = null`) is the break-away
-  // showcase on a crash.
-  const seatLocalX = -16;       // mid-bike seat — rider centered so the arms can
-  const seatLocalY = -14;       // reach forward to the bars and legs to the pegs
-  const seatX = chassis.position.x + seatLocalX;
-  const seatY = chassis.position.y + seatLocalY;
-  const pelvis = buildRider(space, seatX, seatY);
-  _seatWeld = new WeldJoint(
-    chassis, pelvis,
-    new Vec2(seatLocalX, seatLocalY), new Vec2(0, 0),
-  );
-  _seatWeld.stiff = false;       // soft-but-firm: high frequency so it holds tight
-  _seatWeld.frequency = 18;
-  _seatWeld.damping = 0.9;
-  _seatWeld.space = space;
+  // Rider welded to the seat. The pelvis locks rigidly to that point so the
+  // chassis lean drives the whole rig; the *visible* weight shift comes from
+  // the active pose (applyPose), not from weld give — so this weld is firm.
+  // Breaking it (`_seatWeld.space = null`) is the break-away showcase on a crash.
+  // (BUILD_RIDER lets us bring the bike up alone while iterating on it.)
+  if (BUILD_RIDER) {
+    const seatLocalX = -18;       // over the seat, just behind the tank
+    const seatLocalY = -16;
+    const seatX = chassis.position.x + seatLocalX;
+    const seatY = chassis.position.y + seatLocalY;
+    const pelvis = buildRider(space, seatX, seatY);
+    _seatWeld = new WeldJoint(
+      chassis, pelvis,
+      new Vec2(seatLocalX, seatLocalY), new Vec2(0, 0),
+    );
+    _seatWeld.stiff = false;       // soft-but-firm: high frequency so it holds tight
+    _seatWeld.frequency = 18;
+    _seatWeld.damping = 0.9;
+    _seatWeld.space = space;
+  }
 }
 
 // ── Reset / respawn ─────────────────────────────────────────────────────────
@@ -473,15 +575,15 @@ function teardownBikeAndRider() {
   _seatWeld = null;
   for (const j of _riderJoints) { if (j.space) j.space = null; }
   _riderJoints = [];
-  if (_fSusp && _fSusp.space) _fSusp.space = null;
-  if (_rSusp && _rSusp.space) _rSusp.space = null;
-  if (_rMotor && _rMotor.space) _rMotor.space = null;
+  // All bike constraints (fork line + spring, swingarm pivots, monoshock, motor).
+  for (const j of _bikeJoints) { if (j.space) j.space = null; }
+  _bikeJoints.length = 0;
   _fSusp = _rSusp = _rMotor = null;
 
   for (const b of _riderParts) { if (b.space) b.space = null; }
   _riderParts = [];
-  for (const b of [_chassis, _fWheel, _rWheel]) { if (b && b.space) b.space = null; }
-  _chassis = _fWheel = _rWheel = _rider = null;
+  for (const b of [_chassis, _fWheel, _rWheel, _swingarm]) { if (b && b.space) b.space = null; }
+  _chassis = _fWheel = _rWheel = _swingarm = _rider = null;
   _poseJoints = null;
   _pose = { ...POSE_NEUTRAL };
 }
@@ -768,15 +870,49 @@ function drawSuspension(ctx, camX, camY) {
   const cp = _chassis.position;
   const ca = _chassis.rotation;
   const cos = Math.cos(ca), sin = Math.sin(ca);
-  const offY = CHASSIS_H / 2;
-  const anchor = (dx) => ({
-    x: cp.x + (dx * cos - offY * sin),
-    y: cp.y + (dx * sin + offY * cos),
+  // chassis local → world
+  const toWorld = (lx, ly) => ({
+    x: cp.x + (lx * cos - ly * sin),
+    y: cp.y + (lx * sin + ly * cos),
   });
-  const fa = anchor(WHEEL_BASE);
-  const ra = anchor(-WHEEL_BASE);
-  drawSpring(ctx, fa.x, fa.y, _fWheel.position.x, _fWheel.position.y, "#d2992299");
-  drawSpring(ctx, ra.x, ra.y, _rWheel.position.x, _rWheel.position.y, "#d2992299");
+
+  // Front fork: a pair of tubes from the steering head down to the front axle,
+  // following the (rotated) fork axis. Drawn as two parallel thick lines so it
+  // reads as upside-down telescopic forks.
+  const head = toWorld(40, -12);
+  const fw = _fWheel.position;
+  const fdx = fw.x - head.x, fdy = fw.y - head.y;
+  const flen = Math.hypot(fdx, fdy) || 1;
+  const fpx = -fdy / flen, fpy = fdx / flen;   // perpendicular for the two tubes
+  ctx.strokeStyle = "#9aa4ad";
+  ctx.lineWidth = 3;
+  ctx.setLineDash([]);
+  for (const s of [-2.5, 2.5]) {
+    ctx.beginPath();
+    ctx.moveTo(head.x + fpx * s, head.y + fpy * s);
+    ctx.lineTo(fw.x + fpx * s, fw.y + fpy * s);
+    ctx.stroke();
+  }
+
+  // Rear: cosmetic swingarm + monoshock over the sprung-axle physics. The
+  // swingarm bar runs from a pivot under the engine straight back to the rear
+  // axle; the monoshock coil drops nearly vertically from a frame anchor ABOVE
+  // the axle down to it (a real monoshock sits roughly over the wheel, not
+  // crossing the bike diagonally).
+  const rw = _rWheel.position;
+  const pivot = toWorld(SWINGARM_PIVOT.x, SWINGARM_PIVOT.y);
+  // swingarm bar (thick line, pivot → rear axle)
+  ctx.strokeStyle = "#8a939c";
+  ctx.lineWidth = 5;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(pivot.x, pivot.y);
+  ctx.lineTo(rw.x, rw.y);
+  ctx.stroke();
+  ctx.lineCap = "butt";
+  // monoshock coil from a frame anchor just above the rear axle, straight down.
+  const shockTop = toWorld(SHOCK_TOP.x, SHOCK_TOP.y);
+  drawSpring(ctx, shockTop.x, shockTop.y, rw.x, rw.y, "#d29922cc", 6, 4);
   ctx.restore();
 }
 

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -153,8 +153,11 @@ const MOTOR_FORCE = 75000;      // torque cap — moderate so acceleration doesn
 // Ground lean drives the chassis toward a TARGET pitch rate and holds it there,
 // strong enough to overpower the wheels' tendency to cancel the rotation each
 // frame (a gentle nudge just gets absorbed — that's why leaning felt dead).
-const LEAN_GROUND_VEL = 5.0;     // target pitch rate while a lean key is held (rad/s)
-const LEAN_GROUND_GAIN = 0.5;    // how hard we drive angularVel toward that target
+const LEAN_GROUND_VEL = 6.0;     // target pitch rate while a lean key is held (rad/s)
+const LEAN_GROUND_GAIN = 0.6;    // how hard we drive angularVel toward that target
+const LEAN_MAX_ANGLE = 1.15;     // rad (~66°) — past this we brake the spin so a
+                                 // held lean gives a big wheelie/endo that HOLDS,
+                                 // instead of looping the bike all the way over
 const LEAN_TORQUE = 110;        // ground lean impulse per frame — pops a wheelie
                                 // / pushes the nose down for jump setup
 const AIR_SPIN_RATE = 0.45;     // rad/s added to chassis angularVel per frame
@@ -740,19 +743,31 @@ export default {
       if (leanFwd) _chassis.angularVel += AIR_SPIN_RATE;
     } else {
       // On the ground the grounded wheels cancel a pure torque each frame, so a
-      // nudge feels dead. Instead drive angularVel TOWARD a target pitch rate and
-      // hold it — this lifts the front (wheelie, nose-up = negative) or pushes it
-      // down (endo) authoritatively, while the rear/front wheel keeps the bike
-      // from simply spinning. The torque impulse adds a bit more bite.
+      // nudge feels dead. Instead drive angularVel TOWARD a strong target pitch
+      // rate and hold it — this snaps the front up (wheelie, nose-up = negative)
+      // or down (endo) authoritatively. An ANGLE GUARD stops driving once the
+      // bike is already pitched past LEAN_MAX_ANGLE, so a held key gives a big,
+      // fast lean that HOLDS there instead of looping the bike over.
+      let pitch = _chassis.rotation % (Math.PI * 2);
+      if (pitch > Math.PI) pitch -= Math.PI * 2;
+      if (pitch < -Math.PI) pitch += Math.PI * 2;
       if (leanBack) {
-        const target = -LEAN_GROUND_VEL;
-        _chassis.angularVel += (target - _chassis.angularVel) * LEAN_GROUND_GAIN;
-        _chassis.applyAngularImpulse(-LEAN_TORQUE);
+        if (pitch > -LEAN_MAX_ANGLE) {
+          // still within the wheelie range → drive the pitch up hard
+          _chassis.angularVel += (-LEAN_GROUND_VEL - _chassis.angularVel) * LEAN_GROUND_GAIN;
+          _chassis.applyAngularImpulse(-LEAN_TORQUE);
+        } else if (_chassis.angularVel < 0) {
+          // reached the wheelie cap → kill the spin so it HOLDS, not loops
+          _chassis.angularVel = 0;
+        }
       }
       if (leanFwd) {
-        const target = LEAN_GROUND_VEL;
-        _chassis.angularVel += (target - _chassis.angularVel) * LEAN_GROUND_GAIN;
-        _chassis.applyAngularImpulse(LEAN_TORQUE);
+        if (pitch < LEAN_MAX_ANGLE) {
+          _chassis.angularVel += (LEAN_GROUND_VEL - _chassis.angularVel) * LEAN_GROUND_GAIN;
+          _chassis.applyAngularImpulse(LEAN_TORQUE);
+        } else if (_chassis.angularVel > 0) {
+          _chassis.angularVel = 0;
+        }
       }
     }
 

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -150,9 +150,11 @@ const MOTOR_RATE = 30;          // rear-wheel motor target angular rate. Kept
                                 // sane rate give smooth, fast power delivery.
 const MOTOR_FORCE = 75000;      // torque cap — moderate so acceleration doesn't
                                 // break traction (or loft the front into a flip).
-const LEAN_GROUND_ASSIST = 0.9;  // rad/s of direct pitch added per frame on the
-                                 // ground so leaning is FELT (not absorbed by grip)
-const LEAN_GROUND_VEL = 4.5;     // cap on that ground-lean pitch rate (controllable)
+// Ground lean drives the chassis toward a TARGET pitch rate and holds it there,
+// strong enough to overpower the wheels' tendency to cancel the rotation each
+// frame (a gentle nudge just gets absorbed — that's why leaning felt dead).
+const LEAN_GROUND_VEL = 5.0;     // target pitch rate while a lean key is held (rad/s)
+const LEAN_GROUND_GAIN = 0.5;    // how hard we drive angularVel toward that target
 const LEAN_TORQUE = 110;        // ground lean impulse per frame — pops a wheelie
                                 // / pushes the nose down for jump setup
 const AIR_SPIN_RATE = 0.45;     // rad/s added to chassis angularVel per frame
@@ -737,18 +739,20 @@ export default {
       if (leanBack) _chassis.angularVel -= AIR_SPIN_RATE;
       if (leanFwd) _chassis.angularVel += AIR_SPIN_RATE;
     } else {
-      // On the ground the grounded wheels resist a pure torque (it mostly gets
-      // absorbed). To make leaning actually FEEL like a weight shift, combine a
-      // strong torque impulse with a direct angular-velocity bias toward the
-      // lean direction (capped, so the bike can lift a wheel into a wheelie /
-      // endo but the wheels still keep traction). Sign: nose-up = negative.
+      // On the ground the grounded wheels cancel a pure torque each frame, so a
+      // nudge feels dead. Instead drive angularVel TOWARD a target pitch rate and
+      // hold it — this lifts the front (wheelie, nose-up = negative) or pushes it
+      // down (endo) authoritatively, while the rear/front wheel keeps the bike
+      // from simply spinning. The torque impulse adds a bit more bite.
       if (leanBack) {
+        const target = -LEAN_GROUND_VEL;
+        _chassis.angularVel += (target - _chassis.angularVel) * LEAN_GROUND_GAIN;
         _chassis.applyAngularImpulse(-LEAN_TORQUE);
-        if (_chassis.angularVel > -LEAN_GROUND_VEL) _chassis.angularVel -= LEAN_GROUND_ASSIST;
       }
       if (leanFwd) {
+        const target = LEAN_GROUND_VEL;
+        _chassis.angularVel += (target - _chassis.angularVel) * LEAN_GROUND_GAIN;
         _chassis.applyAngularImpulse(LEAN_TORQUE);
-        if (_chassis.angularVel < LEAN_GROUND_VEL) _chassis.angularVel += LEAN_GROUND_ASSIST;
       }
     }
 

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -1,6 +1,6 @@
 import {
   Body, BodyType, Vec2, Circle, Polygon, Material, InteractionFilter,
-  SpringJoint, LineJoint, MotorJoint, PivotJoint, AngleJoint, WeldJoint, DistanceJoint,
+  SpringJoint, LineJoint, MotorJoint, PivotJoint, AngleJoint, WeldJoint,
 } from "../nape-js.esm.js";
 
 // Dirtline — a side-view hill-climb / trials motorbike with an articulated
@@ -179,24 +179,65 @@ const CRASH_SPIN_RATE = 7;      // rad/s — above this the bike is tumbling out
                                 // control (a fast flip never sustains one angle)
 const CRASH_SPIN_FRAMES = 14;   // ~0.23s of that spin before the rider bails
 
-// ── Rider limb hinges ───────────────────────────────────────────────────────
-// Each limb is BUILT already rotated into its seated rest pose (arms reaching
-// up-forward to the bars, legs angled down to the pegs); each AngleJoint is a
-// soft spring around that built rest angle. The rider is attached to the bike
-// only at the hands (handlebar) and feet (pegs) plus a soft pelvis tether, so
-// the body hangs naturally on those points — the hinges just keep the limbs
-// from flailing, they don't pose the body rigidly.
-const POSE_SOFT = 0.04;         // half-width of each hinge's rest window
-// Torso lean: how far the rider's upper body shifts when you lean the bike, and
-// the cap on forward dip so the torso can't fold down into the bike body.
-const TORSO_LEAN_BACK = -0.65;  // rad added to the torso rest angle on lean-back (×1.3)
-const TORSO_LEAN_FWD = 0.29;    // rad added on lean-forward (positive = nose-down) (×1.3)
-const TORSO_FWD_MAX = 0.29;     // hard cap on forward torso tilt past rest so the
-                                // upper body can't fold flat onto the bike
-const TORSO_LEAN_LERP = 0.12;   // how fast the torso eases to the new lean target
-// Legs extend with the lean (rider pushes off the pegs): the knee straightens by
-// this much at full lean. Sign tuned so the leg straightens (less bend), not curls.
-const KNEE_STRAIGHTEN = 0.7;
+// ── Rider rig — two fixed points + a moving seat ─────────────────────────────
+// The rider is bolted to the bike at exactly TWO rigid points: the HANDS on the
+// handlebar grip and the FEET on the footpegs. Those never move relative to the
+// bike — they're the skeleton the whole pose hangs off. Between them the lower
+// body is held onto the seat by a SOFT weld whose chassis-side anchor we slide
+// at runtime. That moving seat anchor is the whole trick:
+//   • neutral     → seat anchor low/back → the rider SITS, knees bent, torso up
+//   • lean fwd/back → seat anchor rises (and shifts fore/aft) → the pelvis is
+//     pulled UP off the seat, so with the hands+feet pinned the rider STANDS,
+//     legs straightening, exactly like the reference frames 2 & 3.
+// Because hands & feet are rigid and the seat is soft, raising the seat target
+// makes the body unfold around the two fixed points instead of teleporting.
+const POSE_SOFT = 0.04;         // half-width of each limb hinge's rest window
+// Torso lean: how far the rider's upper body swings when you lean the bike.
+const TORSO_LEAN_BACK = -0.55;  // rad added to the torso rest angle on lean-back.
+                                // Modest: the upper body sits back but stays
+                                // tipped slightly FORWARD over the bars (a bigger
+                                // value stood the torso bolt-upright / hanyatt —
+                                // the rider should still reach toward the bars).
+const TORSO_LEAN_FWD = 0.27;    // rad added on lean-forward — torso pitches down
+                                // over the bars (positive = nose-down — frame 2).
+                                // Kept modest so the head/chest stay UP over the
+                                // bars and don't headbutt the cockpit (a big value
+                                // buried the head / clipped the bars — see images).
+const TORSO_LEAN_LERP = 0.14;   // how fast the torso eases to the new lean target
+// Seat lift — how the soft-weld's chassis anchor moves from its neutral seat
+// position when the rider stands on a lean. Local chassis coords (+x fwd, +y down).
+// The lift is DIRECTION-SPECIFIC: forward and back leans stand the rider up by
+// different amounts and shift the hips opposite ways, so each pose can be tuned
+// without the other going wrong (a shared lift made the back-lean hips skew).
+const SEAT_LOCAL = { x: -18, y: -16 };   // neutral pelvis-on-seat anchor
+// Forward and back leans move the hips OPPOSITE ways vertically:
+//   • FORWARD → hips RISE (rider stands tall, crouches over the bars).
+//   • BACK    → hips DROP and slide back — the rider pushes the whole body
+//     down-and-rearward off the pegs (the "pull-back" hang). NOT a stand-up;
+//     a positive value here LOWERS the hips (sy = SEAT_LOCAL.y − lift·amt).
+const SEAT_LIFT_FWD = 16;       // px the hips rise on lean-FWD → head comes up too
+const SEAT_LIFT_BACK = -7;      // px (negative → hips DROP) on lean-BACK: the whole
+                                // body sinks back-and-down, arms angling downward.
+                                // Kept mild — a big drop let the body slump into a
+                                // low pose the soft seat weld couldn't climb out of.
+const SEAT_SHIFT_FWD = 5;       // px forward hip shift on lean-forward (small — too
+                                // much pushed the chest into the bars)
+const SEAT_SHIFT_BACK = 14;     // px rearward hip shift on lean-back (big — the body
+                                // slides well back so the rider hangs off the rear)
+const SEAT_LERP = 0.14;         // how fast the seat anchor eases to its lean target
+// Knee extension on a lean. FORWARD: knee opens a lot (crouch over the bars).
+// BACK: knee opens HARD too — pushing the body down-and-back off the pegs takes
+// nearly straight legs (the rider extends to hang rearward), which was the
+// missing "leg isn't extended enough" in the back-lean pose.
+const KNEE_STRAIGHTEN_FWD = 1.0;
+const KNEE_STRAIGHTEN_BACK = 1.1;
+// Pelvis tilt — the soft seat weld locks the pelvis ROTATION to the chassis
+// (its phase). On a lean we rotate that target so the pelvis follows the body
+// instead of staying bolted level and getting skewed: tip slightly forward on a
+// forward lean, recline on a back lean. This is what stops the back-lean lower
+// body from twisting oddly — the pelvis reclines WITH the torso as one unit.
+const PELVIS_TILT_FWD = 0.15;   // rad the pelvis tips forward (nose-down) on fwd lean
+const PELVIS_TILT_BACK = -0.3;  // rad the pelvis reclines on back lean (sits back)
 
 // ── Module state ────────────────────────────────────────────────────────────
 let _space = null;
@@ -222,6 +263,8 @@ let _torsoBase = 0;           // its built rest angle (the upright seated pose)
 let _torsoLean = 0;           // current eased lean offset applied to the torso
 let _kneeHinges = [];         // [{ joint, base }] knee hinges, straightened on lean
 let _legExtend = 0;           // eased 0→1: how straight the legs are on a lean
+let _seatLift = 0;            // eased 0→1: how far the rider has risen off the seat
+let _seatShift = 0;           // eased −1..1: fore(+)/aft(−) seat anchor shift
 let _crashed = false;
 let _flipFrames = 0;
 let _spinFrames = 0;
@@ -310,9 +353,12 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   new PivotJoint(pelvis, torso, new Vec2(0, -5), new Vec2(-2, 15)).space = space;
   _torsoBase = torso.rotation - pelvis.rotation;
   _torsoHinge = new AngleJoint(pelvis, torso, _torsoBase - POSE_SOFT, _torsoBase + POSE_SOFT);
-  _torsoHinge.stiff = false;
-  _torsoHinge.frequency = 13;    // strong enough to hold the torso up against the
-  _torsoHinge.damping = 0.9;     // forward pull of the arms gripping the bars
+  // STIFF: the torso angle is posture-critical and must win against the pull of
+  // the rigidly-pinned hands. A soft joint just got dragged forward by the arms
+  // on a lean-back, so the rider never actually leaned back. A stiff joint
+  // authoritatively commands the torso angle; the soft arms then straighten /
+  // fold to keep the hands on the bars. step() retargets the window each frame.
+  _torsoHinge.stiff = true;
   _torsoHinge.space = space;
   _riderJoints.push(_torsoHinge);
 
@@ -420,21 +466,18 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     }
   }
   if (chassis && pegLocal) {
-    // Feet use a SOFT DistanceJoint (not a rigid pin) so the foot stays near the
-    // peg but can move a little when the rider extends a leg on a lean. A rigid
-    // pin locked the leg flat and killed that motion. jointMin=0 / jointMax give
-    // a small window; the soft spring keeps the foot on the peg under normal
-    // riding. step() straightens the KNEE on a lean to extend the leg.
+    // Feet are RIGIDLY pinned to the footpeg — one of the rider's two fixed
+    // anchor points (the other is the hands on the bars). The foot does NOT move
+    // relative to the bike. When the rider stands on a lean we raise the SEAT
+    // anchor (see step()), which pulls the pelvis up; with the foot pinned here
+    // the knee then opens to absorb the rise — that's what reads as "standing on
+    // the pegs". A rigid pin (not the old soft DistanceJoint) gives a solid,
+    // predictable foot↔peg join exactly as asked.
     for (const leg of [lLeg, rLeg]) {
-      const d = new DistanceJoint(
+      _pegJoints.push(new PivotJoint(
         chassis, leg.shin,
         new Vec2(pegLocal.x, pegLocal.y), new Vec2(shinLen / 2, 0),
-        0, 8,
-      );
-      d.stiff = false;
-      d.frequency = 7;
-      d.damping = 0.7;
-      _pegJoints.push(d);
+      ));
     }
   }
   for (const j of _gripJoints) j.space = space;
@@ -600,20 +643,25 @@ function buildBike(space, spawnX, groundY) {
   // Hands stay pinned to the bars, feet to the pegs. (BUILD_RIDER lets us bring
   // the bike up alone while iterating on it.)
   if (BUILD_RIDER) {
-    const seatLocalX = -18;       // where the pelvis sits, over the seat
-    const seatLocalY = -16;
-    const seatX = chassis.position.x + seatLocalX;
-    const seatY = chassis.position.y + seatLocalY;
+    // The seat is the rider's lower-body tether (NOT a fixed point — the two
+    // fixed points are hands + feet). Its chassis anchor starts at SEAT_LOCAL and
+    // step() slides it up/fore/aft on a lean to STAND the rider. seatX/seatY is
+    // the world build position of the pelvis.
+    const seatX = chassis.position.x + SEAT_LOCAL.x;
+    const seatY = chassis.position.y + SEAT_LOCAL.y;
     const gripLocal = new Vec2(27, -31);
     const pegLocal = new Vec2(-4, 10);
     const pelvis = buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal);
     _seatWeld = new WeldJoint(
       chassis, pelvis,
-      new Vec2(seatLocalX, seatLocalY), new Vec2(0, 0),
+      new Vec2(SEAT_LOCAL.x, SEAT_LOCAL.y), new Vec2(0, 0),
     );
     _seatWeld.stiff = false;
-    _seatWeld.frequency = 7;       // soft seat — holds the pelvis without bolting it
-    _seatWeld.damping = 0.7;
+    _seatWeld.frequency = 9;       // firm-ish seat — holds the pelvis, and (when
+    _seatWeld.damping = 0.8;       // its anchor is moved) drives it to the new spot
+                                   // AND reliably back to neutral on release. Too
+                                   // soft (≈6) let a dropped-hip back-lean slump
+                                   // into a low pose it couldn't recover from.
     _seatWeld.space = space;
   }
 }
@@ -644,6 +692,8 @@ function teardownBikeAndRider() {
   _torsoLean = 0;
   _kneeHinges = [];
   _legExtend = 0;
+  _seatLift = 0;
+  _seatShift = 0;
 }
 
 function respawn() {
@@ -826,32 +876,59 @@ export default {
       }
     }
 
-    // Active rider pose — the whole-body weight shift. The soft seat weld holds
-    // the rider on the bike; here we drive the torso + legs with the lean keys:
-    //   • lean BACK  → torso leans back, legs EXTEND (rider stretches rearward)
-    //   • lean FWD   → torso reaches up-and-forward, legs EXTEND (stands/reaches)
-    //   • neutral    → torso upright, legs bent (relaxed seated pose)
-    // Both lean directions extend the legs (the rider pushes off the pegs); only
-    // the torso angle differs. Everything is eased so it sways, not snaps.
+    // Active rider pose — the whole-body weight shift, built around the two FIXED
+    // points (hands on the bars, feet on the pegs). The lean keys do three things,
+    // all eased so the body sways rather than snaps:
+    //   • SEAT LIFT — raise the soft-weld's chassis anchor so the pelvis is pulled
+    //     UP off the seat. With the feet pinned, the rider rises into a stand.
+    //   • SEAT SHIFT — slide that anchor forward (lean fwd) or back (lean back),
+    //     so the standing rider's hips travel toward the bars or over the tail.
+    //   • TORSO + KNEES — pitch the upper body down over the bars (fwd) or extend
+    //     it rearward (back), and open the knees to feed the leg extension.
+    // Neutral relaxes all of it: hips drop back onto the seat, knees re-bend,
+    // torso returns upright — the compact seated rest pose (reference frame 1).
     if (!_crashed && _torsoHinge && _torsoHinge.space) {
-      // Torso target angle.
+      // Signed lean: +1 = full forward, −1 = full back, 0 = neutral. A single
+      // eased value drives every pose channel so forward/back stay opposite and
+      // neutral always relaxes cleanly back to the seated rest silhouette.
+      let leanTarget = 0;
+      if (leanFwd) leanTarget = 1;
+      else if (leanBack) leanTarget = -1;
+      _seatShift += (leanTarget - _seatShift) * SEAT_LERP;   // reused as signed lean
+      const s = _seatShift;
+      const fwdAmt = Math.max(0, s);    // 0..1 forward
+      const backAmt = Math.max(0, -s);  // 0..1 back
+
+      // ── Torso angle ── (eased toward the direction's target)
       let torsoTarget = 0;
-      if (leanBack) torsoTarget = TORSO_LEAN_BACK;
-      else if (leanFwd) torsoTarget = TORSO_LEAN_FWD;
+      if (leanFwd) torsoTarget = TORSO_LEAN_FWD;
+      else if (leanBack) torsoTarget = TORSO_LEAN_BACK;
       _torsoLean += (torsoTarget - _torsoLean) * TORSO_LEAN_LERP;
-      const t = _torsoBase + Math.max(-Math.abs(TORSO_LEAN_BACK), Math.min(TORSO_FWD_MAX, _torsoLean));
+      const t = _torsoBase + _torsoLean;
       _torsoHinge.jointMin = t - POSE_SOFT;
       _torsoHinge.jointMax = t + POSE_SOFT;
 
-      // Legs straighten on EITHER lean: the rider extends the legs (pushes off
-      // the pegs) when shifting weight back or forward, and tucks them when
-      // neutral. We straighten the KNEE toward 0 bend; the soft foot tether lets
-      // the foot follow. _legExtend eases 0→1.
-      const wantExtend = (leanBack || leanFwd) ? 1 : 0;
-      _legExtend += (wantExtend - _legExtend) * TORSO_LEAN_LERP;
+      // ── Seat anchor — the body-shift driver. Direction-specific and OPPOSITE
+      // vertically: forward RAISES the hips (stand tall, crouch over the bars);
+      // back DROPS + slides them rearward (the rider pushes the whole body down-
+      // and-back off the pegs, so the arms angle downward to the bars).
+      _seatLift = fwdAmt + backAmt;   // total shift amount (for any future use)
+      if (_seatWeld && _seatWeld.space) {
+        const sx = SEAT_LOCAL.x + SEAT_SHIFT_FWD * fwdAmt - SEAT_SHIFT_BACK * backAmt;
+        const sy = SEAT_LOCAL.y - (SEAT_LIFT_FWD * fwdAmt + SEAT_LIFT_BACK * backAmt);
+        _seatWeld.anchor1 = new Vec2(sx, sy);
+        // Recline / tip the pelvis WITH the lean so the lower body moves as one
+        // unit instead of staying bolted level and skewing on a back lean.
+        _seatWeld.phase = PELVIS_TILT_FWD * fwdAmt + PELVIS_TILT_BACK * backAmt;
+      }
+
+      // ── Knees — open as the rider stands; direction-specific so the back-lean
+      // leg stays bent and planted instead of folding the wrong way.
+      const kneeOpen = KNEE_STRAIGHTEN_FWD * fwdAmt + KNEE_STRAIGHTEN_BACK * backAmt;
+      _legExtend = kneeOpen;
       for (const h of _kneeHinges) {
         if (!h || !h.joint || h.joint.space === null) continue;
-        const a = h.base - KNEE_STRAIGHTEN * _legExtend;  // reduce the knee bend
+        const a = h.base - kneeOpen;   // reduce the knee bend by the open amount
         h.joint.jointMin = a - POSE_SOFT;
         h.joint.jointMax = a + POSE_SOFT;
       }

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -168,11 +168,9 @@ const SHOCK_FREQ = 4.4;         // holds ride height, but softer/livelier than 6
 const SHOCK_DAMP = 0.2;         // low → lively, springy rear (more dynamic feel)
 const SHOCK_MIN = -26;          // deep compression available for jumps/landings
 const SHOCK_MAX = 12;           // a little top-out travel
-// Visual swingarm + monoshock anchors (drawn only — no physics). Pivot under
-// the engine; SHOCK_TOP sits just above the rear axle so the coil drops nearly
-// straight down to the wheel instead of crossing the bike diagonally.
+// Visual swingarm anchor (drawn only — no physics). Pivot under the engine; the
+// cosmetic swingarm bar runs from here back to the rear axle.
 const SWINGARM_PIVOT = { x: -22, y: 8 };
-const SHOCK_TOP = { x: -44, y: -12 };
 
 const MOTOR_RATE = 48;          // rear-wheel motor target angular rate. Raised
                                 // for a notably faster top speed; paired with a
@@ -1242,29 +1240,6 @@ function updateGravel(emitter, wheel) {
   emitter.rate = GRAVEL_RATE_MAX * t;
 }
 
-// Draw the suspension springs (chassis anchor → wheel hub) in world space.
-function drawSpring(ctx, x1, y1, x2, y2, color, coils = 5, amp = 5) {
-  const dx = x2 - x1, dy = y2 - y1;
-  const len = Math.sqrt(dx * dx + dy * dy);
-  if (len < 2) return;
-  const ux = dx / len, uy = dy / len;
-  const px = -uy, py = ux;
-  const n = coils * 2;
-  ctx.beginPath();
-  ctx.moveTo(x1, y1);
-  ctx.lineTo(x1 + ux * len * 0.1, y1 + uy * len * 0.1);
-  for (let i = 1; i <= n; i++) {
-    const t = 0.1 + (i / n) * 0.8;
-    const sign = i % 2 === 0 ? 1 : -1;
-    ctx.lineTo(x1 + ux * len * t + px * amp * sign, y1 + uy * len * t + py * amp * sign);
-  }
-  ctx.lineTo(x2, y2);
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.setLineDash([]);
-  ctx.stroke();
-}
-
 function drawSuspension(ctx, camX, camY) {
   if (!_chassis || !_fWheel || !_rWheel) return;
   ctx.save();
@@ -1312,9 +1287,9 @@ function drawSuspension(ctx, camX, camY) {
   ctx.lineTo(rw.x, rw.y);
   ctx.stroke();
   ctx.lineCap = "butt";
-  // monoshock coil from a frame anchor just above the rear axle, straight down.
-  const shockTop = toWorld(SHOCK_TOP.x, SHOCK_TOP.y);
-  drawSpring(ctx, shockTop.x, shockTop.y, rw.x, rw.y, "#d29922cc", 6, 4);
+  // (No drawn monoshock coil — the rear suspension is left bare like the front,
+  // which only shows its fork tubes and no coil. The swingarm bar above is kept
+  // so the rear wheel still reads as connected to the frame.)
   ctx.restore();
 }
 
@@ -1322,10 +1297,11 @@ function drawHUD(ctx, sw) {
   ctx.save();
   ctx.textBaseline = "alphabetic";
 
-  // Distance + speed readout.
+  // Distance + speed readout. 40 px = 1 m, so px/s → m/s is /40 and m/s → km/h
+  // is ×3.6 — i.e. px/s ÷ 40 × 3.6.
   const meters = (_maxDist / 40).toFixed(1);
-  let speed = 0;
-  if (_chassis) speed = Math.hypot(_chassis.velocity.x, _chassis.velocity.y) / 40;
+  let kmh = 0;
+  if (_chassis) kmh = (Math.hypot(_chassis.velocity.x, _chassis.velocity.y) / 40) * 3.6;
   ctx.fillStyle = "rgba(13,17,23,0.78)";
   ctx.fillRect(10, 10, 188, 60);
   ctx.fillStyle = "#e6edf3";
@@ -1334,7 +1310,7 @@ function drawHUD(ctx, sw) {
   ctx.fillText(`Distance: ${meters} m`, 22, 34);
   ctx.font = "13px system-ui, sans-serif";
   ctx.fillStyle = "#8b949e";
-  ctx.fillText(`Speed: ${speed.toFixed(1)} m/s`, 22, 56);
+  ctx.fillText(`Speed: ${kmh.toFixed(0)} km/h`, 22, 56);
 
   // Crashed banner + restart hint.
   if (_crashed) {

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -213,6 +213,8 @@ const _bikeJoints = [];       // every bike constraint, for clean teardown
 // are the articulation. `_riderParts` / `_riderJoints` are kept for teardown.
 let _rider = null;            // { pelvis, torso, head, ... } refs for drawing
 let _seatWeld = null;
+let _gripJoints = [];         // hand→handlebar pins (break away with the seat weld)
+let _pegJoints = [];          // foot→footpeg pins (break away with the seat weld)
 let _riderParts = [];
 let _riderJoints = [];
 // Pose-driving AngleJoints, grouped so step() can push each toward its target.
@@ -246,9 +248,11 @@ let _spawnGroundY = 0;
 // rewrites those targets each frame so the rider crouches on the gas and stands
 // when you lean back — exactly the TeaGames-style weight shift. On a crash the
 // targets are abandoned and the windows thrown wide so the rig goes limp.
-function buildRider(space, seatX, seatY) {
+function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   _riderParts = [];
   _riderJoints = [];
+  _gripJoints = [];
+  _pegJoints = [];
 
   const add = (body) => { _riderParts.push(body); return body; };
 
@@ -387,6 +391,31 @@ function buildRider(space, seatX, seatY) {
   for (const b of _riderParts) {
     for (const shape of b.shapes) shape.filter = BIKE_FILTER;
   }
+
+  // Pin the hands to the handlebar grip and the feet to the footpeg. These are
+  // PivotJoints fixing the lower-arm end (the hand) and the shin end (the foot)
+  // onto the chassis at the given local anchors, so the rider actually GRIPS the
+  // bars and rests on the pegs instead of its limbs flapping. They break away
+  // together with the seat weld on a crash (see bailRider) so the rider ragdolls
+  // free. The AngleJoint poses still shape the limbs; these just lock the ends.
+  if (chassis && gripLocal) {
+    for (const arm of [lArm, rArm]) {
+      _gripJoints.push(new PivotJoint(
+        chassis, arm.lower,
+        new Vec2(gripLocal.x, gripLocal.y), new Vec2(armLen / 2, 0),
+      ));
+    }
+  }
+  if (chassis && pegLocal) {
+    for (const leg of [lLeg, rLeg]) {
+      _pegJoints.push(new PivotJoint(
+        chassis, leg.shin,
+        new Vec2(pegLocal.x, pegLocal.y), new Vec2(shinLen / 2, 0),
+      ));
+    }
+  }
+  for (const j of _gripJoints) j.space = space;
+  for (const j of _pegJoints) j.space = space;
 
   _poseJoints = { torso: jTorso, head: jHead, shoulders, elbows, hips, knees };
   _pose = { ...POSE_NEUTRAL };
@@ -572,7 +601,11 @@ function buildBike(space, spawnX, groundY) {
     const seatLocalY = -16;
     const seatX = chassis.position.x + seatLocalX;
     const seatY = chassis.position.y + seatLocalY;
-    const pelvis = buildRider(space, seatX, seatY);
+    // Hand + foot anchor points on the frame (chassis-local): the handlebar grip
+    // (the crossbar at the top of the riser) and a footpeg under the seat.
+    const gripLocal = new Vec2(27, -31);
+    const pegLocal = new Vec2(-4, 10);
+    const pelvis = buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal);
     _seatWeld = new WeldJoint(
       chassis, pelvis,
       new Vec2(seatLocalX, seatLocalY), new Vec2(0, 0),
@@ -591,6 +624,10 @@ function buildBike(space, spawnX, groundY) {
 function teardownBikeAndRider() {
   if (_seatWeld && _seatWeld.space) _seatWeld.space = null;
   _seatWeld = null;
+  for (const j of _gripJoints) { if (j.space) j.space = null; }
+  for (const j of _pegJoints) { if (j.space) j.space = null; }
+  _gripJoints = [];
+  _pegJoints = [];
   for (const j of _riderJoints) { if (j.space) j.space = null; }
   _riderJoints = [];
   // All bike constraints (fork line + spring, swingarm pivots, monoshock, motor).
@@ -623,6 +660,12 @@ function bailRider() {
   _crashed = true;
   if (_seatWeld.space) _seatWeld.space = null;
   _seatWeld = null;
+  // Release the hands from the bars and the feet from the pegs too, so the whole
+  // rider comes free (not just the pelvis).
+  for (const j of _gripJoints) { if (j.space) j.space = null; }
+  for (const j of _pegJoints) { if (j.space) j.space = null; }
+  _gripJoints = [];
+  _pegJoints = [];
   // A small backward+up kick on the pelvis so the rider visibly tumbles off
   // the back rather than sitting in place.
   if (_rider && _rider.pelvis && _rider.pelvis.space) {

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -1,0 +1,585 @@
+import {
+  Body, BodyType, Vec2, Circle, Polygon, Material,
+  SpringJoint, LineJoint, MotorJoint, PivotJoint, AngleJoint, WeldJoint,
+} from "../nape-js.esm.js";
+
+// Dirtline — a side-view hill-climb / trials motorbike with an articulated
+// ragdoll rider. A deliberately richer sibling of `car-sideview.js`: the bike
+// has MotorJoint-driven wheels on SpringJoint suspension, and the rider is a
+// PivotJoint+AngleJoint ragdoll WELDED to the chassis at the pelvis. As you
+// pitch the bike (lean keys apply chassis torque) the welded pelvis drags the
+// torso, so the rider visibly sways forward/back within its AngleJoint range.
+// Flip the bike past a threshold (or smack the ground hard) and the seat weld
+// breaks away — the rider detaches and ragdolls free off the back.
+//
+// Renderer-agnostic: the default body draw handles every part across
+// canvas2d / threejs / pixi; `render3dOverlay` paints the springs + HUD on top.
+// CodePen-safe: no imports inside setup/step, no module-level W/H — the screen
+// dims come from SCREEN_W / SCREEN_H.
+
+const SCREEN_W = 900;
+const SCREEN_H = 500;
+
+// ── World / terrain ─────────────────────────────────────────────────────────
+const WORLD_W = 6000;
+const SEG_W = 40;               // terrain sample spacing
+const GRAVITY = 1100;
+
+// Rolling hills are a sum of sines — same trick as car-sideview but longer and
+// a touch tamer so the bike can actually climb. groundY is the baseline.
+function terrainY(x, groundY) {
+  return groundY
+    + Math.sin(x * 0.0016) * 110   // long sweeping hills
+    + Math.sin(x * 0.006) * 38     // medium rollers
+    + Math.sin(x * 0.02) * 10      // small chatter
+    + Math.sin(x * 0.045) * 4;     // fine bumps
+}
+
+// Build the terrain as a chain of static Polygon quads from each surface pair
+// down to a flat skirt. NO explicit Material on the terrain — the known
+// "Polygon + explicit Material → tunneling" bug bites static floors too, so we
+// take engine defaults here and tune grip via the wheel materials instead.
+function buildTerrain(space, groundY) {
+  const numSegs = Math.ceil(WORLD_W / SEG_W);
+  const bottom = groundY + 260;
+  for (let i = 0; i < numSegs; i++) {
+    const x0 = i * SEG_W;
+    const x1 = x0 + SEG_W;
+    const y0 = terrainY(x0, groundY);
+    const y1 = terrainY(x1, groundY);
+    const seg = new Body(BodyType.STATIC);
+    seg.shapes.add(new Polygon([
+      new Vec2(x0, y0),
+      new Vec2(x1, y1),
+      new Vec2(x1, bottom),
+      new Vec2(x0, bottom),
+    ]));
+    try { seg.userData._colorIdx = 5; } catch (_) {}
+    seg.space = space;
+  }
+}
+
+// ── Bike tuning ─────────────────────────────────────────────────────────────
+const WHEEL_R = 22;
+const WHEEL_BASE = 52;          // half the axle-to-axle distance
+const CHASSIS_H = 14;
+const SUSP_REST = 34;           // spring rest length (chassis → wheel)
+const SUSP_FREQ = 3.0;
+const SUSP_DAMP = 0.5;
+const SUSP_MIN = -8;            // LineJoint travel limits
+const SUSP_MAX = 30;
+const MOTOR_RATE = 26;          // rear-wheel motor angular rate
+const LEAN_TORQUE = 9;          // chassis lean angular impulse per frame
+
+// Flip / crash detection. If the chassis tilts past FLIP_ANGLE for
+// FLIP_FRAMES consecutive steps, or takes a hard vertical impact, the rider's
+// seat weld breaks away.
+const FLIP_ANGLE = 2.2;         // radians from upright (~126°)
+const FLIP_FRAMES = 18;         // ~0.3s sustained before bail
+const CRASH_IMPACT_SPEED = 720; // downward speed that counts as a hard smack
+
+// ── Module state ────────────────────────────────────────────────────────────
+let _space = null;
+let _chassis = null;
+let _fWheel = null;
+let _rWheel = null;
+let _rMotor = null;
+let _fSusp = null;
+let _rSusp = null;
+
+// Rider rig — the welded ragdoll. `_seatWeld` is the break-away joint; the rest
+// are the articulation. `_riderParts` / `_riderJoints` are kept for teardown.
+let _rider = null;            // { pelvis, torso, head, ... } refs for drawing
+let _seatWeld = null;
+let _riderParts = [];
+let _riderJoints = [];
+let _crashed = false;
+let _flipFrames = 0;
+let _maxDist = 0;             // furthest the bike has travelled (for HUD)
+let _frame = 0;
+let _stepped = false;        // set true each physics step; gates camera lerp
+
+const keys = {};
+let _onKeyDown = null;
+let _onKeyUp = null;
+
+// Spawn anchor — recomputed on reset so the bike always lands on the surface.
+let _spawnX = 220;
+let _spawnGroundY = 0;
+
+// ── Rider ragdoll ───────────────────────────────────────────────────────────
+// A compact seated ragdoll. The pelvis is the root: it gets WELDED to the
+// chassis seat so the bike's lean transmits through. Every other joint is a
+// PivotJoint (the physical hinge) plus a soft AngleJoint (the spring that gives
+// the limb a rest pose + a sway range). The torso's AngleJoint window is the
+// "lean transmission" — when the welded pelvis pitches with the bike, the
+// torso sways forward/back inside that window.
+function buildRider(space, seatX, seatY) {
+  _riderParts = [];
+  _riderJoints = [];
+
+  const add = (body) => { _riderParts.push(body); return body; };
+  const joint = (j) => { j.space = space; _riderJoints.push(j); return j; };
+
+  // Soft angle hinge helper — rest pose with a sway range and a gentle spring.
+  const hinge = (a, b, anchorA, anchorB, min, max, freq = 7, damp = 0.7) => {
+    joint(new PivotJoint(a, b, anchorA, anchorB));
+    const ang = new AngleJoint(a, b, min, max);
+    ang.stiff = false;
+    ang.frequency = freq;
+    ang.damping = damp;
+    return joint(ang);
+  };
+
+  // Pelvis — the root the bike weld attaches to.
+  const pelvis = add(new Body(BodyType.DYNAMIC, new Vec2(seatX, seatY)));
+  pelvis.shapes.add(new Polygon(Polygon.box(20, 14), new Material(0.1, 0.4, 0.5, 0.6)));
+  try { pelvis.userData._colorIdx = 1; } catch (_) {}
+  pelvis.space = space;
+
+  // Torso — leans with the bike. Its AngleJoint window IS the lean transmission.
+  const torso = add(new Body(BodyType.DYNAMIC, new Vec2(seatX, seatY - 24)));
+  torso.shapes.add(new Polygon(Polygon.box(16, 34), new Material(0.1, 0.4, 0.5, 0.5)));
+  try { torso.userData._colorIdx = 1; } catch (_) {}
+  torso.space = space;
+  hinge(pelvis, torso, new Vec2(0, -7), new Vec2(0, 17), -0.9, 0.9, 6, 0.5);
+
+  // Head.
+  const head = add(new Body(BodyType.DYNAMIC, new Vec2(seatX, seatY - 50)));
+  head.shapes.add(new Circle(9, undefined, new Material(0.1, 0.4, 0.5, 0.5)));
+  try { head.userData._colorIdx = 1; } catch (_) {}
+  head.space = space;
+  hinge(torso, head, new Vec2(0, -17), new Vec2(0, 9), -0.5, 0.5, 8, 0.7);
+
+  // Arms — both reach forward toward the bars (handlebar offset is ahead of
+  // the seat). Narrow ranges so they stay roughly on the grips while seated.
+  const armLen = 18, armW = 6;
+  const buildArm = (sx) => {
+    const upper = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + sx, seatY - 16)));
+    upper.shapes.add(new Polygon(Polygon.box(armLen, armW), new Material(0.1, 0.4, 0.5, 0.4)));
+    try { upper.userData._colorIdx = 2; } catch (_) {}
+    upper.space = space;
+    hinge(torso, upper, new Vec2(sx > 0 ? 8 : -8, -10), new Vec2(sx > 0 ? -9 : 9, 0), -1.2, 1.2, 5, 0.5);
+
+    const lower = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + sx + (sx > 0 ? armLen : -armLen), seatY - 16)));
+    lower.shapes.add(new Polygon(Polygon.box(armLen, armW), new Material(0.1, 0.4, 0.5, 0.4)));
+    try { lower.userData._colorIdx = 2; } catch (_) {}
+    lower.space = space;
+    hinge(upper, lower, new Vec2(sx > 0 ? 9 : -9, 0), new Vec2(sx > 0 ? -9 : 9, 0), -1.0, 1.0, 5, 0.5);
+    return { upper, lower };
+  };
+  const lArm = buildArm(-2);
+  const rArm = buildArm(2);
+
+  // Legs — bent at the knee in a seated/pegged pose; thighs forward, shins down.
+  const thighLen = 22, shinLen = 22, legW = 8;
+  const buildLeg = (sx) => {
+    const thigh = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + sx + 10, seatY + 4)));
+    thigh.shapes.add(new Polygon(Polygon.box(thighLen, legW), new Material(0.1, 0.4, 0.5, 0.5)));
+    try { thigh.userData._colorIdx = 2; } catch (_) {}
+    thigh.space = space;
+    hinge(pelvis, thigh, new Vec2(sx, 5), new Vec2(-10, 0), -0.6, 0.6, 5, 0.5);
+
+    const shin = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + sx + 22, seatY + 18)));
+    shin.shapes.add(new Polygon(Polygon.box(legW, shinLen), new Material(0.1, 0.4, 0.5, 0.5)));
+    try { shin.userData._colorIdx = 2; } catch (_) {}
+    shin.space = space;
+    hinge(thigh, shin, new Vec2(10, 0), new Vec2(0, -10), -0.4, 0.8, 5, 0.5);
+    return { thigh, shin };
+  };
+  const lLeg = buildLeg(-2);
+  const rLeg = buildLeg(2);
+
+  _rider = { pelvis, torso, head, lArm, rArm, lLeg, rLeg };
+  return pelvis;
+}
+
+// ── Bike ────────────────────────────────────────────────────────────────────
+// Chassis is a single low Polygon (no explicit Material → dodges the tunneling
+// bug). Wheels are Circles with grippy Material (high friction, low bounce) on
+// SpringJoint suspension constrained to vertical travel by a LineJoint. The
+// rear wheel gets a MotorJoint = throttle. The rider's pelvis is WELDED to the
+// chassis seat — that weld is the break-away joint.
+function buildBike(space, spawnX, groundY) {
+  const cy = groundY - 90;
+
+  // Chassis — a stubby motorbike silhouette. Default material on purpose.
+  const chassis = new Body(BodyType.DYNAMIC, new Vec2(spawnX, cy));
+  chassis.shapes.add(new Polygon([
+    new Vec2(-46, -2), new Vec2(40, -2),
+    new Vec2(46, 4), new Vec2(40, 10),
+    new Vec2(-46, 10), new Vec2(-52, 4),
+  ]));
+  // Seat hump at the back + a little tank up front for visual read.
+  chassis.shapes.add(new Polygon([
+    new Vec2(-44, -14), new Vec2(-14, -14),
+    new Vec2(-10, -2), new Vec2(-44, -2),
+  ]));
+  chassis.shapes.add(new Polygon([
+    new Vec2(8, -10), new Vec2(34, -6),
+    new Vec2(36, -2), new Vec2(8, -2),
+  ]));
+  try { chassis.userData._colorIdx = 0; } catch (_) {}
+  chassis.space = space;
+
+  const wheelMat = new Material(0.2, 1.6, 1.8, 1.4);  // bouncy-low, very grippy
+  const makeWheel = (dx) => {
+    const w = new Body(BodyType.DYNAMIC, new Vec2(spawnX + dx, cy + 46));
+    w.shapes.add(new Circle(WHEEL_R, undefined, wheelMat));
+    try { w.userData._colorIdx = 3; } catch (_) {}
+    w.space = space;
+    return w;
+  };
+  const fWheel = makeWheel(WHEEL_BASE);
+  const rWheel = makeWheel(-WHEEL_BASE);
+
+  // Suspension: spring + vertical line constraint per wheel.
+  const suspend = (wheel, dx) => {
+    const spring = new SpringJoint(
+      chassis, wheel,
+      new Vec2(dx, CHASSIS_H / 2), new Vec2(0, 0),
+      SUSP_REST,
+    );
+    spring.frequency = SUSP_FREQ;
+    spring.damping = SUSP_DAMP;
+    spring.space = space;
+    new LineJoint(
+      chassis, wheel,
+      new Vec2(dx, CHASSIS_H / 2), new Vec2(0, 0),
+      new Vec2(0, 1), SUSP_MIN, SUSP_MAX,
+    ).space = space;
+    return spring;
+  };
+  _fSusp = suspend(fWheel, WHEEL_BASE);
+  _rSusp = suspend(rWheel, -WHEEL_BASE);
+
+  // Rear-wheel motor = throttle (rate set per frame in step()).
+  _rMotor = new MotorJoint(chassis, rWheel, 0);
+  _rMotor.space = space;
+
+  _chassis = chassis;
+  _fWheel = fWheel;
+  _rWheel = rWheel;
+
+  // Rider welded to the seat. The pelvis sits just above the seat hump; the
+  // WeldJoint's anchors lock the pelvis rigidly to that point so the chassis
+  // lean drives the rider. Breaking this weld (`_seatWeld.space = null`) is the
+  // break-away showcase on a crash.
+  const seatLocalX = -28;       // over the seat hump
+  const seatLocalY = -18;
+  const seatX = chassis.position.x + seatLocalX;
+  const seatY = chassis.position.y + seatLocalY;
+  const pelvis = buildRider(space, seatX, seatY);
+  _seatWeld = new WeldJoint(
+    chassis, pelvis,
+    new Vec2(seatLocalX, seatLocalY), new Vec2(0, 0),
+  );
+  _seatWeld.stiff = false;       // a touch of give so leans read as sway, not rigid
+  _seatWeld.frequency = 9;
+  _seatWeld.damping = 0.7;
+  _seatWeld.space = space;
+}
+
+// ── Reset / respawn ─────────────────────────────────────────────────────────
+// Detach joints BEFORE bodies (nape requires both endpoints share the joint's
+// space; pulling a body first leaves a dangling constraint that throws on the
+// next mutation — same ordering floppy-fists uses).
+function teardownBikeAndRider() {
+  if (_seatWeld && _seatWeld.space) _seatWeld.space = null;
+  _seatWeld = null;
+  for (const j of _riderJoints) { if (j.space) j.space = null; }
+  _riderJoints = [];
+  if (_fSusp && _fSusp.space) _fSusp.space = null;
+  if (_rSusp && _rSusp.space) _rSusp.space = null;
+  if (_rMotor && _rMotor.space) _rMotor.space = null;
+  _fSusp = _rSusp = _rMotor = null;
+
+  for (const b of _riderParts) { if (b.space) b.space = null; }
+  _riderParts = [];
+  for (const b of [_chassis, _fWheel, _rWheel]) { if (b && b.space) b.space = null; }
+  _chassis = _fWheel = _rWheel = _rider = null;
+}
+
+function respawn() {
+  teardownBikeAndRider();
+  _crashed = false;
+  _flipFrames = 0;
+  buildBike(_space, _spawnX, _spawnGroundY);
+  _maxDist = 0;
+}
+
+// ── Crash / break-away ──────────────────────────────────────────────────────
+// On a sustained flip or a hard impact, break the seat weld so the rider
+// ragdolls free. We only break once (the weld is gone afterward).
+function bailRider() {
+  if (_crashed || !_seatWeld) return;
+  _crashed = true;
+  if (_seatWeld.space) _seatWeld.space = null;
+  _seatWeld = null;
+  // A small backward+up kick on the pelvis so the rider visibly tumbles off
+  // the back rather than sitting in place.
+  if (_rider && _rider.pelvis && _rider.pelvis.space) {
+    const v = _rider.pelvis.velocity;
+    _rider.pelvis.velocity = new Vec2(v.x - 120, v.y - 160);
+  }
+  // Open the torso/head/limb angle windows so the freed rider flops loosely.
+  for (const j of _riderJoints) {
+    if (j.jointMin !== undefined && j.jointMax !== undefined) {
+      j.jointMin = -Math.PI;
+      j.jointMax = Math.PI;
+      j.frequency = 2;
+      j.damping = 0.3;
+    }
+  }
+}
+
+export default {
+  id: "dirtline",
+  label: "Dirtline",
+  featured: false,
+  tags: ["MotorJoint", "SpringJoint", "WeldJoint", "Ragdoll", "Vehicle", "Camera", "Break-away"],
+  desc:
+    "Hill-climb trials bike with an articulated ragdoll rider welded to the " +
+    "seat. <b>→</b> / <b>D</b> throttle, <b>←</b> / <b>A</b> reverse, " +
+    "<b>↑</b> / <b>W</b> lean back (pop the front), <b>↓</b> / <b>S</b> lean " +
+    "forward (nose-down). Flip the bike or smack the ground hard and the rider " +
+    "breaks away and tumbles off. <b>R</b> or click to respawn. " +
+    "Showcases MotorJoint wheels on SpringJoint suspension, a ragdoll attached " +
+    "to a moving vehicle, and a break-away WeldJoint.",
+  walls: false,
+
+  camera: null,
+
+  setup(space) {
+    _space = space;
+    space.gravity = new Vec2(0, GRAVITY);
+
+    _frame = 0;
+    const groundY = SCREEN_H - 60;
+    _spawnGroundY = groundY;
+    _spawnX = 220;
+
+    buildTerrain(space, groundY);
+
+    // Left / right world walls so the bike can't fall off the ends.
+    const wallL = new Body(BodyType.STATIC, new Vec2(-30, 0));
+    wallL.shapes.add(new Polygon(Polygon.box(40, SCREEN_H * 4)));
+    wallL.space = space;
+    const wallR = new Body(BodyType.STATIC, new Vec2(WORLD_W + 30, 0));
+    wallR.shapes.add(new Polygon(Polygon.box(40, SCREEN_H * 4)));
+    wallR.space = space;
+
+    buildBike(space, _spawnX, groundY);
+
+    _crashed = false;
+    _flipFrames = 0;
+    _maxDist = 0;
+
+    // Function follow so the camera tracks whatever the *current* chassis is —
+    // respawn() builds a fresh chassis body, and a static body ref would leave
+    // the camera following the removed one.
+    this.camera = {
+      follow: () => {
+        if (_chassis) return { x: _chassis.position.x, y: _chassis.position.y };
+        return { x: _spawnX, y: _spawnGroundY - 90 };
+      },
+      offsetX: 0,
+      offsetY: -30,
+      bounds: { minX: 0, minY: -400, maxX: WORLD_W, maxY: SCREEN_H + 300 },
+      lerp: 0.1,
+    };
+
+    for (const k of Object.keys(keys)) keys[k] = false;
+    _onKeyDown = (e) => {
+      keys[e.code] = true;
+      if (e.code === "KeyR") respawn();
+      if ([
+        "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown",
+        "KeyA", "KeyD", "KeyW", "KeyS",
+      ].includes(e.code)) {
+        e.preventDefault();
+      }
+    };
+    _onKeyUp = (e) => { keys[e.code] = false; };
+    if (typeof window !== "undefined") {
+      window.addEventListener("keydown", _onKeyDown);
+      window.addEventListener("keyup", _onKeyUp);
+    }
+  },
+
+  teardown() {
+    if (typeof window !== "undefined") {
+      if (_onKeyDown) window.removeEventListener("keydown", _onKeyDown);
+      if (_onKeyUp) window.removeEventListener("keyup", _onKeyUp);
+    }
+    _onKeyDown = _onKeyUp = null;
+  },
+
+  step(space) {
+    _frame++;
+    _stepped = true;
+    if (!_chassis) return;
+
+    // ── Throttle (rear motor) ──────────────────────────────────────────────
+    const fwd = keys.ArrowRight || keys.KeyD || keys._touchRight;
+    const rev = keys.ArrowLeft || keys.KeyA || keys._touchLeft;
+    if (_rMotor) {
+      if (fwd) _rMotor.rate = MOTOR_RATE;
+      else if (rev) _rMotor.rate = -MOTOR_RATE;
+      else _rMotor.rate = 0;
+    }
+
+    // ── Lean (chassis angular impulse) ─────────────────────────────────────
+    // Up/back = pop the front up (counter-clockwise = negative torque in
+    // screen coords where +y is down). Down/forward = nose-down.
+    const leanBack = keys.ArrowUp || keys.KeyW || keys._touchUp;
+    const leanFwd = keys.ArrowDown || keys.KeyS || keys._touchDown;
+    if (leanBack) _chassis.applyAngularImpulse(-LEAN_TORQUE);
+    if (leanFwd) _chassis.applyAngularImpulse(LEAN_TORQUE);
+
+    // ── Distance HUD ───────────────────────────────────────────────────────
+    const dist = Math.max(0, (_chassis.position.x - _spawnX));
+    if (dist > _maxDist) _maxDist = dist;
+
+    // ── Crash detection: sustained flip OR hard ground impact ──────────────
+    if (!_crashed) {
+      // Normalise chassis rotation into [-π, π] and measure tilt from upright.
+      let rot = _chassis.rotation % (Math.PI * 2);
+      if (rot > Math.PI) rot -= Math.PI * 2;
+      if (rot < -Math.PI) rot += Math.PI * 2;
+      if (Math.abs(rot) > FLIP_ANGLE) {
+        _flipFrames++;
+        if (_flipFrames > FLIP_FRAMES) bailRider();
+      } else {
+        _flipFrames = 0;
+      }
+
+      // Hard impact: chassis is moving down fast while a wheel is in contact.
+      const vy = _chassis.velocity.y;
+      if (vy > CRASH_IMPACT_SPEED && wheelTouchingGround()) {
+        bailRider();
+        if (this._runner) this._runner.shakeCamera(8, 0.25);
+      }
+    }
+  },
+
+  click(x, y, space) {
+    // Click respawns once crashed; otherwise tap-left / tap-right drives.
+    if (_crashed) { respawn(); return; }
+    if (!_chassis) return;
+    if (x < _chassis.position.x) keys._touchLeft = true;
+    else keys._touchRight = true;
+  },
+
+  drag(x, y) {
+    if (!_chassis || _crashed) return;
+    keys._touchLeft = keys._touchRight = false;
+    if (x < _chassis.position.x) keys._touchLeft = true;
+    else keys._touchRight = true;
+  },
+
+  release() {
+    keys._touchLeft = keys._touchRight = false;
+    keys._touchUp = keys._touchDown = false;
+  },
+
+  render3dOverlay(ctx, _ignored, W, H, camX, camY) {
+    const sw = W ?? SCREEN_W;
+    drawSuspension(ctx, camX ?? 0, camY ?? 0);
+    drawHUD(ctx, sw);
+  },
+};
+
+// ── Helpers (kept below export for readability; all module-level so the ──────
+//    CodePen extractor picks them up as preamble) ────────────────────────────
+
+// True if either wheel currently has a contact arbiter (ground touch).
+function wheelTouchingGround() {
+  if (!_space || !_rWheel) return false;
+  try {
+    const arbs = _space.arbiters;
+    const count = arbs.zpp_gl();
+    for (let i = 0; i < count; i++) {
+      const a = arbs.at(i);
+      if (a.body1 === _rWheel || a.body2 === _rWheel ||
+          a.body1 === _fWheel || a.body2 === _fWheel) {
+        return true;
+      }
+    }
+  } catch (_) {}
+  return false;
+}
+
+// Draw the suspension springs (chassis anchor → wheel hub) in world space.
+function drawSpring(ctx, x1, y1, x2, y2, color, coils = 5, amp = 5) {
+  const dx = x2 - x1, dy = y2 - y1;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len < 2) return;
+  const ux = dx / len, uy = dy / len;
+  const px = -uy, py = ux;
+  const n = coils * 2;
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x1 + ux * len * 0.1, y1 + uy * len * 0.1);
+  for (let i = 1; i <= n; i++) {
+    const t = 0.1 + (i / n) * 0.8;
+    const sign = i % 2 === 0 ? 1 : -1;
+    ctx.lineTo(x1 + ux * len * t + px * amp * sign, y1 + uy * len * t + py * amp * sign);
+  }
+  ctx.lineTo(x2, y2);
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.setLineDash([]);
+  ctx.stroke();
+}
+
+function drawSuspension(ctx, camX, camY) {
+  if (!_chassis || !_fWheel || !_rWheel) return;
+  ctx.save();
+  ctx.translate(-camX, -camY);
+  const cp = _chassis.position;
+  const ca = _chassis.rotation;
+  const cos = Math.cos(ca), sin = Math.sin(ca);
+  const offY = CHASSIS_H / 2;
+  const anchor = (dx) => ({
+    x: cp.x + (dx * cos - offY * sin),
+    y: cp.y + (dx * sin + offY * cos),
+  });
+  const fa = anchor(WHEEL_BASE);
+  const ra = anchor(-WHEEL_BASE);
+  drawSpring(ctx, fa.x, fa.y, _fWheel.position.x, _fWheel.position.y, "#d2992299");
+  drawSpring(ctx, ra.x, ra.y, _rWheel.position.x, _rWheel.position.y, "#d2992299");
+  ctx.restore();
+}
+
+function drawHUD(ctx, sw) {
+  ctx.save();
+  ctx.textBaseline = "alphabetic";
+
+  // Distance + speed readout.
+  const meters = (_maxDist / 40).toFixed(1);
+  let speed = 0;
+  if (_chassis) speed = Math.hypot(_chassis.velocity.x, _chassis.velocity.y) / 40;
+  ctx.fillStyle = "rgba(13,17,23,0.78)";
+  ctx.fillRect(10, 10, 188, 60);
+  ctx.fillStyle = "#e6edf3";
+  ctx.font = "bold 16px system-ui, sans-serif";
+  ctx.textAlign = "left";
+  ctx.fillText(`Distance: ${meters} m`, 22, 34);
+  ctx.font = "13px system-ui, sans-serif";
+  ctx.fillStyle = "#8b949e";
+  ctx.fillText(`Speed: ${speed.toFixed(1)} m/s`, 22, 56);
+
+  // Crashed banner + restart hint.
+  if (_crashed) {
+    ctx.fillStyle = "rgba(248,81,73,0.92)";
+    ctx.fillRect(sw / 2 - 150, 18, 300, 56);
+    ctx.fillStyle = "#fff";
+    ctx.font = "bold 22px system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("CRASHED!", sw / 2, 44);
+    ctx.font = "13px system-ui, sans-serif";
+    ctx.fillText("Press R or click to respawn", sw / 2, 64);
+  }
+  ctx.restore();
+}

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -179,24 +179,14 @@ const CRASH_SPIN_RATE = 7;      // rad/s — above this the bike is tumbling out
                                 // control (a fast flip never sustains one angle)
 const CRASH_SPIN_FRAMES = 14;   // ~0.23s of that spin before the rider bails
 
-// ── Rider active-pose targets ───────────────────────────────────────────────
+// ── Rider limb hinges ───────────────────────────────────────────────────────
 // Each limb is BUILT already rotated into its seated rest pose (arms reaching
-// up-forward to the bars, legs angled down to the pegs), and each AngleJoint
-// holds its hinge at the relative angle that *reproduces* that built pose. The
-// pose values below are therefore small lean DELTAS layered on top of that rest
-// pose (jointMin === jointMax = an always-active hard/soft lock around the rest
-// angle + delta — see the AngleJoint slack note). step() lerps between a NEUTRAL
-// seat, a CROUCH (lean forward / on the gas — tucked low over the bars) and a
-// STAND (lean back — weight up and off the back). Sign: +torso leans back,
-// −torso leans forward; limb deltas were tuned so the silhouette reads.
-//
-// pose = { torso, head, shoulder, elbow, hip, knee }  (radians, deltas)
-const POSE_NEUTRAL = { torso:  0.00, head: 0.00, shoulder:  0.00, elbow: 0.00, hip:  0.00, knee: 0.00 };
-const POSE_CROUCH  = { torso: -0.55, head: 0.25, shoulder: -0.35, elbow: 0.20, hip: -0.30, knee: 0.35 };
-const POSE_STAND   = { torso:  0.55, head: -0.18, shoulder: 0.35, elbow: -0.30, hip:  0.55, knee: -0.45 };
-const POSE_LERP = 0.14;         // how fast the rider settles into a new target pose
-const POSE_SOFT = 0.04;         // half-width kept around each target so the spring
-                                // isn't perfectly rigid (a hair of natural give)
+// up-forward to the bars, legs angled down to the pegs); each AngleJoint is a
+// soft spring around that built rest angle. The rider is attached to the bike
+// only at the hands (handlebar) and feet (pegs) plus a soft pelvis tether, so
+// the body hangs naturally on those points — the hinges just keep the limbs
+// from flailing, they don't pose the body rigidly.
+const POSE_SOFT = 0.04;         // half-width of each hinge's rest window
 
 // ── Module state ────────────────────────────────────────────────────────────
 let _space = null;
@@ -217,11 +207,6 @@ let _gripJoints = [];         // hand→handlebar pins (break away with the seat
 let _pegJoints = [];          // foot→footpeg pins (break away with the seat weld)
 let _riderParts = [];
 let _riderJoints = [];
-// Pose-driving AngleJoints, grouped so step() can push each toward its target.
-// { torso, head, shoulders[], elbows[], hips[], knees[] }
-let _poseJoints = null;
-// The rider's current (lerped) pose — driven toward POSE_* targets each step.
-let _pose = { ...POSE_NEUTRAL };
 let _crashed = false;
 let _flipFrames = 0;
 let _spinFrames = 0;
@@ -284,7 +269,7 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     }
     ang.space = space;
     _riderJoints.push(ang);
-    return { joint: ang, base };            // keep base so applyPose adds the delta
+    return { joint: ang, base };            // (return kept for symmetry; unused)
   };
 
   // Lighter limbs than the bike so the rider doesn't overpower the suspension.
@@ -299,18 +284,18 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   // Torso — slightly forward-leaning rest pose (a rider crouches a touch over
   // the bars). Its pose delta is the visible weight shift (crouch / stand).
   const torso = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + 3, seatY - 21)));
-  torso.rotation = 0.18;          // lean a little forward at rest
+  torso.rotation = -0.15;         // sit fairly upright (slight back lean at rest)
   torso.shapes.add(new Polygon(Polygon.box(14, 30), RM(0.5)));
   try { torso.userData._colorIdx = 1; } catch (_) {}
   torso.space = space;
-  const jTorso = poseHinge(pelvis, torso, new Vec2(0, -5), new Vec2(-2, 15), { stiff: true });
+  poseHinge(pelvis, torso, new Vec2(0, -5), new Vec2(-2, 15), { freq: 9, damp: 0.8 });
 
   // Head — sits atop the torso, follows its lean.
   const head = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + 7, seatY - 44)));
   head.shapes.add(new Circle(8.5, undefined, RM(0.5)));
   try { head.userData._colorIdx = 1; } catch (_) {}
   head.space = space;
-  const jHead = poseHinge(torso, head, new Vec2(0, -15), new Vec2(0, 8.5), { freq: 14, damp: 0.9 });
+  poseHinge(torso, head, new Vec2(0, -15), new Vec2(0, 8.5), { freq: 14, damp: 0.9 });
 
   // Arms — built reaching UP-FORWARD from the shoulder toward the handlebars at
   // the front of the bike. Upper arm angled ~ -0.5 rad (up-forward), forearm
@@ -365,7 +350,7 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     try { thigh.userData._colorIdx = 2; } catch (_) {}
     thigh.space = space;
     hips.push(poseHinge(pelvis, thigh, new Vec2(8, 4), new Vec2(-thighLen / 2, 0),
-      { stiff: true }));
+      { freq: 4, damp: 0.6 }));
 
     const kneeX = hipX + Math.cos(ta) * thighLen;
     const kneeY = hipY + Math.sin(ta) * thighLen;
@@ -417,30 +402,8 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   for (const j of _gripJoints) j.space = space;
   for (const j of _pegJoints) j.space = space;
 
-  _poseJoints = { torso: jTorso, head: jHead, shoulders, elbows, hips, knees };
-  _pose = { ...POSE_NEUTRAL };
   _rider = { pelvis, torso, head, lArm, rArm, lLeg, rLeg };
   return pelvis;
-}
-
-// Push every pose joint's target toward the current lerped `_pose`. Each entry
-// is { joint, base }; the commanded angle is base (the built rest pose) + the
-// lean delta. Setting jointMin/jointMax to a near-point around it keeps the
-// lock always-active (a real window would let the limb go slack inside it).
-function applyPose() {
-  if (!_poseJoints) return;
-  const set = (h, delta) => {
-    if (!h || !h.joint || h.joint.space === null) return;
-    const t = h.base + delta;
-    h.joint.jointMin = t - POSE_SOFT;
-    h.joint.jointMax = t + POSE_SOFT;
-  };
-  set(_poseJoints.torso, _pose.torso);
-  set(_poseJoints.head, _pose.head);
-  for (const h of _poseJoints.shoulders) set(h, _pose.shoulder);
-  for (const h of _poseJoints.elbows) set(h, _pose.elbow);
-  for (const h of _poseJoints.hips) set(h, _pose.hip);
-  for (const h of _poseJoints.knees) set(h, _pose.knee);
 }
 
 // ── Bike ────────────────────────────────────────────────────────────────────
@@ -606,13 +569,18 @@ function buildBike(space, spawnX, groundY) {
     const gripLocal = new Vec2(27, -31);
     const pegLocal = new Vec2(-4, 10);
     const pelvis = buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal);
+    // The rider is attached to the bike ONLY at the hands (handlebar) and feet
+    // (pegs) — see the grip/peg pins in buildRider. The pelvis just rests on the
+    // seat with a very soft tether so the body hangs naturally between those four
+    // points (no rigid weld → no over-constraint jitter, not a stiff puppet). The
+    // tether is gentle enough to read as "sitting", not "bolted on".
     _seatWeld = new WeldJoint(
       chassis, pelvis,
       new Vec2(seatLocalX, seatLocalY), new Vec2(0, 0),
     );
-    _seatWeld.stiff = false;       // soft-but-firm: high frequency so it holds tight
-    _seatWeld.frequency = 18;
-    _seatWeld.damping = 0.9;
+    _seatWeld.stiff = false;
+    _seatWeld.frequency = 8;       // soft seat tether — holds the pelvis planted
+    _seatWeld.damping = 0.7;       // but with give, so the rider isn't bolted rigid
     _seatWeld.space = space;
   }
 }
@@ -639,8 +607,6 @@ function teardownBikeAndRider() {
   _riderParts = [];
   for (const b of [_chassis, _fWheel, _rWheel, _swingarm]) { if (b && b.space) b.space = null; }
   _chassis = _fWheel = _rWheel = _swingarm = _rider = null;
-  _poseJoints = null;
-  _pose = { ...POSE_NEUTRAL };
 }
 
 function respawn() {
@@ -672,9 +638,8 @@ function bailRider() {
     const v = _rider.pelvis.velocity;
     _rider.pelvis.velocity = new Vec2(v.x - 120, v.y - 160);
   }
-  // Stop driving the pose and throw every limb window wide so the freed rider
-  // flops loosely instead of holding its seated shape.
-  _poseJoints = null;
+  // Throw every limb hinge window wide so the freed rider flops loosely
+  // instead of holding its seated shape.
   for (const j of _riderJoints) {
     if (j.jointMin !== undefined && j.jointMax !== undefined) {
       j.jointMin = -Math.PI;
@@ -824,22 +789,11 @@ export default {
       }
     }
 
-    // ── Active rider pose (the visible weight shift) ───────────────────────
-    // Choose a target pose from the lean keys and lerp toward it, then push the
-    // pose joints. Lean back → STAND (weight off the back); lean forward / on
-    // the gas → CROUCH (tucked over the bars); otherwise the NEUTRAL seat.
-    if (!_crashed && _poseJoints) {
-      let target = POSE_NEUTRAL;
-      if (leanBack) target = POSE_STAND;
-      else if (leanFwd || fwd) target = POSE_CROUCH;
-      _pose.torso += (target.torso - _pose.torso) * POSE_LERP;
-      _pose.head += (target.head - _pose.head) * POSE_LERP;
-      _pose.shoulder += (target.shoulder - _pose.shoulder) * POSE_LERP;
-      _pose.elbow += (target.elbow - _pose.elbow) * POSE_LERP;
-      _pose.hip += (target.hip - _pose.hip) * POSE_LERP;
-      _pose.knee += (target.knee - _pose.knee) * POSE_LERP;
-      applyPose();
-    }
+    // No active-pose driving: the rider is held to the bike only at the hands
+    // (handlebar) and feet (pegs), with soft limb hinges, so the body hangs and
+    // sways naturally between those four points. Leaning the bike moves the grip
+    // + peg anchors, which carries the rider's weight shift for free — no posed
+    // AngleJoint targets fighting the pins (that conflict caused the jitter).
 
     // ── Distance HUD ───────────────────────────────────────────────────────
     const dist = Math.max(0, (_chassis.position.x - _spawnX));

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -153,11 +153,13 @@ const MOTOR_FORCE = 75000;      // torque cap — moderate so acceleration doesn
 // Ground lean drives the chassis toward a TARGET pitch rate and holds it there,
 // strong enough to overpower the wheels' tendency to cancel the rotation each
 // frame (a gentle nudge just gets absorbed — that's why leaning felt dead).
-const LEAN_GROUND_VEL = 6.0;     // target pitch rate while a lean key is held (rad/s)
-const LEAN_GROUND_GAIN = 0.6;    // how hard we drive angularVel toward that target
+const LEAN_GROUND_VEL = 7.0;     // target pitch rate while a lean key is held (rad/s)
+const LEAN_GROUND_GAIN = 0.4;    // how hard we drive angularVel toward that target
 const LEAN_MAX_ANGLE = 1.15;     // rad (~66°) — past this we brake the spin so a
                                  // held lean gives a big wheelie/endo that HOLDS,
                                  // instead of looping the bike all the way over
+const GROUND_TOL = 6;            // px — a wheel counts as grounded if its bottom
+                                 // is within this of the terrain surface.
 const LEAN_TORQUE = 110;        // ground lean impulse per frame — pops a wheelie
                                 // / pushes the nose down for jump setup
 const AIR_SPIN_RATE = 0.45;     // rad/s added to chassis angularVel per frame
@@ -857,20 +859,22 @@ export default {
 //    CodePen extractor picks them up as preamble) ────────────────────────────
 
 // True if either wheel currently has a contact arbiter (ground touch).
+// True if either wheel is resting on the terrain. NOTE: we can't rely on
+// `space.arbiters` here — the demo runner calls demo.step() BEFORE space.step(),
+// so the arbiter list is empty/stale at this point (it always read 0 → the bike
+// was wrongly treated as permanently airborne, which silently disabled the
+// strong ground-lean). Instead we test geometry: a wheel is grounded if its
+// bottom edge is at/below the terrain surface (within a small tolerance). This
+// is independent of step order and matches what `buildTerrain` lays down.
 function wheelTouchingGround() {
-  if (!_space || !_rWheel) return false;
-  try {
-    const arbs = _space.arbiters;
-    const count = arbs.zpp_gl();
-    for (let i = 0; i < count; i++) {
-      const a = arbs.at(i);
-      if (a.body1 === _rWheel || a.body2 === _rWheel ||
-          a.body1 === _fWheel || a.body2 === _fWheel) {
-        return true;
-      }
-    }
-  } catch (_) {}
-  return false;
+  const onGround = (w) => {
+    if (!w) return false;
+    const p = w.position;
+    const surfaceY = terrainY(p.x, _spawnGroundY);
+    // wheel bottom = p.y + WHEEL_R; grounded if it's at/under the surface.
+    return p.y + WHEEL_R >= surfaceY - GROUND_TOL;
+  };
+  return onGround(_rWheel) || onGround(_fWheel);
 }
 
 // Draw the suspension springs (chassis anchor → wheel hub) in world space.

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -150,7 +150,10 @@ const MOTOR_RATE = 30;          // rear-wheel motor target angular rate. Kept
                                 // sane rate give smooth, fast power delivery.
 const MOTOR_FORCE = 75000;      // torque cap — moderate so acceleration doesn't
                                 // break traction (or loft the front into a flip).
-const LEAN_TORQUE = 40;         // ground lean impulse per frame — pops a wheelie
+const LEAN_GROUND_ASSIST = 0.9;  // rad/s of direct pitch added per frame on the
+                                 // ground so leaning is FELT (not absorbed by grip)
+const LEAN_GROUND_VEL = 4.5;     // cap on that ground-lean pitch rate (controllable)
+const LEAN_TORQUE = 110;        // ground lean impulse per frame — pops a wheelie
                                 // / pushes the nose down for jump setup
 const AIR_SPIN_RATE = 0.45;     // rad/s added to chassis angularVel per frame
                                 // while airborne — strong enough that holding a
@@ -734,8 +737,19 @@ export default {
       if (leanBack) _chassis.angularVel -= AIR_SPIN_RATE;
       if (leanFwd) _chassis.angularVel += AIR_SPIN_RATE;
     } else {
-      if (leanBack) _chassis.applyAngularImpulse(-LEAN_TORQUE);
-      if (leanFwd) _chassis.applyAngularImpulse(LEAN_TORQUE);
+      // On the ground the grounded wheels resist a pure torque (it mostly gets
+      // absorbed). To make leaning actually FEEL like a weight shift, combine a
+      // strong torque impulse with a direct angular-velocity bias toward the
+      // lean direction (capped, so the bike can lift a wheel into a wheelie /
+      // endo but the wheels still keep traction). Sign: nose-up = negative.
+      if (leanBack) {
+        _chassis.applyAngularImpulse(-LEAN_TORQUE);
+        if (_chassis.angularVel > -LEAN_GROUND_VEL) _chassis.angularVel -= LEAN_GROUND_ASSIST;
+      }
+      if (leanFwd) {
+        _chassis.applyAngularImpulse(LEAN_TORQUE);
+        if (_chassis.angularVel < LEAN_GROUND_VEL) _chassis.angularVel += LEAN_GROUND_ASSIST;
+      }
     }
 
     // ── Active rider pose (the visible weight shift) ───────────────────────

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -222,8 +222,9 @@ let _riderJoints = [];
 let _torsoHinge = null;       // pelvis→torso AngleJoint, retargeted on lean
 let _torsoBase = 0;           // its built rest angle (the upright seated pose)
 let _torsoLean = 0;           // current eased lean offset applied to the torso
-let _legHinges = [];          // [{ joint, base }] hip + knee hinges, retargeted on
-                              // lean so the legs extend/tuck with the weight shift
+let _legExtend = 0;           // eased 0→1: how much the legs are extended on a lean
+let _legHinges = [];          // [{ joint, base }] hip hinges, retargeted on lean so
+                              // the legs extend with the weight shift
 let _crashed = false;
 let _flipFrames = 0;
 let _spinFrames = 0;
@@ -378,7 +379,8 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     try { thigh.userData._colorIdx = 2; } catch (_) {}
     thigh.space = space;
     const hipH = poseHinge(pelvis, thigh, new Vec2(8, 4), new Vec2(-thighLen / 2, 0),
-      { freq: 9, damp: 0.8 });  // firmer so retargeting actually swings the leg
+      { freq: 14, damp: 0.85 }); // firm: with no pelvis weld, the hips hold the
+                                 // seated posture up (and let lean swing the leg)
     hips.push(hipH);
     _legHinges.push(hipH);      // retargeted on lean to extend/tuck the legs
 
@@ -427,26 +429,16 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     // a rigid pin locked the leg and killed that motion. jointMin=0 lets the
     // foot pull in; jointMax gives a little slack; the soft spring keeps it on
     // the peg under normal riding.
+    // The foot is pinned to the peg at a FIXED point (a rigid PivotJoint, like
+    // the hands on the bars) — the ankle. The knee/hip above it stay soft, so
+    // the leg can still bend/shift on a lean while the foot stays planted on the
+    // peg. The rider is attached to the bike ONLY here + at the hands (no pelvis
+    // weld), so the body genuinely hangs off the four contact points.
     for (const leg of [lLeg, rLeg]) {
-      const d = new DistanceJoint(
+      _pegJoints.push(new PivotJoint(
         chassis, leg.shin,
         new Vec2(pegLocal.x, pegLocal.y), new Vec2(shinLen / 2, 0),
-        0, 10,
-      );
-      d.stiff = false;
-      d.frequency = 6;
-      d.damping = 0.7;
-      _pegJoints.push(d);
-      // Hold the FOOT at a fixed orientation on the peg (the sole rests flat,
-      // not dangling) with a soft AngleJoint to the chassis. A ± window keeps it
-      // soft enough that the leg can still shift a little on a lean. It breaks
-      // away with the other peg joints on a crash (it's in _pegJoints).
-      const footRest = leg.shin.rotation - chassis.rotation;
-      const foot = new AngleJoint(chassis, leg.shin, footRest - FOOT_ANGLE_SLACK, footRest + FOOT_ANGLE_SLACK);
-      foot.stiff = false;
-      foot.frequency = 6;
-      foot.damping = 0.7;
-      _pegJoints.push(foot);
+      ));
     }
   }
   for (const j of _gripJoints) j.space = space;
@@ -604,33 +596,28 @@ function buildBike(space, spawnX, groundY) {
   // No physical swingarm body — it's drawn for looks in drawSuspension.
   _swingarm = null;
 
-  // Rider welded to the seat. The pelvis locks rigidly to that point so the
-  // chassis lean drives the whole rig; the *visible* weight shift comes from
-  // the active pose (applyPose), not from weld give — so this weld is firm.
-  // Breaking it (`_seatWeld.space = null`) is the break-away showcase on a crash.
-  // (BUILD_RIDER lets us bring the bike up alone while iterating on it.)
+  // Rider attachment. The pelvis gets a SOFT WeldJoint to the seat — not rigid,
+  // so the body isn't bolted on, but firm enough that the upper body doesn't
+  // fold forward off the bars. step() then actively poses the torso + legs with
+  // the lean keys (lean back → body back + legs extend; lean forward → body
+  // up-and-forward + legs extend), so the rider visibly shifts its whole weight.
+  // Hands stay pinned to the bars, feet to the pegs. (BUILD_RIDER lets us bring
+  // the bike up alone while iterating on it.)
   if (BUILD_RIDER) {
-    const seatLocalX = -18;       // over the seat, just behind the tank
+    const seatLocalX = -18;       // where the pelvis sits, over the seat
     const seatLocalY = -16;
     const seatX = chassis.position.x + seatLocalX;
     const seatY = chassis.position.y + seatLocalY;
-    // Hand + foot anchor points on the frame (chassis-local): the handlebar grip
-    // (the crossbar at the top of the riser) and a footpeg under the seat.
     const gripLocal = new Vec2(27, -31);
     const pegLocal = new Vec2(-4, 10);
     const pelvis = buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal);
-    // The rider is attached to the bike ONLY at the hands (handlebar) and feet
-    // (pegs) — see the grip/peg pins in buildRider. The pelvis just rests on the
-    // seat with a very soft tether so the body hangs naturally between those four
-    // points (no rigid weld → no over-constraint jitter, not a stiff puppet). The
-    // tether is gentle enough to read as "sitting", not "bolted on".
     _seatWeld = new WeldJoint(
       chassis, pelvis,
       new Vec2(seatLocalX, seatLocalY), new Vec2(0, 0),
     );
     _seatWeld.stiff = false;
-    _seatWeld.frequency = 8;       // soft seat tether — holds the pelvis planted
-    _seatWeld.damping = 0.7;       // but with give, so the rider isn't bolted rigid
+    _seatWeld.frequency = 7;       // soft seat — holds the pelvis without bolting it
+    _seatWeld.damping = 0.7;
     _seatWeld.space = space;
   }
 }
@@ -659,6 +646,7 @@ function teardownBikeAndRider() {
   _chassis = _fWheel = _rWheel = _swingarm = _rider = null;
   _torsoHinge = null;
   _torsoLean = 0;
+  _legExtend = 0;
   _legHinges = [];
 }
 
@@ -672,15 +660,15 @@ function respawn() {
 }
 
 // ── Crash / break-away ──────────────────────────────────────────────────────
-// On a sustained flip or a hard impact, break the seat weld so the rider
-// ragdolls free. We only break once (the weld is gone afterward).
+// On a sustained flip or a hard impact, release the rider's hand + foot pins so
+// the whole body comes free and ragdolls. We only break once.
 function bailRider() {
-  if (_crashed || !_seatWeld) return;
+  if (_crashed || !_rider) return;
   _crashed = true;
-  if (_seatWeld.space) _seatWeld.space = null;
+  // Release the seat weld + the hands from the bars + the feet from the pegs so
+  // the rider comes off the bike entirely.
+  if (_seatWeld && _seatWeld.space) _seatWeld.space = null;
   _seatWeld = null;
-  // Release the hands from the bars and the feet from the pegs too, so the whole
-  // rider comes free (not just the pelvis).
   for (const j of _gripJoints) { if (j.space) j.space = null; }
   for (const j of _pegJoints) { if (j.space) j.space = null; }
   _gripJoints = [];
@@ -842,29 +830,30 @@ export default {
       }
     }
 
-    // The rider is held to the bike at the hands (handlebar) and feet (pegs)
-    // with soft limb hinges, so the body hangs naturally. On top of that we
-    // shift the UPPER BODY with the lean keys: lean-back eases the torso back/up
-    // (the rider sits up and shifts weight rearward), lean-forward eases it
-    // forward over the bars. Only the torso hinge is retargeted (a soft spring,
-    // so it sways rather than snapping), and its window is clamped so the torso
-    // can't fold forward into the bike body (TORSO_FWD_MAX).
+    // Active rider pose — the whole-body weight shift. The soft seat weld holds
+    // the rider on the bike; here we drive the torso + legs with the lean keys:
+    //   • lean BACK  → torso leans back, legs EXTEND (rider stretches rearward)
+    //   • lean FWD   → torso reaches up-and-forward, legs EXTEND (stands/reaches)
+    //   • neutral    → torso upright, legs bent (relaxed seated pose)
+    // Both lean directions extend the legs (the rider pushes off the pegs); only
+    // the torso angle differs. Everything is eased so it sways, not snaps.
     if (!_crashed && _torsoHinge && _torsoHinge.space) {
-      let leanTarget = 0;
-      if (leanBack) leanTarget = TORSO_LEAN_BACK;
-      else if (leanFwd) leanTarget = TORSO_LEAN_FWD;
-      _torsoLean += (leanTarget - _torsoLean) * TORSO_LEAN_LERP;
-      const t = _torsoBase + Math.min(TORSO_FWD_MAX, _torsoLean);
+      // Torso target angle.
+      let torsoTarget = 0;
+      if (leanBack) torsoTarget = TORSO_LEAN_BACK;
+      else if (leanFwd) torsoTarget = TORSO_LEAN_FWD;
+      _torsoLean += (torsoTarget - _torsoLean) * TORSO_LEAN_LERP;
+      const t = _torsoBase + Math.max(-Math.abs(TORSO_LEAN_BACK), Math.min(TORSO_FWD_MAX, _torsoLean));
       _torsoHinge.jointMin = t - POSE_SOFT;
       _torsoHinge.jointMax = t + POSE_SOFT;
 
-      // Legs extend with the lean too: lean-back pushes the legs out (rider rises
-      // off the pegs), lean-forward tucks them. _torsoLean is negative on
-      // lean-back, so scale the hip offset off it for a synced whole-body shift.
-      const legOffset = (_torsoLean / Math.abs(TORSO_LEAN_BACK)) * -LEG_LEAN;
+      // Leg extension: extend on EITHER lean (rider rises off the pegs / stretches),
+      // bent when neutral. _legExtend eases 0→1; the hip opens by LEG_LEAN.
+      const wantExtend = (leanBack || leanFwd) ? 1 : 0;
+      _legExtend += (wantExtend - _legExtend) * TORSO_LEAN_LERP;
       for (const h of _legHinges) {
         if (!h || !h.joint || h.joint.space === null) continue;
-        const a = h.base + legOffset;
+        const a = h.base - LEG_LEAN * _legExtend;   // open the hip → leg straightens
         h.joint.jointMin = a - POSE_SOFT;
         h.joint.jointMax = a + POSE_SOFT;
       }

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -22,17 +22,47 @@ const SCREEN_H = 500;
 
 // ── World / terrain ─────────────────────────────────────────────────────────
 const WORLD_W = 6000;
-const SEG_W = 40;               // terrain sample spacing
+const SEG_W = 24;               // terrain sample spacing (fine enough that the
+                                // ramp lips read as smooth launches, not steps)
 const GRAVITY = 1100;
 
 // Rolling hills are a sum of sines — same trick as car-sideview but longer and
 // a touch tamer so the bike can actually climb. groundY is the baseline.
+// Kicker ramps spaced along the course — each launches the bike for real air
+// (the smooth sine hills alone only make little hops). A ramp is an asymmetric
+// bump: a long gentle approach up the front and a sharp drop off the back, so
+// you hit it, get launched, and have to control rotation before landing. Folded
+// into terrainY so the surface stays continuous (no seams to snag a wheel on).
+const RAMPS = [
+  { x: 1100, up: 46, w: 220 },
+  { x: 2200, up: 56, w: 250 },
+  { x: 3300, up: 50, w: 230 },
+  { x: 4400, up: 62, w: 260 },
+  { x: 5300, up: 54, w: 240 },
+];
+
+function rampLift(x) {
+  let lift = 0;
+  for (const r of RAMPS) {
+    const d = x - r.x;
+    // Smooth symmetric-ish kicker: long gentle approach, lip at d=0, then a
+    // somewhat shorter (but not cliff-like) back face. Gentle enough that a
+    // level approach lands cleanly; over-rotate in the air and you eat it.
+    if (d > -r.w && d < r.w * 0.6) {
+      const t = d < 0 ? (d + r.w) / r.w : 1 - d / (r.w * 0.6);
+      lift -= r.up * Math.max(0, Math.sin(t * Math.PI * 0.5));
+    }
+  }
+  return lift;
+}
+
 function terrainY(x, groundY) {
   return groundY
-    + Math.sin(x * 0.0016) * 110   // long sweeping hills
-    + Math.sin(x * 0.006) * 38     // medium rollers
-    + Math.sin(x * 0.02) * 10      // small chatter
-    + Math.sin(x * 0.045) * 4;     // fine bumps
+    + Math.sin(x * 0.0016) * 90    // long sweeping hills (climbable grade)
+    + Math.sin(x * 0.006) * 30     // medium rollers
+    + Math.sin(x * 0.02) * 9       // small chatter
+    + Math.sin(x * 0.045) * 4      // fine bumps
+    + rampLift(x);                 // launch ramps
 }
 
 // Build the terrain as a chain of static Polygon quads from each surface pair
@@ -60,23 +90,58 @@ function buildTerrain(space, groundY) {
 }
 
 // ── Bike tuning ─────────────────────────────────────────────────────────────
-const WHEEL_R = 22;
-const WHEEL_BASE = 52;          // half the axle-to-axle distance
+// Crossmotor (dirt-bike) proportions — bigger spoked wheels, longer wheelbase,
+// and a higher seat than a road bike so it reads as a trials/MX machine.
+const WHEEL_R = 26;
+const WHEEL_BASE = 58;          // half the axle-to-axle distance
 const CHASSIS_H = 14;
-const SUSP_REST = 34;           // spring rest length (chassis → wheel)
-const SUSP_FREQ = 3.0;
-const SUSP_DAMP = 0.5;
-const SUSP_MIN = -8;            // LineJoint travel limits
-const SUSP_MAX = 30;
-const MOTOR_RATE = 26;          // rear-wheel motor angular rate
-const LEAN_TORQUE = 9;          // chassis lean angular impulse per frame
+const SUSP_REST = 40;           // spring rest length (chassis → wheel) — long MX travel
+const SUSP_FREQ = 3.2;
+const SUSP_DAMP = 0.55;
+const SUSP_MIN = -10;           // LineJoint travel limits — generous suspension stroke
+const SUSP_MAX = 38;
+const MOTOR_RATE = 18;          // rear-wheel motor target angular rate (caps top
+                                // wheel speed → caps how violently a wheelie develops)
+const MOTOR_FORCE = 200000;     // torque cap — high so the bike can actually
+                                // climb under load; the low RATE (not the force)
+                                // is what keeps it from instantly looping out
+const LEAN_TORQUE = 40;         // ground lean impulse per frame — pops a wheelie
+                                // / pushes the nose down for jump setup
+const AIR_SPIN_RATE = 0.45;     // rad/s added to chassis angularVel per frame
+                                // while airborne — strong enough that holding a
+                                // lean through a jump over-rotates into a crash,
+                                // while a neutral approach lands clean
 
 // Flip / crash detection. If the chassis tilts past FLIP_ANGLE for
 // FLIP_FRAMES consecutive steps, or takes a hard vertical impact, the rider's
 // seat weld breaks away.
-const FLIP_ANGLE = 2.2;         // radians from upright (~126°)
-const FLIP_FRAMES = 18;         // ~0.3s sustained before bail
-const CRASH_IMPACT_SPEED = 720; // downward speed that counts as a hard smack
+const FLIP_ANGLE = 1.5;         // radians from upright (~86°) — past this you're
+                                // going over; neutral riding stays well under it
+const FLIP_FRAMES = 22;         // ~0.37s sustained past the angle before bail
+                                // (a quick wheelie that comes back down is fine)
+const CRASH_IMPACT_SPEED = 700; // downward speed that counts as a hard smack
+const CRASH_SPIN_RATE = 7;      // rad/s — above this the bike is tumbling out of
+                                // control (a fast flip never sustains one angle)
+const CRASH_SPIN_FRAMES = 14;   // ~0.23s of that spin before the rider bails
+
+// ── Rider active-pose targets ───────────────────────────────────────────────
+// Each limb is BUILT already rotated into its seated rest pose (arms reaching
+// up-forward to the bars, legs angled down to the pegs), and each AngleJoint
+// holds its hinge at the relative angle that *reproduces* that built pose. The
+// pose values below are therefore small lean DELTAS layered on top of that rest
+// pose (jointMin === jointMax = an always-active hard/soft lock around the rest
+// angle + delta — see the AngleJoint slack note). step() lerps between a NEUTRAL
+// seat, a CROUCH (lean forward / on the gas — tucked low over the bars) and a
+// STAND (lean back — weight up and off the back). Sign: +torso leans back,
+// −torso leans forward; limb deltas were tuned so the silhouette reads.
+//
+// pose = { torso, head, shoulder, elbow, hip, knee }  (radians, deltas)
+const POSE_NEUTRAL = { torso:  0.00, head: 0.00, shoulder:  0.00, elbow: 0.00, hip:  0.00, knee: 0.00 };
+const POSE_CROUCH  = { torso: -0.55, head: 0.25, shoulder: -0.35, elbow: 0.20, hip: -0.30, knee: 0.35 };
+const POSE_STAND   = { torso:  0.55, head: -0.18, shoulder: 0.35, elbow: -0.30, hip:  0.55, knee: -0.45 };
+const POSE_LERP = 0.14;         // how fast the rider settles into a new target pose
+const POSE_SOFT = 0.04;         // half-width kept around each target so the spring
+                                // isn't perfectly rigid (a hair of natural give)
 
 // ── Module state ────────────────────────────────────────────────────────────
 let _space = null;
@@ -93,8 +158,14 @@ let _rider = null;            // { pelvis, torso, head, ... } refs for drawing
 let _seatWeld = null;
 let _riderParts = [];
 let _riderJoints = [];
+// Pose-driving AngleJoints, grouped so step() can push each toward its target.
+// { torso, head, shoulders[], elbows[], hips[], knees[] }
+let _poseJoints = null;
+// The rider's current (lerped) pose — driven toward POSE_* targets each step.
+let _pose = { ...POSE_NEUTRAL };
 let _crashed = false;
 let _flipFrames = 0;
+let _spinFrames = 0;
 let _maxDist = 0;             // furthest the bike has travelled (for HUD)
 let _frame = 0;
 let _stepped = false;        // set true each physics step; gates camera lerp
@@ -107,91 +178,175 @@ let _onKeyUp = null;
 let _spawnX = 220;
 let _spawnGroundY = 0;
 
-// ── Rider ragdoll ───────────────────────────────────────────────────────────
-// A compact seated ragdoll. The pelvis is the root: it gets WELDED to the
-// chassis seat so the bike's lean transmits through. Every other joint is a
-// PivotJoint (the physical hinge) plus a soft AngleJoint (the spring that gives
-// the limb a rest pose + a sway range). The torso's AngleJoint window is the
-// "lean transmission" — when the welded pelvis pitches with the bike, the
-// torso sways forward/back inside that window.
+// ── Rider ragdoll (active-pose) ─────────────────────────────────────────────
+// A seated rider built from a pelvis root + torso/head + two arms + two legs.
+// The pelvis is WELDED to the chassis seat so the bike's lean drives the whole
+// rig. Each limb hinge is a PivotJoint (the physical pin) plus an AngleJoint
+// run as a TIGHT soft spring around a *target* angle — `jointMin === jointMax`
+// (± a sliver of POSE_SOFT) gives an always-active spring that holds the limb in
+// pose instead of letting it flop (the AngleJoint slack note: a window means no
+// force inside it; a point target means a constant restoring spring). step()
+// rewrites those targets each frame so the rider crouches on the gas and stands
+// when you lean back — exactly the TeaGames-style weight shift. On a crash the
+// targets are abandoned and the windows thrown wide so the rig goes limp.
 function buildRider(space, seatX, seatY) {
   _riderParts = [];
   _riderJoints = [];
 
   const add = (body) => { _riderParts.push(body); return body; };
-  const joint = (j) => { j.space = space; _riderJoints.push(j); return j; };
 
-  // Soft angle hinge helper — rest pose with a sway range and a gentle spring.
-  const hinge = (a, b, anchorA, anchorB, min, max, freq = 7, damp = 0.7) => {
-    joint(new PivotJoint(a, b, anchorA, anchorB));
-    const ang = new AngleJoint(a, b, min, max);
-    ang.stiff = false;
-    ang.frequency = freq;
-    ang.damping = damp;
-    return joint(ang);
+  // Active-pose hinge: a physical PivotJoint pin + an AngleJoint that *commands*
+  // the relative angle toward `target`. A STIFF AngleJoint with jointMin ===
+  // jointMax rigidly holds (and tracks) the target — strong enough to posture a
+  // limb against gravity, which a soft spring is not. Posture-critical joints
+  // (torso / shoulders / hips) are stiff so the rider holds its shape and the
+  // lean reads cleanly; the head / elbows / knees stay soft for natural life.
+  // Returns the AngleJoint so the caller can group it for per-frame retargeting.
+  // Active-pose hinge. The limbs are pre-rotated into their rest pose, so the
+  // hinge's REST relative angle is (b.rotation − a.rotation) at build time. We
+  // park the AngleJoint there (+ the per-frame lean delta) so "neutral" keeps
+  // exactly the built silhouette. A stiff joint rigidly commands the pose
+  // (needed to posture a limb against gravity); soft joints get a little life.
+  const poseHinge = (a, b, anchorA, anchorB, opts = {}) => {
+    const { stiff = false, freq = 13, damp = 0.85 } = opts;
+    const pin = new PivotJoint(a, b, anchorA, anchorB);
+    pin.space = space;
+    _riderJoints.push(pin);
+    const base = b.rotation - a.rotation;   // rest relative angle from the geometry
+    const ang = new AngleJoint(a, b, base - POSE_SOFT, base + POSE_SOFT);
+    if (stiff) {
+      ang.stiff = true;
+    } else {
+      ang.stiff = false;
+      ang.frequency = freq;
+      ang.damping = damp;
+    }
+    ang.space = space;
+    _riderJoints.push(ang);
+    return { joint: ang, base };            // keep base so applyPose adds the delta
   };
 
-  // Pelvis — the root the bike weld attaches to.
+  // Lighter limbs than the bike so the rider doesn't overpower the suspension.
+  const RM = (d) => new Material(0.1, 0.4, 0.5, d);
+
+  // Pelvis — root the bike weld attaches to. A bit heavier for a stable base.
   const pelvis = add(new Body(BodyType.DYNAMIC, new Vec2(seatX, seatY)));
-  pelvis.shapes.add(new Polygon(Polygon.box(20, 14), new Material(0.1, 0.4, 0.5, 0.6)));
+  pelvis.shapes.add(new Polygon(Polygon.box(20, 12), RM(0.7)));
   try { pelvis.userData._colorIdx = 1; } catch (_) {}
   pelvis.space = space;
 
-  // Torso — leans with the bike. Its AngleJoint window IS the lean transmission.
-  const torso = add(new Body(BodyType.DYNAMIC, new Vec2(seatX, seatY - 24)));
-  torso.shapes.add(new Polygon(Polygon.box(16, 34), new Material(0.1, 0.4, 0.5, 0.5)));
+  // Torso — slightly forward-leaning rest pose (a rider crouches a touch over
+  // the bars). Its pose delta is the visible weight shift (crouch / stand).
+  const torso = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + 3, seatY - 21)));
+  torso.rotation = 0.18;          // lean a little forward at rest
+  torso.shapes.add(new Polygon(Polygon.box(14, 30), RM(0.5)));
   try { torso.userData._colorIdx = 1; } catch (_) {}
   torso.space = space;
-  hinge(pelvis, torso, new Vec2(0, -7), new Vec2(0, 17), -0.9, 0.9, 6, 0.5);
+  const jTorso = poseHinge(pelvis, torso, new Vec2(0, -5), new Vec2(-2, 15), { stiff: true });
 
-  // Head.
-  const head = add(new Body(BodyType.DYNAMIC, new Vec2(seatX, seatY - 50)));
-  head.shapes.add(new Circle(9, undefined, new Material(0.1, 0.4, 0.5, 0.5)));
+  // Head — sits atop the torso, follows its lean.
+  const head = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + 7, seatY - 44)));
+  head.shapes.add(new Circle(8.5, undefined, RM(0.5)));
   try { head.userData._colorIdx = 1; } catch (_) {}
   head.space = space;
-  hinge(torso, head, new Vec2(0, -17), new Vec2(0, 9), -0.5, 0.5, 8, 0.7);
+  const jHead = poseHinge(torso, head, new Vec2(0, -15), new Vec2(0, 8.5), { freq: 14, damp: 0.9 });
 
-  // Arms — both reach forward toward the bars (handlebar offset is ahead of
-  // the seat). Narrow ranges so they stay roughly on the grips while seated.
-  const armLen = 18, armW = 6;
-  const buildArm = (sx) => {
-    const upper = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + sx, seatY - 16)));
-    upper.shapes.add(new Polygon(Polygon.box(armLen, armW), new Material(0.1, 0.4, 0.5, 0.4)));
+  // Arms — built reaching UP-FORWARD from the shoulder toward the handlebars at
+  // the front of the bike. Upper arm angled ~ -0.5 rad (up-forward), forearm
+  // continuing forward-down to the grips. Stiff shoulder holds the reach.
+  const armLen = 16, armW = 5;
+  const shoulders = [];
+  const elbows = [];
+  const shoulderX = seatX + 6, shoulderY = seatY - 30;   // shoulder socket (upper torso)
+  const buildArm = () => {
+    const ua = -0.55;             // upper-arm rest angle: up & forward
+    const uMidX = shoulderX + Math.cos(ua) * armLen / 2;
+    const uMidY = shoulderY + Math.sin(ua) * armLen / 2;
+    const upper = add(new Body(BodyType.DYNAMIC, new Vec2(uMidX, uMidY)));
+    upper.rotation = ua;
+    upper.shapes.add(new Polygon(Polygon.box(armLen, armW), RM(0.3)));
     try { upper.userData._colorIdx = 2; } catch (_) {}
     upper.space = space;
-    hinge(torso, upper, new Vec2(sx > 0 ? 8 : -8, -10), new Vec2(sx > 0 ? -9 : 9, 0), -1.2, 1.2, 5, 0.5);
+    shoulders.push(poseHinge(torso, upper,
+      new Vec2(shoulderX - (seatX + 3), shoulderY - (seatY - 21)), new Vec2(-armLen / 2, 0),
+      { stiff: true }));
 
-    const lower = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + sx + (sx > 0 ? armLen : -armLen), seatY - 16)));
-    lower.shapes.add(new Polygon(Polygon.box(armLen, armW), new Material(0.1, 0.4, 0.5, 0.4)));
+    const elbowX = shoulderX + Math.cos(ua) * armLen;
+    const elbowY = shoulderY + Math.sin(ua) * armLen;
+    const la = 0.35;              // forearm angles back down toward the grip
+    const lMidX = elbowX + Math.cos(la) * armLen / 2;
+    const lMidY = elbowY + Math.sin(la) * armLen / 2;
+    const lower = add(new Body(BodyType.DYNAMIC, new Vec2(lMidX, lMidY)));
+    lower.rotation = la;
+    lower.shapes.add(new Polygon(Polygon.box(armLen, armW), RM(0.25)));
     try { lower.userData._colorIdx = 2; } catch (_) {}
     lower.space = space;
-    hinge(upper, lower, new Vec2(sx > 0 ? 9 : -9, 0), new Vec2(sx > 0 ? -9 : 9, 0), -1.0, 1.0, 5, 0.5);
+    elbows.push(poseHinge(upper, lower, new Vec2(armLen / 2, 0), new Vec2(-armLen / 2, 0),
+      { stiff: true }));
     return { upper, lower };
   };
-  const lArm = buildArm(-2);
-  const rArm = buildArm(2);
+  const lArm = buildArm();
+  const rArm = buildArm();
 
-  // Legs — bent at the knee in a seated/pegged pose; thighs forward, shins down.
-  const thighLen = 22, shinLen = 22, legW = 8;
-  const buildLeg = (sx) => {
-    const thigh = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + sx + 10, seatY + 4)));
-    thigh.shapes.add(new Polygon(Polygon.box(thighLen, legW), new Material(0.1, 0.4, 0.5, 0.5)));
+  // Legs — built angled DOWN-FORWARD from the hip to the pegs, shin dropping
+  // down to the footrest. Stiff hip holds the seated knee-bend.
+  const thighLen = 19, shinLen = 20, legW = 7;
+  const hips = [];
+  const knees = [];
+  const hipX = seatX + 4, hipY = seatY + 4;
+  const buildLeg = () => {
+    const ta = 0.15;              // thigh: nearly level, slightly down-forward
+    const tMidX = hipX + Math.cos(ta) * thighLen / 2;
+    const tMidY = hipY + Math.sin(ta) * thighLen / 2;
+    const thigh = add(new Body(BodyType.DYNAMIC, new Vec2(tMidX, tMidY)));
+    thigh.rotation = ta;
+    thigh.shapes.add(new Polygon(Polygon.box(thighLen, legW), RM(0.5)));
     try { thigh.userData._colorIdx = 2; } catch (_) {}
     thigh.space = space;
-    hinge(pelvis, thigh, new Vec2(sx, 5), new Vec2(-10, 0), -0.6, 0.6, 5, 0.5);
+    hips.push(poseHinge(pelvis, thigh, new Vec2(8, 4), new Vec2(-thighLen / 2, 0),
+      { stiff: true }));
 
-    const shin = add(new Body(BodyType.DYNAMIC, new Vec2(seatX + sx + 22, seatY + 18)));
-    shin.shapes.add(new Polygon(Polygon.box(legW, shinLen), new Material(0.1, 0.4, 0.5, 0.5)));
+    const kneeX = hipX + Math.cos(ta) * thighLen;
+    const kneeY = hipY + Math.sin(ta) * thighLen;
+    const sa = 1.45;             // shin: drops steeply down to the peg
+    const sMidX = kneeX + Math.cos(sa) * shinLen / 2;
+    const sMidY = kneeY + Math.sin(sa) * shinLen / 2;
+    const shin = add(new Body(BodyType.DYNAMIC, new Vec2(sMidX, sMidY)));
+    shin.rotation = sa;
+    shin.shapes.add(new Polygon(Polygon.box(shinLen, legW), RM(0.5)));
     try { shin.userData._colorIdx = 2; } catch (_) {}
     shin.space = space;
-    hinge(thigh, shin, new Vec2(10, 0), new Vec2(0, -10), -0.4, 0.8, 5, 0.5);
+    knees.push(poseHinge(thigh, shin, new Vec2(thighLen / 2, 0), new Vec2(-shinLen / 2, 0),
+      { freq: 12, damp: 0.85 }));
     return { thigh, shin };
   };
-  const lLeg = buildLeg(-2);
-  const rLeg = buildLeg(2);
+  const lLeg = buildLeg();
+  const rLeg = buildLeg();
 
+  _poseJoints = { torso: jTorso, head: jHead, shoulders, elbows, hips, knees };
+  _pose = { ...POSE_NEUTRAL };
   _rider = { pelvis, torso, head, lArm, rArm, lLeg, rLeg };
   return pelvis;
+}
+
+// Push every pose joint's target toward the current lerped `_pose`. Each entry
+// is { joint, base }; the commanded angle is base (the built rest pose) + the
+// lean delta. Setting jointMin/jointMax to a near-point around it keeps the
+// lock always-active (a real window would let the limb go slack inside it).
+function applyPose() {
+  if (!_poseJoints) return;
+  const set = (h, delta) => {
+    if (!h || !h.joint || h.joint.space === null) return;
+    const t = h.base + delta;
+    h.joint.jointMin = t - POSE_SOFT;
+    h.joint.jointMax = t + POSE_SOFT;
+  };
+  set(_poseJoints.torso, _pose.torso);
+  set(_poseJoints.head, _pose.head);
+  for (const h of _poseJoints.shoulders) set(h, _pose.shoulder);
+  for (const h of _poseJoints.elbows) set(h, _pose.elbow);
+  for (const h of _poseJoints.hips) set(h, _pose.hip);
+  for (const h of _poseJoints.knees) set(h, _pose.knee);
 }
 
 // ── Bike ────────────────────────────────────────────────────────────────────
@@ -201,30 +356,55 @@ function buildRider(space, seatX, seatY) {
 // rear wheel gets a MotorJoint = throttle. The rider's pelvis is WELDED to the
 // chassis seat — that weld is the break-away joint.
 function buildBike(space, spawnX, groundY) {
-  const cy = groundY - 90;
+  const cy = groundY - 96;
 
-  // Chassis — a stubby motorbike silhouette. Default material on purpose.
+  // Chassis — a crossmotor silhouette: low slim frame, kicked-up seat/tail at
+  // the back, sloped tank + number plate at the front. Default material on
+  // purpose (dodges the Polygon+Material tunneling bug on fast landings).
   const chassis = new Body(BodyType.DYNAMIC, new Vec2(spawnX, cy));
+  // Main frame spar (slim, between the wheels).
   chassis.shapes.add(new Polygon([
-    new Vec2(-46, -2), new Vec2(40, -2),
-    new Vec2(46, 4), new Vec2(40, 10),
-    new Vec2(-46, 10), new Vec2(-52, 4),
+    new Vec2(-50, 0), new Vec2(46, 0),
+    new Vec2(50, 6), new Vec2(44, 11),
+    new Vec2(-48, 11), new Vec2(-54, 6),
   ]));
-  // Seat hump at the back + a little tank up front for visual read.
+  // Kicked-up rear fender + seat (the high MX tail).
   chassis.shapes.add(new Polygon([
-    new Vec2(-44, -14), new Vec2(-14, -14),
-    new Vec2(-10, -2), new Vec2(-44, -2),
+    new Vec2(-54, -16), new Vec2(-22, -12),
+    new Vec2(-16, 0), new Vec2(-50, 0),
+  ]));
+  // Tank / shroud up front, sloping down toward the bars.
+  chassis.shapes.add(new Polygon([
+    new Vec2(4, -12), new Vec2(30, -7),
+    new Vec2(40, 0), new Vec2(4, 0),
+  ]));
+  // Front number plate / fork shroud (thin, angled forward).
+  chassis.shapes.add(new Polygon([
+    new Vec2(40, -4), new Vec2(54, -10),
+    new Vec2(58, -4), new Vec2(46, 2),
+  ]));
+  // Handlebar riser + grip — gives the rider's hands a target to reach and
+  // reads as the cockpit. Riser climbs up from the front of the tank; the grip
+  // is a short crossbar at the top, pulled back toward the rider so the arms
+  // reach it.
+  chassis.shapes.add(new Polygon([
+    new Vec2(24, -8), new Vec2(30, -8),
+    new Vec2(28, -28), new Vec2(22, -28),
   ]));
   chassis.shapes.add(new Polygon([
-    new Vec2(8, -10), new Vec2(34, -6),
-    new Vec2(36, -2), new Vec2(8, -2),
+    new Vec2(14, -30), new Vec2(30, -30),
+    new Vec2(30, -25), new Vec2(14, -25),
   ]));
   try { chassis.userData._colorIdx = 0; } catch (_) {}
   chassis.space = space;
 
-  const wheelMat = new Material(0.2, 1.6, 1.8, 1.4);  // bouncy-low, very grippy
+  // Low bounce, grippy MX tyre. Friction kept moderate (1.2) on purpose: with
+  // the torque-capped motor, *too much* grip stalls the bike on a steep face
+  // (the contact locks before the wheel can roll up it). 1.2 climbs the hills
+  // cleanly while still biting enough to launch off jumps.
+  const wheelMat = new Material(0.15, 1.4, 1.4, 1.3);
   const makeWheel = (dx) => {
-    const w = new Body(BodyType.DYNAMIC, new Vec2(spawnX + dx, cy + 46));
+    const w = new Body(BodyType.DYNAMIC, new Vec2(spawnX + dx, cy + 52));
     w.shapes.add(new Circle(WHEEL_R, undefined, wheelMat));
     try { w.userData._colorIdx = 3; } catch (_) {}
     w.space = space;
@@ -253,20 +433,24 @@ function buildBike(space, spawnX, groundY) {
   _fSusp = suspend(fWheel, WHEEL_BASE);
   _rSusp = suspend(rWheel, -WHEEL_BASE);
 
-  // Rear-wheel motor = throttle (rate set per frame in step()).
+  // Rear-wheel motor = throttle (rate set per frame in step()). maxForce caps
+  // the torque so the throttle is progressive — climbs hills without the rear
+  // wheel snapping the whole bike into an instant backflip.
   _rMotor = new MotorJoint(chassis, rWheel, 0);
+  _rMotor.maxForce = MOTOR_FORCE;
   _rMotor.space = space;
 
   _chassis = chassis;
   _fWheel = fWheel;
   _rWheel = rWheel;
 
-  // Rider welded to the seat. The pelvis sits just above the seat hump; the
-  // WeldJoint's anchors lock the pelvis rigidly to that point so the chassis
-  // lean drives the rider. Breaking this weld (`_seatWeld.space = null`) is the
-  // break-away showcase on a crash.
-  const seatLocalX = -28;       // over the seat hump
-  const seatLocalY = -18;
+  // Rider welded to the seat over the kicked-up MX tail. The pelvis locks
+  // rigidly to that point so the chassis lean drives the whole rig; the *visible*
+  // weight shift comes from the active pose (applyPose), not from weld give — so
+  // this weld is firm. Breaking it (`_seatWeld.space = null`) is the break-away
+  // showcase on a crash.
+  const seatLocalX = -16;       // mid-bike seat — rider centered so the arms can
+  const seatLocalY = -14;       // reach forward to the bars and legs to the pegs
   const seatX = chassis.position.x + seatLocalX;
   const seatY = chassis.position.y + seatLocalY;
   const pelvis = buildRider(space, seatX, seatY);
@@ -274,9 +458,9 @@ function buildBike(space, spawnX, groundY) {
     chassis, pelvis,
     new Vec2(seatLocalX, seatLocalY), new Vec2(0, 0),
   );
-  _seatWeld.stiff = false;       // a touch of give so leans read as sway, not rigid
-  _seatWeld.frequency = 9;
-  _seatWeld.damping = 0.7;
+  _seatWeld.stiff = false;       // soft-but-firm: high frequency so it holds tight
+  _seatWeld.frequency = 18;
+  _seatWeld.damping = 0.9;
   _seatWeld.space = space;
 }
 
@@ -298,12 +482,15 @@ function teardownBikeAndRider() {
   _riderParts = [];
   for (const b of [_chassis, _fWheel, _rWheel]) { if (b && b.space) b.space = null; }
   _chassis = _fWheel = _rWheel = _rider = null;
+  _poseJoints = null;
+  _pose = { ...POSE_NEUTRAL };
 }
 
 function respawn() {
   teardownBikeAndRider();
   _crashed = false;
   _flipFrames = 0;
+  _spinFrames = 0;
   buildBike(_space, _spawnX, _spawnGroundY);
   _maxDist = 0;
 }
@@ -322,7 +509,9 @@ function bailRider() {
     const v = _rider.pelvis.velocity;
     _rider.pelvis.velocity = new Vec2(v.x - 120, v.y - 160);
   }
-  // Open the torso/head/limb angle windows so the freed rider flops loosely.
+  // Stop driving the pose and throw every limb window wide so the freed rider
+  // flops loosely instead of holding its seated shape.
+  _poseJoints = null;
   for (const j of _riderJoints) {
     if (j.jointMin !== undefined && j.jointMax !== undefined) {
       j.jointMin = -Math.PI;
@@ -429,32 +618,71 @@ export default {
       else _rMotor.rate = 0;
     }
 
-    // ── Lean (chassis angular impulse) ─────────────────────────────────────
-    // Up/back = pop the front up (counter-clockwise = negative torque in
-    // screen coords where +y is down). Down/forward = nose-down.
+    // ── Lean / air control ─────────────────────────────────────────────────
+    // Screen coords have +y down, so a NEGATIVE angularVel rotates the nose UP.
+    // On the ground the lean keys apply a torque impulse to pitch the bike (pop
+    // the front for a wheelie, or push the nose down). In the air there's no
+    // wheel contact to absorb it, so the same keys DRIVE the angular velocity
+    // directly — crisp, predictable rotation for whips and flips (and the way
+    // you set up — or botch — a landing, which is what triggers a crash).
     const leanBack = keys.ArrowUp || keys.KeyW || keys._touchUp;
     const leanFwd = keys.ArrowDown || keys.KeyS || keys._touchDown;
-    if (leanBack) _chassis.applyAngularImpulse(-LEAN_TORQUE);
-    if (leanFwd) _chassis.applyAngularImpulse(LEAN_TORQUE);
+    const airborne = !wheelTouchingGround();
+    if (airborne) {
+      if (leanBack) _chassis.angularVel -= AIR_SPIN_RATE;
+      if (leanFwd) _chassis.angularVel += AIR_SPIN_RATE;
+    } else {
+      if (leanBack) _chassis.applyAngularImpulse(-LEAN_TORQUE);
+      if (leanFwd) _chassis.applyAngularImpulse(LEAN_TORQUE);
+    }
+
+    // ── Active rider pose (the visible weight shift) ───────────────────────
+    // Choose a target pose from the lean keys and lerp toward it, then push the
+    // pose joints. Lean back → STAND (weight off the back); lean forward / on
+    // the gas → CROUCH (tucked over the bars); otherwise the NEUTRAL seat.
+    if (!_crashed && _poseJoints) {
+      let target = POSE_NEUTRAL;
+      if (leanBack) target = POSE_STAND;
+      else if (leanFwd || fwd) target = POSE_CROUCH;
+      _pose.torso += (target.torso - _pose.torso) * POSE_LERP;
+      _pose.head += (target.head - _pose.head) * POSE_LERP;
+      _pose.shoulder += (target.shoulder - _pose.shoulder) * POSE_LERP;
+      _pose.elbow += (target.elbow - _pose.elbow) * POSE_LERP;
+      _pose.hip += (target.hip - _pose.hip) * POSE_LERP;
+      _pose.knee += (target.knee - _pose.knee) * POSE_LERP;
+      applyPose();
+    }
 
     // ── Distance HUD ───────────────────────────────────────────────────────
     const dist = Math.max(0, (_chassis.position.x - _spawnX));
     if (dist > _maxDist) _maxDist = dist;
 
-    // ── Crash detection: sustained flip OR hard ground impact ──────────────
+    // ── Crash detection ────────────────────────────────────────────────────
+    // Three ways to bite it: (1) hung past the tip-over angle for a beat;
+    // (2) spinning out of control (a fast tumble never *sustains* a single
+    // angle, so the angle test alone misses it — catch it by angular speed);
+    // (3) a hard ground smack. Any one breaks the seat weld and the rider bails.
     if (!_crashed) {
       // Normalise chassis rotation into [-π, π] and measure tilt from upright.
       let rot = _chassis.rotation % (Math.PI * 2);
       if (rot > Math.PI) rot -= Math.PI * 2;
       if (rot < -Math.PI) rot += Math.PI * 2;
-      if (Math.abs(rot) > FLIP_ANGLE) {
-        _flipFrames++;
-        if (_flipFrames > FLIP_FRAMES) bailRider();
+      // Accumulate while past the tip angle; decay (don't hard-reset) so a fast
+      // tumble that flickers under the angle each rotation still trips it.
+      if (Math.abs(rot) > FLIP_ANGLE) _flipFrames += 1;
+      else _flipFrames = Math.max(0, _flipFrames - 2);
+      if (_flipFrames > FLIP_FRAMES) bailRider();
+
+      // Spinning out of control — a violent tumble in the air or after a bad
+      // landing. Sustained high angular speed = you've lost it.
+      if (Math.abs(_chassis.angularVel) > CRASH_SPIN_RATE) {
+        _spinFrames += 1;
+        if (_spinFrames > CRASH_SPIN_FRAMES) bailRider();
       } else {
-        _flipFrames = 0;
+        _spinFrames = Math.max(0, _spinFrames - 1);
       }
 
-      // Hard impact: chassis is moving down fast while a wheel is in contact.
+      // Hard impact: chassis driving down fast onto the ground.
       const vy = _chassis.velocity.y;
       if (vy > CRASH_IMPACT_SPEED && wheelTouchingGround()) {
         bailRider();

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -22,7 +22,7 @@ const SCREEN_H = 500;
 
 // Dev toggle: build the bike alone (no rider) while iterating on the chassis +
 // suspension. Flip back to true once the bike looks/behaves right.
-const BUILD_RIDER = false;
+const BUILD_RIDER = true;
 
 // ── World / terrain ─────────────────────────────────────────────────────────
 const WORLD_W = 6000;
@@ -379,6 +379,14 @@ function buildRider(space, seatX, seatY) {
   };
   const lLeg = buildLeg();
   const rLeg = buildLeg();
+
+  // Rider parts share the bike's collision filter: they collide with the
+  // terrain (so a bailed rider tumbles on the ground) but NOT with the bike or
+  // with each other — the seated rig would otherwise jam its own legs against
+  // the wheels/frame.
+  for (const b of _riderParts) {
+    for (const shape of b.shapes) shape.filter = BIKE_FILTER;
+  }
 
   _poseJoints = { torso: jTorso, head: jHead, shoulders, elbows, hips, knees };
   _pose = { ...POSE_NEUTRAL };

--- a/docs/demos/dirtline.js
+++ b/docs/demos/dirtline.js
@@ -194,8 +194,9 @@ const TORSO_LEAN_FWD = 0.29;    // rad added on lean-forward (positive = nose-do
 const TORSO_FWD_MAX = 0.29;     // hard cap on forward torso tilt past rest so the
                                 // upper body can't fold flat onto the bike
 const TORSO_LEAN_LERP = 0.12;   // how fast the torso eases to the new lean target
-// Legs extend with the lean too (rider pushes up off the pegs), so the whole
-// body shifts — not just the torso. Hip opens by this much at full lean.
+// Legs extend with the lean (rider pushes off the pegs): the knee straightens by
+// this much at full lean. Sign tuned so the leg straightens (less bend), not curls.
+const KNEE_STRAIGHTEN = 0.7;
 
 // ── Module state ────────────────────────────────────────────────────────────
 let _space = null;
@@ -219,6 +220,8 @@ let _riderJoints = [];
 let _torsoHinge = null;       // pelvis→torso AngleJoint, retargeted on lean
 let _torsoBase = 0;           // its built rest angle (the upright seated pose)
 let _torsoLean = 0;           // current eased lean offset applied to the torso
+let _kneeHinges = [];         // [{ joint, base }] knee hinges, straightened on lean
+let _legExtend = 0;           // eased 0→1: how straight the legs are on a lean
 let _crashed = false;
 let _flipFrames = 0;
 let _spinFrames = 0;
@@ -250,6 +253,7 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
   _riderJoints = [];
   _gripJoints = [];
   _pegJoints = [];
+  _kneeHinges = [];
 
   const add = (body) => { _riderParts.push(body); return body; };
 
@@ -384,8 +388,10 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     shin.shapes.add(new Polygon(Polygon.box(shinLen, legW), RM(0.5)));
     try { shin.userData._colorIdx = 2; } catch (_) {}
     shin.space = space;
-    knees.push(poseHinge(thigh, shin, new Vec2(thighLen / 2, 0), new Vec2(-shinLen / 2, 0),
-      { freq: 12, damp: 0.85 }));
+    const kneeH = poseHinge(thigh, shin, new Vec2(thighLen / 2, 0), new Vec2(-shinLen / 2, 0),
+      { freq: 12, damp: 0.85 });
+    knees.push(kneeH);
+    _kneeHinges.push(kneeH);    // straightened on lean to extend the leg
     return { thigh, shin };
   };
   const lLeg = buildLeg();
@@ -414,21 +420,21 @@ function buildRider(space, seatX, seatY, chassis, gripLocal, pegLocal) {
     }
   }
   if (chassis && pegLocal) {
-    // Feet use a SOFT DistanceJoint (not a rigid pivot) so the foot stays near
-    // the peg but the leg can EXTEND when the rider shifts weight on a lean —
-    // a rigid pin locked the leg and killed that motion. jointMin=0 lets the
-    // foot pull in; jointMax gives a little slack; the soft spring keeps it on
-    // the peg under normal riding.
-    // The foot is pinned to the peg at a FIXED point (a rigid PivotJoint, like
-    // the hands on the bars) — the ankle. The knee/hip above it stay soft, so
-    // the leg can still bend/shift on a lean while the foot stays planted on the
-    // peg. The rider is attached to the bike ONLY here + at the hands (no pelvis
-    // weld), so the body genuinely hangs off the four contact points.
+    // Feet use a SOFT DistanceJoint (not a rigid pin) so the foot stays near the
+    // peg but can move a little when the rider extends a leg on a lean. A rigid
+    // pin locked the leg flat and killed that motion. jointMin=0 / jointMax give
+    // a small window; the soft spring keeps the foot on the peg under normal
+    // riding. step() straightens the KNEE on a lean to extend the leg.
     for (const leg of [lLeg, rLeg]) {
-      _pegJoints.push(new PivotJoint(
+      const d = new DistanceJoint(
         chassis, leg.shin,
         new Vec2(pegLocal.x, pegLocal.y), new Vec2(shinLen / 2, 0),
-      ));
+        0, 8,
+      );
+      d.stiff = false;
+      d.frequency = 7;
+      d.damping = 0.7;
+      _pegJoints.push(d);
     }
   }
   for (const j of _gripJoints) j.space = space;
@@ -636,6 +642,8 @@ function teardownBikeAndRider() {
   _chassis = _fWheel = _rWheel = _swingarm = _rider = null;
   _torsoHinge = null;
   _torsoLean = 0;
+  _kneeHinges = [];
+  _legExtend = 0;
 }
 
 function respawn() {
@@ -834,8 +842,19 @@ export default {
       const t = _torsoBase + Math.max(-Math.abs(TORSO_LEAN_BACK), Math.min(TORSO_FWD_MAX, _torsoLean));
       _torsoHinge.jointMin = t - POSE_SOFT;
       _torsoHinge.jointMax = t + POSE_SOFT;
-      // Note: the legs are pinned at a fixed point on the pegs, so the visible
-      // weight shift comes from the torso; the legs intentionally stay planted.
+
+      // Legs straighten on EITHER lean: the rider extends the legs (pushes off
+      // the pegs) when shifting weight back or forward, and tucks them when
+      // neutral. We straighten the KNEE toward 0 bend; the soft foot tether lets
+      // the foot follow. _legExtend eases 0→1.
+      const wantExtend = (leanBack || leanFwd) ? 1 : 0;
+      _legExtend += (wantExtend - _legExtend) * TORSO_LEAN_LERP;
+      for (const h of _kneeHinges) {
+        if (!h || !h.joint || h.joint.space === null) continue;
+        const a = h.base - KNEE_STRAIGHTEN * _legExtend;  // reduce the knee bend
+        h.joint.jointMin = a - POSE_SOFT;
+        h.joint.jointMax = a + POSE_SOFT;
+      }
     }
 
     // ── Distance HUD ───────────────────────────────────────────────────────

--- a/docs/examples.js
+++ b/docs/examples.js
@@ -75,6 +75,7 @@ import brickline            from "./demos/brickline.js?v=3.35.0";
 import pulleyCrane          from "./demos/pulley-crane.js?v=3.35.0";
 import tinywheelsCup        from "./demos/tinywheels-cup.js?v=3.35.0";
 import tiltrun               from "./demos/tiltrun.js?v=3.35.0";
+import dirtline              from "./demos/dirtline.js?v=3.35.0";
 
 // Note on order: cardEntries reverses ALL_DEMOS, so the LAST tuple entry
 // becomes the TOP card in the grid. New demos go at the end so they take
@@ -119,6 +120,7 @@ const ALL_DEMOS = [
   pulleyCrane,
   tinywheelsCup,
   tiltrun,
+  dirtline,
 ];
 
 const gtag = window.gtag || function() {};


### PR DESCRIPTION
## Summary

Closes #214 (P90). **Dirtline** — a side-view hill-climb / trials motorbike with an articulated ragdoll rider, the richer sibling of `car-sideview`. New demo at `docs/demos/dirtline.js` (585 lines), registered in `docs/examples.js` and `docs/demo-categories.js` (`GAME_DEMO_IDS`).

No prior PR touched this issue — fresh, complete implementation.

## What it shows

- **MotorJoint-driven rear wheel** on **SpringJoint + LineJoint** suspension over long sum-of-sines rolling terrain.
- **Articulated ragdoll rider** (`PivotJoint` + soft `AngleJoint` per joint, à la `ragdoll.js`) **welded to the moving chassis** at the pelvis via a `WeldJoint`.
- **Lean transmission**: chassis lean (angular impulse on ↑/↓) drags the welded pelvis, so the torso sways forward/back inside its `AngleJoint` window.
- **Break-away joint**: a sustained flip past a threshold *or* a hard ground impact breaks the seat `WeldJoint` (`constraint.space = null`) — the rider detaches and ragdolls off the back.
- Step-locked camera follow, HUD (distance / speed / CRASHED), R-or-click respawn.

## Controls

- **→ / D** throttle · **← / A** reverse · **↑ / W** lean back (pop the front) · **↓ / S** lean forward (nose-down)
- **R** or click respawns (click also tap-drives left/right)

## Acceptance criteria

- [x] Throttle + pitch (lean forward/back) controls
- [x] Motor-driven wheels with suspension over rolling terrain
- [x] Ragdoll rider attached to the bike that visibly leans with pitch
- [x] Rider detaches / falls off on a flip or hard crash
- [x] Reset / respawn
- [x] HUD overlay via `render3dOverlay` (renderer-agnostic)
- [x] Works on all three renderers (canvas2d / threejs / pixi) — default body draw + overlay
- [x] CodePen export works (verified: template imports already include all joints used; preamble extracts the post-export helpers)
- [x] ≤ 2000 lines (585)

## Engine-safety notes

- Terrain + chassis use the **default Material** to dodge the known *Polygon + explicit Material → tunneling* bug; grip is tuned via the **wheel** Materials instead.
- Chassis lean reads `body.rotation` (not `shape.rotation`, which doesn't affect collision geometry).
- Camera uses a **function-follow** so it tracks the *current* chassis across respawns (a static body ref would follow the removed one); lerp is gated behind the runner's `stepped` flag.

## Pre-push checks

- `npm run format:check` ✅
- `npm run lint` ✅
- `npm test` ✅ (6169 + 73)
- `npm run build` ✅ (DTS clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)