### PR TITLE
feat(docs): celebratory "Exploding 50" demo for 50 GitHub stars

### DIFF
--- a/docs/codepen-templates.js
+++ b/docs/codepen-templates.js
@@ -225,6 +225,8 @@ const COLORS = [
 ];
 let _showOutlines = __OUTLINES__;
 function bodyColor(body) {
+  const custom = body.userData?._color;
+  if (custom) return custom;
   if (body.isStatic()) return { fill: "rgba(120,160,200,0.15)", stroke: "#607888" };
   const idx = (body.userData?._colorIdx ?? 0) % COLORS.length;
   return COLORS[idx];
@@ -320,8 +322,11 @@ function addBodyMesh(body) {
     }
     if (!geom) continue;
     const isSensor = shape.sensorEnabled || shape.fluidEnabled;
+    const _cc = body.userData?._color;
     const cIdx = (body.userData?._colorIdx ?? 0) % MESH_COLORS.length;
-    const color = body.isStatic() ? 0x607888 : MESH_COLORS[cIdx];
+    const color = _cc
+      ? parseInt(_cc.stroke.replace("#", ""), 16)
+      : body.isStatic() ? 0x607888 : MESH_COLORS[cIdx];
     const mat = isSensor
       ? new THREE.MeshBasicMaterial({ color, wireframe: true, transparent: true, opacity: 0.5 })
       : new THREE.MeshPhongMaterial({ color, shininess: 80, specular: 0x444444, side: THREE.DoubleSide });
@@ -373,6 +378,8 @@ const _debug = new PixiDebugDraw({
   staticColor: STATIC_FILL,
   showOutlines: __OUTLINES__,
   colorResolver: (body) => {
+    const custom = body.userData?._color;
+    if (custom) return parseInt(custom.stroke.replace("#", ""), 16);
     if (body.isStatic()) return STATIC_FILL;
     const idx = body.userData?._colorIdx;
     if (idx != null && idx >= 0) return FILL_COLORS[idx % FILL_COLORS.length];
@@ -418,6 +425,27 @@ _demo.setup(space, W, H);
 // ── Camera ──────────────────────────────────────────────────────────────────
 let _camX = 0, _camY = 0;
 const _camCfg = _demo.camera || null;
+// ── Camera shake ──────────────────────────────────────────────────────────
+// Mirrors the docs DemoRunner: demos call shakeCamera(amplitude, duration)
+// via _demo._runner; the offset decays quadratically and is added to the
+// camera each frame. Without this, shake-driven demos run but feel static.
+let _shakeAmp = 0, _shakeRemaining = 0, _shakeTotal = 0, _shakeOffX = 0, _shakeOffY = 0;
+function shakeCamera(amplitude, duration = 0.25) {
+  if (!(amplitude > 0) || !(duration > 0)) return;
+  if (amplitude < _shakeAmp && _shakeRemaining > 0) return;
+  _shakeAmp = amplitude; _shakeRemaining = duration; _shakeTotal = duration;
+}
+function _updateShake(frameSec) {
+  if (_shakeRemaining <= 0) { _shakeOffX = 0; _shakeOffY = 0; return; }
+  _shakeRemaining = Math.max(0, _shakeRemaining - frameSec);
+  const t = _shakeTotal > 0 ? _shakeRemaining / _shakeTotal : 0;
+  const amp = _shakeAmp * t * t;
+  const ang = Math.random() * Math.PI * 2;
+  _shakeOffX = Math.cos(ang) * amp;
+  _shakeOffY = Math.sin(ang) * amp;
+}
+// Expose to demos that call this._runner?.shakeCamera?.(...)
+_demo._runner = { shakeCamera };
 function _updateCamera() {
   const cfg = _camCfg;
   if (!cfg) return;
@@ -464,19 +492,21 @@ function _loop() {
   if (_demo.step) _demo.step(space, W, H);
   space.step(1 / 60, __VEL_ITER__, __POS_ITER__);
   _updateCamera();
+  _updateShake(1 / 60);
+  const _cx = _camX + _shakeOffX, _cy = _camY + _shakeOffY;
   ctx.clearRect(0, 0, W, H);
   if (_demo.render) {
-    _demo.render(ctx, space, W, H, _showOutlines, _camX, _camY);
+    _demo.render(ctx, space, W, H, _showOutlines, _cx, _cy);
   } else {
     ctx.save();
-    ctx.translate(-_camX, -_camY);
+    ctx.translate(-_cx, -_cy);
     drawGrid();
     for (const body of space.bodies) drawBody(body);
     drawConstraintLines();
     ctx.restore();
   }
   // HUD overlay (legend, labels) — same as canvas2d-adapter locally
-  if (_demo.render3dOverlay) _demo.render3dOverlay(ctx, space, W, H, _camX, _camY);
+  if (_demo.render3dOverlay) _demo.render3dOverlay(ctx, space, W, H, _cx, _cy);
   requestAnimationFrame(_loop);
 }
 _loop();
@@ -548,6 +578,27 @@ _demo.setup(space, W, H);
 // ── Camera ──────────────────────────────────────────────────────────────────
 let _camX = 0, _camY = 0;
 const _camCfg = _demo.camera || null;
+// ── Camera shake ──────────────────────────────────────────────────────────
+// Mirrors the docs DemoRunner: demos call shakeCamera(amplitude, duration)
+// via _demo._runner; the offset decays quadratically and is added to the
+// camera each frame. Without this, shake-driven demos run but feel static.
+let _shakeAmp = 0, _shakeRemaining = 0, _shakeTotal = 0, _shakeOffX = 0, _shakeOffY = 0;
+function shakeCamera(amplitude, duration = 0.25) {
+  if (!(amplitude > 0) || !(duration > 0)) return;
+  if (amplitude < _shakeAmp && _shakeRemaining > 0) return;
+  _shakeAmp = amplitude; _shakeRemaining = duration; _shakeTotal = duration;
+}
+function _updateShake(frameSec) {
+  if (_shakeRemaining <= 0) { _shakeOffX = 0; _shakeOffY = 0; return; }
+  _shakeRemaining = Math.max(0, _shakeRemaining - frameSec);
+  const t = _shakeTotal > 0 ? _shakeRemaining / _shakeTotal : 0;
+  const amp = _shakeAmp * t * t;
+  const ang = Math.random() * Math.PI * 2;
+  _shakeOffX = Math.cos(ang) * amp;
+  _shakeOffY = Math.sin(ang) * amp;
+}
+// Expose to demos that call this._runner?.shakeCamera?.(...)
+_demo._runner = { shakeCamera };
 function _updateCamera() {
   const cfg = _camCfg;
   if (!cfg) return;
@@ -591,20 +642,25 @@ function _loop() {
   if (_demo.step) _demo.step(space, W, H);
   space.step(1 / 60, __VEL_ITER__, __POS_ITER__);
   _updateCamera();
+  _updateShake(1 / 60);
+  const _cx = _camX + _shakeOffX, _cy = _camY + _shakeOffY;
   if (!_demo.render3d) syncBodies3D(space);
   if (_demo.render3d) {
-    _demo.render3d(renderer, scene, camera, space, W, H, _camX, _camY);
+    _demo.render3d(renderer, scene, camera, space, W, H, _cx, _cy);
   } else {
-    if (_camCfg) {
+    // Offset the 3D camera for follow-camera and/or active shake. When neither
+    // applies, _cx/_cy are 0 so the camera stays at its default framing.
+    if (_camCfg || _shakeOffX || _shakeOffY) {
       const _baseCamX = W / 2, _baseCamY = -H / 2, _camZZ = camera.position.z;
-      camera.position.set(_baseCamX + _camX, _baseCamY - _camY, _camZZ);
-      camera.lookAt(_baseCamX + _camX, _baseCamY - _camY, 0);
+      const _tx = _baseCamX + _cx, _ty = _baseCamY - _cy;
+      camera.position.set(_tx, _ty, _camZZ);
+      camera.lookAt(_tx, _ty, 0);
     }
     renderer.render(scene, camera);
   }
   if (_overlayCtx) {
     _overlayCtx.clearRect(0, 0, W, H);
-    _demo.render3dOverlay(_overlayCtx, space, W, H, _camX, _camY);
+    _demo.render3dOverlay(_overlayCtx, space, W, H, _cx, _cy);
   }
   requestAnimationFrame(_loop);
 }
@@ -646,6 +702,27 @@ _demo.setup(space, W, H);
 // ── Camera ──────────────────────────────────────────────────────────────────
 let _camX = 0, _camY = 0;
 const _camCfg = _demo.camera || null;
+// ── Camera shake ──────────────────────────────────────────────────────────
+// Mirrors the docs DemoRunner: demos call shakeCamera(amplitude, duration)
+// via _demo._runner; the offset decays quadratically and is added to the
+// camera each frame. Without this, shake-driven demos run but feel static.
+let _shakeAmp = 0, _shakeRemaining = 0, _shakeTotal = 0, _shakeOffX = 0, _shakeOffY = 0;
+function shakeCamera(amplitude, duration = 0.25) {
+  if (!(amplitude > 0) || !(duration > 0)) return;
+  if (amplitude < _shakeAmp && _shakeRemaining > 0) return;
+  _shakeAmp = amplitude; _shakeRemaining = duration; _shakeTotal = duration;
+}
+function _updateShake(frameSec) {
+  if (_shakeRemaining <= 0) { _shakeOffX = 0; _shakeOffY = 0; return; }
+  _shakeRemaining = Math.max(0, _shakeRemaining - frameSec);
+  const t = _shakeTotal > 0 ? _shakeRemaining / _shakeTotal : 0;
+  const amp = _shakeAmp * t * t;
+  const ang = Math.random() * Math.PI * 2;
+  _shakeOffX = Math.cos(ang) * amp;
+  _shakeOffY = Math.sin(ang) * amp;
+}
+// Expose to demos that call this._runner?.shakeCamera?.(...)
+_demo._runner = { shakeCamera };
 function _updateCamera() {
   const cfg = _camCfg;
   if (!cfg) return;
@@ -689,18 +766,21 @@ function _loop() {
   if (_demo.step) _demo.step(space, W, H);
   space.step(1 / 60, __VEL_ITER__, __POS_ITER__);
   _updateCamera();
+  _updateShake(1 / 60);
+  const _cx = _camX + _shakeOffX, _cy = _camY + _shakeOffY;
   if (_demo.renderPixi) {
-    _demo.renderPixi({ syncBodies, getEngine: () => ({ PIXI, app }) }, space, W, H, false, _camX, _camY);
+    _demo.renderPixi({ syncBodies, getEngine: () => ({ PIXI, app }) }, space, W, H, false, _cx, _cy);
   } else {
     drawGrid();
     syncBodies(space);
     if (!_demo.render3dOverlay) drawConstraintLines();
-    if (_camCfg) { app.stage.x = -_camX; app.stage.y = -_camY; }
+    // Offset the stage for follow-camera and/or active shake.
+    if (_camCfg || _shakeOffX || _shakeOffY) { app.stage.x = -_cx; app.stage.y = -_cy; }
     app.render();
   }
   if (_overlayCtx) {
     _overlayCtx.clearRect(0, 0, W, H);
-    _demo.render3dOverlay(_overlayCtx, space, W, H, _camX, _camY);
+    _demo.render3dOverlay(_overlayCtx, space, W, H, _cx, _cy);
   }
   requestAnimationFrame(_loop);
 }

--- a/docs/demos/star-fountain.js
+++ b/docs/demos/star-fountain.js
@@ -1,0 +1,376 @@
+import { Body, BodyType, Vec2, Polygon } from "../nape-js.esm.js";
+
+// Exploding "50" — a celebration demo for the project's 50th GitHub star.
+// The number "50" is spelled out of a grid of solid square blocks, each a
+// real dynamic Body sitting still in formation. After a short "charge-up"
+// (a building camera shake) the formation detonates: a radial impulse from
+// the blast center launches every block outward, they tumble, collide with
+// each other and the arena walls, and pile up on the floor — then the "50"
+// re-assembles and detonates again, forever.
+//
+// Blocks that take a hard hit shatter: when a block's blast (or collision)
+// impulse exceeds a threshold it is replaced, at runtime, by four smaller
+// squares carrying its velocity — a cheap deterministic fracture that shows
+// off live body swapping during simulation.
+//
+// What it demonstrates: many-body rigid collision (hundreds of convex
+// polygons interacting), radial impulse application, runtime body fracture,
+// and the engine settling a chaotic pile back to rest — all with the stock
+// debug renderer (no custom drawing, no canvas shadow blur), so it runs at
+// full frame rate and the visuals come straight out of the physics.
+//
+// Engine-bug note (see project memory): dynamic Polygon + an explicit
+// Material tunnels through static Polygon floors. Every block here uses the
+// engine-default material — no Material argument anywhere — so the pile
+// rests cleanly on the floor instead of falling through it.
+
+const DT = 1 / 60;
+
+// --- Tunables -------------------------------------------------------------
+const BLOCK = 10; // block edge in px (also the grid pitch base)
+const GAP = 1; // visual gap between blocks in formation
+const GRAVITY_Y = 900;
+const HOLD_FORMED = 1.6; // seconds the "50" sits intact (incl. charge-up)
+const CHARGE_DURATION = 0.9; // seconds of building shake just before the blast
+const HOLD_SCATTERED = 4.2; // seconds the debris tumbles before re-forming
+const BLAST_IMPULSE = 1500; // peak radial impulse at the blast center
+const BLAST_FALLOFF = 1.0; // 1 = linear falloff to the formation edge
+const FONT_UPSCALE = 2; // each glyph cell becomes UPSCALE×UPSCALE blocks (≈4× count)
+
+// Collision-driven fracture: a block shatters into 4 when the contact
+// impulse it receives in a step (slamming the floor/walls or another block)
+// exceeds this. Because it's measured every step — not just at the blast —
+// the "50" keeps breaking up as the debris lands and piles, so most of the
+// formation ends up as small fragments rather than whole blocks.
+const SHATTER_IMPULSE = 60; // contact-impulse magnitude threshold (Vec3.length)
+const MIN_SHATTER_EDGE = 5; // blocks at/below this edge no longer split (frags stay whole)
+const SHATTER_GRACE = 0.12; // s after a block is born before it may shatter (avoids instant chain-split)
+
+// 7×9 pixel font for the two glyphs we need. 1 = block, 0 = empty.
+// Hand-drawn with 2-block-thick strokes so the "50" reads boldly.
+// prettier-ignore
+const GLYPHS = {
+  "5": [
+    [1,1,1,1,1,1,1],
+    [1,1,1,1,1,1,1],
+    [1,1,0,0,0,0,0],
+    [1,1,1,1,1,1,0],
+    [1,1,1,1,1,1,1],
+    [0,0,0,0,0,1,1],
+    [0,0,0,0,0,1,1],
+    [1,1,1,1,1,1,1],
+    [1,1,1,1,1,1,0],
+  ],
+  "0": [
+    [0,1,1,1,1,1,0],
+    [1,1,1,1,1,1,1],
+    [1,1,0,0,0,1,1],
+    [1,1,0,0,1,1,1],
+    [1,1,0,1,1,1,1],
+    [1,1,1,1,0,1,1],
+    [1,1,1,0,0,1,1],
+    [1,1,1,1,1,1,1],
+    [0,1,1,1,1,1,0],
+  ],
+};
+
+const GLYPH_W = 7;
+const GLYPH_H = 9;
+const GLYPH_SPACING = 1; // empty (upscaled) block-columns between the two glyphs
+
+// --- State ----------------------------------------------------------------
+let _blocks = []; // { body } — live debris/formation bodies
+let _W = 0;
+let _H = 0;
+let _space = null;
+let _phase = "formed"; // "formed" | "scattered"
+let _phaseT = 0;
+let _blastX = 0;
+let _blastY = 0;
+let _formationR = 1; // max distance from blast center to a block (for falloff)
+let _detonated = false; // guards the one-shot blast within the formed phase
+let _elapsed = 0; // monotonic clock (never resets) for per-block shatter grace
+
+function rand(a, b) {
+  return a + Math.random() * (b - a);
+}
+
+// The host runner (docs DemoRunner, or the CodePen template's stub) is set on
+// the demo object as `this._runner`. step()/click() cache it here so the
+// module-level helper detonate() can reach shakeCamera too. Reading
+// `this._runner` from inside a method (rather than referencing the demo
+// object by name) is what makes the shake survive the CodePen export.
+let _runnerRef = null;
+
+// HSL (h in degrees, s/l in 0..1) → "#rrggbb". The renderers' custom-color
+// path parses stroke as hex (Three.js / PixiJS do parseInt(stroke)), so the
+// gradient must resolve to a real hex string, not an hsl() literal.
+function hslHex(h, s, l) {
+  h = ((h % 360) + 360) % 360;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const to = (v) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${to(r)}${to(g)}${to(b)}`;
+}
+
+// Map t ∈ [0,1] to a celebratory hue sweep and return a renderer color object
+// ({ fill, stroke }). Using userData._color (a custom color) rather than
+// _colorIdx (a 6-entry palette) gives a smooth gradient across the whole "50"
+// and survives the blast — debris keeps the hue it was assigned in formation.
+function gradientColor(t) {
+  // Sweep cyan → blue → violet → magenta → warm pink across the number.
+  const hex = hslHex(190 + t * 140, 0.85, 0.62);
+  // Stroke is the hex (used as-is by Canvas2D, parsed to int by 3D/Pixi).
+  // Fill is the same hex at ~0.42 alpha so blocks read clearly with outlines off.
+  return { fill: hex + "6b", stroke: hex };
+}
+
+// Spawn one solid square block. Stores its home + pin state on userData so
+// the formed phase can hold it still and the blast can read its edge size.
+function spawnBlock(x, y, edge, color, homeX, homeY, pinned) {
+  const body = new Body(BodyType.DYNAMIC, new Vec2(x, y));
+  // No Material argument — engine default avoids the polygon-tunneling bug.
+  body.shapes.add(new Polygon(Polygon.box(edge, edge)));
+  body.userData._color = color; // custom gradient color — kept through the blast
+  body.userData._edge = edge;
+  body.userData._homeX = homeX;
+  body.userData._homeY = homeY;
+  body.userData._pinned = pinned;
+  body.userData._bornT = _elapsed;
+  body.space = _space;
+  _blocks.push({ body });
+  return body;
+}
+
+// Lay the "50" out of blocks, centered in the upper portion of the canvas.
+function buildFormation() {
+  for (const b of _blocks) b.body.space = null;
+  _blocks = [];
+
+  const pitch = BLOCK + GAP;
+  const glyphs = ["5", "0"];
+  const cellsPerGlyphW = GLYPH_W * FONT_UPSCALE;
+  const totalCols = cellsPerGlyphW * glyphs.length + GLYPH_SPACING * FONT_UPSCALE * (glyphs.length - 1);
+  const totalW = totalCols * pitch;
+  const totalH = GLYPH_H * FONT_UPSCALE * pitch;
+  const originX = _W / 2 - totalW / 2 + pitch / 2;
+  const originY = _H * 0.4 - totalH / 2 + pitch / 2;
+
+  const maxCol = Math.max(1, totalCols - 1); // for the left→right gradient sweep
+  let colOffset = 0;
+  for (const g of glyphs) {
+    const grid = GLYPHS[g];
+    for (let row = 0; row < GLYPH_H; row++) {
+      for (let col = 0; col < GLYPH_W; col++) {
+        if (!grid[row][col]) continue;
+        // Upscale each filled cell into an UPSCALE×UPSCALE patch of blocks.
+        for (let sy = 0; sy < FONT_UPSCALE; sy++) {
+          for (let sx = 0; sx < FONT_UPSCALE; sx++) {
+            const gx = colOffset + col * FONT_UPSCALE + sx;
+            const gy = row * FONT_UPSCALE + sy;
+            const x = originX + gx * pitch;
+            const y = originY + gy * pitch;
+            // Hue sweeps left→right across the whole "50".
+            spawnBlock(x, y, BLOCK, gradientColor(gx / maxCol), x, y, true);
+          }
+        }
+      }
+    }
+    colOffset += cellsPerGlyphW + GLYPH_SPACING * FONT_UPSCALE;
+  }
+
+  // Blast center = formation center; precompute the max radius for falloff.
+  _blastX = _W / 2;
+  _blastY = originY + (totalH - pitch) / 2;
+  _formationR = 1;
+  for (const blk of _blocks) {
+    const dx = blk.body.userData._homeX - _blastX;
+    const dy = blk.body.userData._homeY - _blastY;
+    _formationR = Math.max(_formationR, Math.hypot(dx, dy));
+  }
+}
+
+// Replace one block with four half-size squares inheriting its motion.
+// Removes the original from the space and returns the four new fragment
+// entries ({ body }) so the caller can splice them into its working list.
+function shatter(body) {
+  const ud = body.userData;
+  const edge = ud._edge;
+  const color = ud._color; // fragments inherit the parent's gradient color
+  const half = edge / 2;
+  const p = body.position;
+  const v = body.velocity;
+  const av = body.angularVel;
+  const rot = body.rotation;
+  const cos = Math.cos(rot);
+  const sin = Math.sin(rot);
+
+  body.space = null;
+
+  const offset = half / 2;
+  const local = [
+    [-offset, -offset],
+    [offset, -offset],
+    [-offset, offset],
+    [offset, offset],
+  ];
+  const frags = [];
+  for (const [lx, ly] of local) {
+    // Rotate the local quarter-offset into world space.
+    const wx = p.x + lx * cos - ly * sin;
+    const wy = p.y + lx * sin + ly * cos;
+    const frag = new Body(BodyType.DYNAMIC, new Vec2(wx, wy));
+    frag.shapes.add(new Polygon(Polygon.box(half, half)));
+    frag.userData._color = color; // keep the parent's gradient hue
+    frag.userData._edge = half;
+    frag.userData._pinned = false;
+    frag.userData._bornT = _elapsed;
+    frag.rotation = rot;
+    // Inherit motion + a small outward kick so the piece visibly separates.
+    frag.velocity = new Vec2(v.x + rand(-50, 50), v.y + rand(-50, 50));
+    frag.angularVel = av + rand(-8, 8);
+    frag.space = _space;
+    frags.push({ body: frag });
+  }
+  return frags;
+}
+
+function detonate() {
+  _detonated = true;
+  _phase = "scattered";
+  _phaseT = 0;
+
+  // The blast only launches blocks — it does not split them. Fracture happens
+  // afterwards, in step(), driven by the actual contact impulse each block
+  // takes as it slams the floor, the walls, and the rest of the debris. So
+  // the breaking-up reads as a consequence of the collisions, not a scripted
+  // event, and keeps going as the pile forms.
+  for (const blk of _blocks) {
+    const b = blk.body;
+    b.userData._pinned = false;
+    b.userData._bornT = _elapsed; // start the grace window from the blast
+    const dx = b.position.x - _blastX;
+    const dy = b.position.y - _blastY;
+    const dist = Math.hypot(dx, dy) || 1;
+    // Linear falloff: center blocks get the full kick, edge blocks less.
+    const k = 1 - BLAST_FALLOFF * (dist / _formationR);
+    const mag = BLAST_IMPULSE * Math.max(0.25, k);
+    const ix = (dx / dist) * mag + rand(-120, 120);
+    const iy = (dy / dist) * mag - rand(120, 320);
+    b.applyImpulse(new Vec2(ix, iy));
+    b.angularVel = rand(-12, 12);
+    // Keep _color — debris stays the gradient hue it had in formation.
+  }
+  _runnerRef?.shakeCamera?.(16, 0.5);
+}
+
+function reform() {
+  _phase = "formed";
+  _phaseT = 0;
+  _detonated = false;
+  buildFormation();
+}
+
+export default {
+  id: "star-fountain",
+  label: "Exploding 50",
+  tags: ["Impulse", "Collision", "Fracture", "Many-body"],
+  featured: false,
+  desc: "<b>50 GitHub stars!</b> 🎉 The number 50, built from hundreds of rigid blocks, charges up then detonates with a radial impulse — hard-hit blocks shatter into four — before re-assembling. <b>Click</b> to blow it up early.",
+  walls: true,
+  workerCompatible: false,
+
+  setup(space, W, H) {
+    _space = space;
+    _W = W;
+    _H = H;
+    _blocks = [];
+    space.gravity = new Vec2(0, GRAVITY_Y);
+    _phase = "formed";
+    _phaseT = 0;
+    _elapsed = 0;
+    _detonated = false;
+    buildFormation();
+  },
+
+  step(space, W, H) {
+    _runnerRef = this._runner; // cache host runner for the module-level helpers
+    _phaseT += DT;
+    _elapsed += DT;
+
+    if (_phase === "formed") {
+      // Pin every block to its home position so the "50" stays crisp and
+      // unaffected by gravity until the blast.
+      for (const blk of _blocks) {
+        const b = blk.body;
+        if (!b.userData._pinned) continue;
+        b.position = new Vec2(b.userData._homeX, b.userData._homeY);
+        b.velocity = new Vec2(0, 0);
+        b.angularVel = 0;
+        b.rotation = 0;
+      }
+
+      // Charge-up: a camera shake that builds in the last CHARGE_DURATION
+      // seconds before detonation, so the blast feels "wound up".
+      const tToBlast = HOLD_FORMED - _phaseT;
+      if (tToBlast <= CHARGE_DURATION && tToBlast > 0) {
+        const ramp = 1 - tToBlast / CHARGE_DURATION; // 0 → 1 as blast nears
+        // Short, frequent shakes whose amplitude grows toward the blast.
+        _runnerRef?.shakeCamera?.(1 + ramp * ramp * 9, 0.12);
+      }
+
+      if (_phaseT >= HOLD_FORMED && !_detonated) detonate();
+    } else {
+      // Collision-driven fracture: any block whose contact impulse this step
+      // crossed the threshold splits into four. Rebuild the working list in
+      // one pass, swapping shattered blocks for their fragments.
+      const next = [];
+      for (const blk of _blocks) {
+        const b = blk.body;
+        const ud = b.userData;
+        const splittable = ud._edge > MIN_SHATTER_EDGE && _elapsed - ud._bornT >= SHATTER_GRACE;
+        if (splittable) {
+          // totalContactsImpulse() sums normal+tangent impulses from this
+          // step's collision arbiters; its magnitude is the "hit hardness".
+          // An arbiter can expire between steps ("Arbiter not currently in
+          // use") — harmless here, just skip the block this frame.
+          let hardness = 0;
+          try {
+            const imp = b.totalContactsImpulse();
+            hardness = imp.length;
+            imp.dispose?.();
+          } catch {
+            hardness = 0;
+          }
+          if (hardness >= SHATTER_IMPULSE) {
+            for (const f of shatter(b)) next.push(f);
+            continue;
+          }
+        }
+        next.push(blk);
+      }
+      _blocks = next;
+
+      if (_phaseT >= HOLD_SCATTERED) reform();
+    }
+  },
+
+  // Click anywhere to detonate early (only meaningful while formed).
+  click() {
+    _runnerRef = this._runner; // cache host runner so click-detonate can shake
+    if (_phase === "formed" && !_detonated) detonate();
+  },
+};

--- a/docs/examples.js
+++ b/docs/examples.js
@@ -76,6 +76,7 @@ import pulleyCrane          from "./demos/pulley-crane.js?v=3.35.0";
 import tinywheelsCup        from "./demos/tinywheels-cup.js?v=3.35.0";
 import tiltrun               from "./demos/tiltrun.js?v=3.35.0";
 import dirtline              from "./demos/dirtline.js?v=3.35.0";
+import starFountain          from "./demos/star-fountain.js?v=3.35.0";
 
 // Note on order: cardEntries reverses ALL_DEMOS, so the LAST tuple entry
 // becomes the TOP card in the grid. New demos go at the end so they take
@@ -121,6 +122,7 @@ const ALL_DEMOS = [
   tinywheelsCup,
   tiltrun,
   dirtline,
+  starFountain,
 ];
 
 const gtag = window.gtag || function() {};


### PR DESCRIPTION
## What

A celebratory **physics demo** marking the project's 50th GitHub star. ⭐

The number **"50"** is built from ~380 rigid blocks that **charge up** (a camera shake that builds), then **detonate** with a radial impulse. Blocks taking a hard contact impulse **shatter into four smaller squares** as they slam the floor, walls, and each other — then the "50" re-assembles and loops. Each block carries a smooth left→right **gradient color** that survives the blast.

## Why it actually demos the engine

The visuals come entirely from the simulation, not from drawn particles:

- **Many-body rigid collision** — hundreds of convex polygons interacting
- **Radial impulse** with distance falloff
- **Collision-driven runtime fracture** — blocks split based on actual `totalContactsImpulse()`, so the breakup is a consequence of the collisions, not a scripted event
- **Solver settling** — a chaotic pile coming back to rest

All via the stock debug renderer (no `shadowBlur`), so it runs at full frame rate (median ~3.4 ms/step in a headless 600-frame run).

## Also in this PR

The CodePen export template (`docs/codepen-templates.js`) is extended for **all three renderers** (canvas2d / three.js / pixi):

- **Camera-shake support** — `shakeCamera()` + decaying offset + a `_demo._runner` stub, so shake-driven demos (this one, popcorn, …) actually shake in the CodePen export, not just in the docs runner.
- **`userData._color` gradient support** in the color resolvers — previously only `_colorIdx` (6-entry palette) was honored, so custom gradient colors now render correctly in exports too.

## Notes

- Blocks use the engine-default material (no `Material` arg) to avoid the known dynamic-Polygon + Material floor-tunneling bug — verified 0 tunneling in headless runs.
- Registered in the examples grid as **"Exploding 50"**.

## Checks

- `npm run format:check` ✅
- `npm run lint` ✅
- `npm test` ✅ (6169 + 73)
- `npm run build` ✅
- Generated CodePen export for all three renderers passes `node --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)