### PR TITLE
fix(ci/release): push branch before tag to avoid orphaned tags

### DIFF
--- a/scripts/ci/release.mjs
+++ b/scripts/ci/release.mjs
@@ -181,11 +181,25 @@ function releasePackage(pkg, isFirstRelease, bump) {
     // Skip hooks in CI — the commit is deterministic and has already passed CI.
     run(`git commit -m "release(${pkg.shortName}): ${newVersion}"`);
   }
-  // Use an annotated tag — `git push --follow-tags` only pushes annotated tags,
-  // so a lightweight `git tag <name>` here would silently leave the tag local-only
-  // (which would also prevent `gh release create` from finding it on the remote).
+  // Push the branch BEFORE creating/pushing the tag, and rebase onto the
+  // remote first. This ordering matters:
+  //   - Concurrent advances of the target branch (a merge, another release
+  //     run) would otherwise make the push a non-fast-forward and fail.
+  //     Rebasing our single release commit on top resolves that cleanly.
+  //   - The previous `git push HEAD --follow-tags` pushed the branch AND the
+  //     tag in one shot. When the branch half was rejected, the tag half had
+  //     already gone — leaving an ORPHANED tag on the remote pointing at a
+  //     commit not on any branch, and skipping npm publish entirely. By
+  //     pushing the branch first and only tagging after it lands, a rejected
+  //     push fails before any tag exists.
+  const branch = shq(`git rev-parse --abbrev-ref HEAD`) || "master";
+  run(`git pull --rebase origin ${branch}`);
+  run(`git push origin HEAD:${branch}`);
+
+  // Branch is safely on the remote — now tag that exact commit and push the
+  // tag on its own. Annotated so `git push <tag>` and `gh release` see it.
   run(`git tag -a ${newTag} -m "Release ${pkg.fullName} v${newVersion}"`);
-  run(`git push origin HEAD --follow-tags`);
+  run(`git push origin ${newTag}`);
 
   // Publish to npm
   run(`npm publish -w ${pkg.fullName} --access public`);


### PR DESCRIPTION
## Problem

`scripts/ci/release.mjs` published with:

```js
run(`git tag -a ${newTag} -m "..."`);
run(`git push origin HEAD --follow-tags`);   // branch + tag in one shot
run(`npm publish ...`);
```

`git push --follow-tags` pushes the branch **and** the tag together. When the branch push is a non-fast-forward — because the target branch advanced during the run (a merge landing, or a second release run racing this one) — git still pushes the tag, then fails on the branch ref. Result:

- an **orphaned `<pkg>-v<ver>` tag** on the remote pointing at a commit that's on no branch,
- `npm publish` **never runs** (the throw aborts the step),
- the **next** release run sees the tag and assumes that version already shipped.

This happened live on `nape-js-v3.39.0`: the tag landed on a stray release commit while `origin/master` already had its own `release(nape-js): 3.39.0` commit, and 3.39.0 was never published to npm. (The stray tag has since been moved onto the master release commit manually; npm publish of 3.39.0 still needs a re-run.)

## Fix

Reorder so a failed push can never strand a tag, and so a concurrent branch advance no longer aborts the release:

1. `git pull --rebase origin <branch>` — rebase our single release commit onto the remote tip (resolves the non-fast-forward instead of failing).
2. `git push origin HEAD:<branch>` — push the branch **alone**.
3. Only after that lands: `git tag -a` + `git push origin <tag>`.
4. `npm publish`.

A rejected branch push now fails **before** any tag exists. `<branch>` is resolved via `git rev-parse --abbrev-ref HEAD` (falls back to `master`).

## Verification

`node scripts/ci/release.mjs --dry-run` shows the new sequence:

```
$ git pull --rebase origin master
$ git push origin HEAD:master
$ git tag -a nape-js-v3.39.0 -m "..."
$ git push origin nape-js-v3.39.0
$ npm publish -w @newkrok/nape-js --access public
```

CI-script-only change; no engine/test/docs impact. `npm run format:check` passes (scripts/ is outside its scope; the pre-existing prettier delta in this file is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)