### PR TITLE
refactor(docs/billiards): rename demo id sidepocket → billiards

### DIFF
--- a/docs/codepen-templates.js
+++ b/docs/codepen-templates.js
@@ -16,7 +16,7 @@ const PIXI_VERSION = "8";
 
 const NAPE_CDN = `https://cdn.jsdelivr.net/npm/@newkrok/nape-js@3.35.0/dist/index.js`;
 // Serialization (spaceToJSON / spaceFromJSON) lives in a subpath bundle, not
-// the main one — emitted only for demos that use it (e.g. sidepocket's
+// the main one — emitted only for demos that use it (e.g. billiards'
 // shadow-sim shot prediction). Bare specifier resolves via the import map.
 const NAPE_SERIALIZATION_CDN = `https://cdn.jsdelivr.net/npm/@newkrok/nape-js@3.35.0/dist/serialization/index.js`;
 const NAPE_SERIALIZATION_BARE = `@newkrok/nape-js/serialization`;

--- a/docs/demo-categories.js
+++ b/docs/demo-categories.js
@@ -30,7 +30,7 @@ export const GAME_DEMO_IDS = new Set([
   "tinywheels-cup",
   "tiltrun",
   "dirtline",
-  "sidepocket",
+  "billiards",
 ]);
 
 export const CATEGORIES = [

--- a/docs/demos/billiards.js
+++ b/docs/demos/billiards.js
@@ -301,7 +301,7 @@ function sinkBall(body) {
 
 // ── Demo definition ──────────────────────────────────────────────────────────
 export default {
-  id: "sidepocket",
+  id: "billiards",
   label: "Billiards",
   tags: ["Billiards", "Sensor", "Material", "Drag", "TopDown"],
   featured: false,

--- a/docs/examples.js
+++ b/docs/examples.js
@@ -77,7 +77,7 @@ import tinywheelsCup        from "./demos/tinywheels-cup.js?v=3.35.0";
 import tiltrun               from "./demos/tiltrun.js?v=3.35.0";
 import dirtline              from "./demos/dirtline.js?v=3.35.0";
 import explodingFifty        from "./demos/exploding-50.js?v=3.35.0";
-import sidepocket            from "./demos/sidepocket.js?v=3.35.0";
+import billiards             from "./demos/billiards.js?v=3.35.0";
 
 // Note on order: cardEntries reverses ALL_DEMOS, so the LAST tuple entry
 // becomes the TOP card in the grid. New demos go at the end so they take
@@ -124,7 +124,7 @@ const ALL_DEMOS = [
   tiltrun,
   dirtline,
   explodingFifty,
-  sidepocket,
+  billiards,
 ];
 
 const gtag = window.gtag || function() {};

--- a/packages/nape-js/tests/demos/billiards-prediction.test.ts
+++ b/packages/nape-js/tests/demos/billiards-prediction.test.ts
@@ -1,5 +1,5 @@
 /**
- * Fidelity harness for the Sidepocket (Billiards) demo's shot prediction.
+ * Fidelity harness for the Billiards demo's shot prediction.
  *
  * The demo predicts a shot by SHADOW SIMULATION: it clones the live space with
  * spaceToJSON/spaceFromJSON, fires the exact shot into the clone, and steps the
@@ -14,7 +14,7 @@
  * velocities, bullet flag, …) the two diverge and the assertions fail.
  *
  * Mirrors the demo's table build + shot physics — keep in sync with
- * docs/demos/sidepocket.js.
+ * docs/demos/billiards.js.
  */
 import { describe, it, expect } from "vitest";
 import {
@@ -29,7 +29,7 @@ import {
 } from "../../src";
 import { spaceToJSON, spaceFromJSON } from "../../src/serialization";
 
-// ── Demo constants (mirror docs/demos/sidepocket.js) ─────────────────────────
+// ── Demo constants (mirror docs/demos/billiards.js) ──────────────────────────
 const TABLE_L = 70;
 const TABLE_R = 830;
 const TABLE_T = 80;
@@ -210,7 +210,7 @@ function randPos(rng: () => number) {
   };
 }
 
-describe("Sidepocket shadow-sim prediction fidelity", () => {
+describe("Billiards shadow-sim prediction fidelity", () => {
   const N = 200;
 
   const stats = (() => {


### PR DESCRIPTION
## Why

The demo displays as **Billiards**, but its public URL was `?open=sidepocket` (the original codename) — because `?open=` matches `demo.id`, and the id was still `"sidepocket"`. This renames the id (and files) so the share URL reads **`?open=billiards`**.

## Changes

- `docs/demos/sidepocket.js` → **`billiards.js`** (git rename, 99% similarity)
- `packages/nape-js/tests/demos/sidepocket-prediction.test.ts` → **`billiards-prediction.test.ts`**
- `id: "sidepocket"` → `id: "billiards"` in the demo
- `examples.js` import + registration, `demo-categories.js` `GAME_DEMO_IDS` entry
- doc/comment references in `codepen-templates.js` and the test

File name now equals the id, consistent with every other demo (minigolf, tinywheels-cup, …).

## Note on old links

There's no id-alias/redirect layer, so a previously shared `?open=sidepocket` link no longer resolves to this demo (it falls back to the first card — examples.js:801 `find` returns undefined). Accepted as part of the rename.

## Checks

`npm run format:check`, `npm run lint`, `npm test` (6175 + 73), `npm run build` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)