### PR TITLE
perf(helpers): index ParticleEmitter's alive list for O(1) membership

### DIFF
--- a/packages/nape-js/src/helpers/ParticleEmitter.ts
+++ b/packages/nape-js/src/helpers/ParticleEmitter.ts
@@ -311,6 +311,12 @@ export class ParticleEmitter {
 
   // ----- internal -----
   private _alive: Body[] = [];
+  /**
+   * Body -> its index in `_alive`, kept in sync by `_spawnOne` / `_killAt`.
+   * Turns the per-collision membership tests and `_flushKillSet` lookups from
+   * O(alive) scans into O(1) hits.
+   */
+  private _aliveIndex: Map<Body, number> = new Map();
   private _ages: number[] = [];
   private _lifetimes: number[] = [];
   private _pool: Body[] = [];
@@ -607,6 +613,7 @@ export class ParticleEmitter {
     const body = this._acquire();
     this._reviveBody(body, wx, wy, vx, vy, 0, 0);
 
+    this._aliveIndex.set(body, this._alive.length);
     this._alive.push(body);
     this._ages.push(0);
     this._lifetimes.push(lifetime);
@@ -635,10 +642,13 @@ export class ParticleEmitter {
     const body = this._alive[index];
     const last = this._alive.length - 1;
     if (index !== last) {
-      this._alive[index] = this._alive[last];
+      const moved = this._alive[last];
+      this._alive[index] = moved;
       this._ages[index] = this._ages[last];
       this._lifetimes[index] = this._lifetimes[last];
+      this._aliveIndex.set(moved, index);
     }
+    this._aliveIndex.delete(body);
     this._alive.pop();
     this._ages.pop();
     this._lifetimes.pop();
@@ -666,8 +676,8 @@ export class ParticleEmitter {
     if (!set || set.size === 0) return;
     // Iterate a snapshot — _killAt mutates `_alive`.
     for (const body of set) {
-      const idx = this._alive.indexOf(body);
-      if (idx >= 0) this._killAt(idx, "manual");
+      const idx = this._aliveIndex.get(body);
+      if (idx !== undefined) this._killAt(idx, "manual");
     }
     set.clear();
   }
@@ -795,8 +805,8 @@ export class ParticleEmitter {
         // shapes' parent bodies (or bodies, depending on internal mapping).
         const a = cb.int1 as unknown as Body;
         const b = cb.int2 as unknown as Body;
-        const aIsParticle = this._alive.indexOf(a) >= 0;
-        const bIsParticle = this._alive.indexOf(b) >= 0;
+        const aIsParticle = this._aliveIndex.has(a);
+        const bIsParticle = this._aliveIndex.has(b);
         if (aIsParticle) this.onCollide(a, b);
         else if (bIsParticle) this.onCollide(b, a);
       },

--- a/packages/nape-js/tests/helpers/ParticleEmitter.test.ts
+++ b/packages/nape-js/tests/helpers/ParticleEmitter.test.ts
@@ -679,6 +679,57 @@ describe("ParticleEmitter — hooks", () => {
     expect(e.active.length).toBe(0);
     expect(reasons).toEqual(["manual"]);
   });
+
+  // The alive list is maintained by swap-pop alongside a Body -> index map.
+  // A stale map entry (e.g. a missed update for the swapped-in body) would let
+  // requestKill kill the wrong particle or silently no-op, so exercise kills
+  // from the middle of the list and in bulk.
+  it("requestKill targets the right particle after swap-pop reordering", () => {
+    const space = makeSpace();
+    const e = new ParticleEmitter({
+      space,
+      origin: new Vec2(0, 0),
+      maxParticles: 10,
+      lifetimeMin: 100,
+      lifetimeMax: 100,
+    });
+    const bodies = e.emit(5);
+    expect(bodies.length).toBe(5);
+
+    // Kill from the middle: forces the last element to be swapped into its slot.
+    e.requestKill(bodies[1]);
+    e.update(0.01);
+    expect(e.active.length).toBe(4);
+    expect(e.active).not.toContain(bodies[1]);
+
+    // The body that got swapped into index 1 must still be killable.
+    e.requestKill(bodies[4]);
+    e.update(0.01);
+    expect(e.active.length).toBe(3);
+    expect(e.active).not.toContain(bodies[4]);
+
+    // Killing an already-dead body is a no-op, not a mis-targeted kill.
+    e.requestKill(bodies[1]);
+    e.update(0.01);
+    expect(e.active.length).toBe(3);
+
+    // Remaining bodies are exactly the ones never killed.
+    expect(new Set(e.active)).toEqual(new Set([bodies[0], bodies[2], bodies[3]]));
+
+    // Bulk-kill the rest, then confirm the emitter can spawn cleanly again
+    // (a leaked map entry would make a recycled pool body look still-alive).
+    for (const b of [bodies[0], bodies[2], bodies[3]]) e.requestKill(b);
+    e.update(0.01);
+    expect(e.active.length).toBe(0);
+
+    const respawned = e.emit(3);
+    expect(respawned.length).toBe(3);
+    expect(e.active.length).toBe(3);
+    e.requestKill(respawned[1]);
+    e.update(0.01);
+    expect(e.active.length).toBe(2);
+    expect(e.active).not.toContain(respawned[1]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two items from the optimization backlog were taken on. One shipped, one is **refuted with measurements** — that refutation is the more valuable half of this PR.

### Shipped: ParticleEmitter `indexOf` → index map (backlog #5)

The collision listener ran **two** `_alive.indexOf()` scans per particle collision, and `_flushKillSet()` one per queued kill — all O(alive). Now a `Body -> index` map maintained alongside the existing swap-pop, giving O(1).

Reported honestly: this is a **complexity fix, not a measured speedup**. In a dense self-colliding scene, before/after sit inside run-to-run noise:

| particles | `indexOf` | index map |
|---|---|---|
| 200 | 1.80 ms/frame | 1.84 ms/frame |
| 400 | 9.42 ms/frame | 9.35 ms/frame |

Frame time is dominated by the physics, not the membership tests. The win is that the scans no longer scale with particle count under heavy collision traffic.

Includes a regression test for the map/swap-pop invariant (kill from the middle, then kill the body swapped into that slot, then re-spawn from the pool). **Mutation-verified**: deleting the swapped-in body's index update makes the test fail.

### Refuted: doForests live-list k-way merge (backlog #1) — no code shipped

Backlog #1 was implemented, measured, and reverted. It assumed islands' `comps` form long sorted runs in `live` that a k-way merge could stitch cheaply. They don't:

- avg island `comps` length = **2.2** elements (79% have ≤1)
- `live` (400 elements) decomposes into **~183 ascending runs** — ~2 per run
- with constraint-linked bodies (larger islands): still ~101 runs over 398

A merge over ~183 runs costs what sorting 400 elements costs. Also, the estimate was off: the `live` sort is **1.5–1.8%** of step time, not 2–4%, and only during the active window — once the pile sleeps `live` is empty and the cost is zero.

The prototype (append + `live_sorted` skip flags) skipped only **14%** of sorts, with timings inside the ±4% noise band. Reverted rather than shipping complexity for noise.

### Landmine found (worth knowing)

Flipping the islands drain from prepend to append **unconditionally** reorders `live_constraints` in non-deterministic mode, which changes Gauss-Seidel solve order and therefore results — it broke `Space.integration.test.ts > should enforce AngleJoint` (0.16 rad vs the `<0.1` assertion). **Any future reordering of `live` / `live_constraints` must be gated on `this.deterministic`.** The existing suite caught this immediately.

Also checked and closed out: the ~39k/250-step `island.comps` sort calls (79% on lists of ≤1) are already early-returned by the `list.head.next == null` guard, so there's nothing to reclaim there.

## Test plan

Full pre-push checklist, all green:

- `npm run format:check` ✅
- `npm run lint` ✅
- `npm test` ✅ — 6192 engine (+1 new) + 73 pixi, 6 platform-gated golden skips off-CI
- `npm run build` ✅ — DTS generation clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)